### PR TITLE
Add support for ticket files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 /tmp
 
 /vendor/*
+
+# Ignore local_env.yml file
+/config/local_env.yml

--- a/Gemfile
+++ b/Gemfile
@@ -56,3 +56,6 @@ gem 'devise'
 # Javascript libraries
 gem 'momentjs-rails'
 gem 'underscore-rails'
+
+# S3
+gem 'aws-s3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,6 +26,10 @@ GEM
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.37)
     arel (4.0.2)
+    aws-s3 (0.6.3)
+      builder
+      mime-types
+      xml-simple
     bcrypt (3.1.7)
     bootstrap-sass (3.1.1.1)
       sass (~> 3.2)
@@ -123,11 +127,13 @@ GEM
     underscore-rails (1.6.0)
     warden (1.2.3)
       rack (>= 1.0)
+    xml-simple (1.1.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-s3
   bootstrap-sass (~> 3.1.1)
   coffee-rails (~> 4.0.0)
   devise

--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ NOTE: The application currently uses a local SQLite database while in developmen
 4. Run `rake test` to verify that existing tests pass.
 5. Execute `rails server` to bring up a local instance.
 
+### Environment Variables
+
+The following are used within the application:
+
+* `SEATSHARE_S3_KEY` - The S3 credentials to use for storing ticket files.
+* `SEATSHARE_S3_SECRET` - The S3 credentials to use for storing ticket files.
+* `SEATSHARE_S3_BUCKET` - The bucket name to use for storing ticket files.
+
+The easiest way to do this is to create a file called `config/local_env.yml` (see the example file in that directory). When configuring on Heroku, you will simply add these as configuration settings.
+
 ### Recommended Tools
 
 There are a handful of tools that will make using the application easier.

--- a/app/models/ticket_file.rb
+++ b/app/models/ticket_file.rb
@@ -4,7 +4,7 @@ class TicketFile < ActiveRecord::Base
   validates :user_id, :ticket_id, :path, :file_name, :presence => true
 
   def download_link
-    "https://lockbox.seatsha.re/#{self.path}"
+    "#{ENV['SEATSHARE_S3_PUBLIC']}/#{self.path}"
   end
 
 end

--- a/app/views/tickets/edit.html.erb
+++ b/app/views/tickets/edit.html.erb
@@ -65,8 +65,8 @@
 
   <div class="form-group">
     <div class="col-md-offset-3 col-md-9">
-      <label for="ticket_file" class="sr-only">File input</label>
-      <input type="file" id="ticket_file" name="ticket_file" />
+      <%= f.label :ticket_file, :class => 'sr-only' %>
+      <%= f.file_field :ticket_file %>
       <p class="help-block">(Optional) Maximum upload size 2 MB.</p>
     </div>
   </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,14 @@ module SeatShare
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
     config.i18n.enforce_available_locales = true
+
+    # Use local_env.yml file if present
+    config.before_configuration do
+      env_file = File.join(Rails.root, 'config', 'local_env.yml')
+      YAML.load(File.open(env_file)).each do |key, value|
+        ENV[key.to_s] = value
+      end if File.exists?(env_file)
+    end
+
   end
 end

--- a/config/initializers/aws_s3.rb
+++ b/config/initializers/aws_s3.rb
@@ -1,0 +1,10 @@
+# Configure the S3 Gem
+# These are required for ticket file uploading.
+if ENV['SEATSHARE_S3_BUCKET'].nil? || ENV['SEATSHARE_S3_BUCKET'].nil? || ENV['SEATSHARE_S3_BUCKET'].nil? || ENV['SEATSHARE_S3_PUBLIC'].nil?
+  raise "MissingConfigurationForS3"
+end
+
+AWS::S3::Base.establish_connection!(
+  :access_key_id     => ENV['SEATSHARE_S3_KEY'],
+  :secret_access_key => ENV['SEATSHARE_S3_SECRET']
+)

--- a/config/local_env.yml.example
+++ b/config/local_env.yml.example
@@ -1,0 +1,13 @@
+# Rename this file to local_env.yml
+# Add account settings and API keys here.
+# This file should be listed in .gitignore to keep your settings secret!
+# Each entry gets set as a local environment variable.
+# This file overrides ENV variables in the Unix shell.
+# For example, setting:
+# GMAIL_USERNAME: 'Your_Gmail_Username'
+# makes 'Your_Gmail_Username' available as ENV["GMAIL_USERNAME"]
+
+SEATSHARE_S3_KEY: 'the_s3_key'
+SEATSHARE_S3_SECRET: 'the_s3_secret'
+SEATSHARE_S3_BUCKET: 'lockbox.seatsha.re'
+SEATSHARE_S3_PUBLIC: 'https://lockbox.seatsha.re'

--- a/tmp/uploads/.gitkeep
+++ b/tmp/uploads/.gitkeep
@@ -1,0 +1,1 @@
+.gitkeep


### PR DESCRIPTION
Forgot to hook in some form of an S3 uploader so that ticket attachments work correctly. This fixes that.
- Adds a `local_env.yml` file so that we don't credentials within the application repository
- Uses the bare-bones `aws-s3` gem to facilitate file uploads
- Adds an uploads folder in the `tmp` directory for temporary storage
- Updates `README.md` to specify new installation requirements.
