### PR TITLE
Move to use PostgreSQL for development/production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 gem 'rails', '4.0.3'
 
 # Use sqlite3 as the database for Active Record
-gem 'sqlite3'
+# gem 'sqlite3'
 
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 4.0.0'
@@ -59,3 +59,6 @@ gem 'underscore-rails'
 
 # S3
 gem 'aws-s3'
+
+# Postgres
+gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,7 @@ GEM
       railties (>= 3.1)
     multi_json (1.9.2)
     orm_adapter (0.5.0)
+    pg (0.17.1)
     polyglot (0.3.4)
     rack (1.5.2)
     rack-test (0.6.2)
@@ -107,7 +108,6 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (~> 2.8)
-    sqlite3 (1.3.9)
     thin (1.6.2)
       daemons (>= 1.0.9)
       eventmachine (>= 1.0.0)
@@ -140,10 +140,10 @@ DEPENDENCIES
   jbuilder (~> 1.2)
   jquery-rails
   momentjs-rails
+  pg
   rails (= 4.0.3)
   sass-rails (~> 4.0.0)
   sdoc
-  sqlite3
   thin
   turbolinks
   uglifier (>= 1.3.0)

--- a/README.md
+++ b/README.md
@@ -6,14 +6,19 @@ This project is a mock SaaS to allow a group of people to manage a pool of ticke
 
 ## Instalation
 
-NOTE: The application currently uses a local SQLite database while in development. The eventual target is Postgres.
+### Pre-requisites
 
-1. Clone the repository into your projects directory.
-2. Ensure you have [Bundler](http://bundler.io/) installed.
-3. Execute `bundle install`.
-4. Execute `rake db:migrate` (creates the `development.sqlite` database) and `rake db:seed` (loads the default fixtures).
-4. Run `rake test` to verify that existing tests pass.
-5. Execute `rails server` to bring up a local instance.
+* [Bundler](http://bundler.io/).
+* PosgtresSQL (e.g. `brew install postgresql`)
+* An Amazon S3 bucket for ticket files
+ 
+### Install Steps
+
+1. Clone the repository into your projects directory
+2. Execute `bundle install`
+3. Execute `rake db:setup` (creates the development and test database and seeds the initial data)
+4. Run `rake test` to verify that existing tests pass
+5. Execute `rails server` to bring up a local instance
 
 ### Environment Variables
 
@@ -37,7 +42,7 @@ When you first launch the application (`http://localhost:3000/`), you will be pr
 
 Once you have installed the application, the next step is to create a group. You will be prompted to select a registered entity and provide a group name. You will be taken to your group page.
 
-NOTE: Intially, none of the `entities` will have `events`. This is a `@TODO` task to have default set of events to use for development that can be seeded. In the interim, connect to the `test.sqlite3` database and export the contents of the `events` table and import it into `development.sqlite3` for testing purposes.
+NOTE: Intially, only one of the `entities` will have `events` (the Tennessee Titans). This is a `@TODO` task to have default set of events to use for development that can be seeded.
 
 ## Database Migrations
 
@@ -54,4 +59,4 @@ See [CONTRIBUTING.md](https://github.com/stephenyeargin/seatshare-rails/blob/mas
 
 ## Deploying
 
-* `@TODO`
+* Push master to the `seatshare-app` repository on Heroku.

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,25 +1,15 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
 development:
-  adapter: sqlite3
-  database: db/development.sqlite3
+  adapter: postgresql
+  encoding: unicode
+  database: seatshare_development
   pool: 5
-  timeout: 5000
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
-  adapter: sqlite3
-  database: db/test.sqlite3
+  adapter: postgresql
+  encoding: unicode
+  database: seatshare_test
   pool: 5
-  timeout: 5000
 
 production:
-  adapter: sqlite3
-  database: db/production.sqlite3
+  adapter: postgresql
   pool: 5
-  timeout: 5000

--- a/test/mailers/schedule_notifier_test.rb
+++ b/test/mailers/schedule_notifier_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class ScheduleNotifierTest < ActionMailer::TestCase
 
   test "send daily schedule" do
-    events = Event.where('DATE(start_time) = "2013-10-15"')
+    events = Event.where('DATE(start_time) = \'2013-10-15\'')
     group = Group.find(1)
     user = User.find(1)
 
@@ -18,7 +18,7 @@ class ScheduleNotifierTest < ActionMailer::TestCase
   end
 
   test "send weekly schedule" do
-    events = Event.where('start_time >= "2013-10-13" AND start_time <= "2013-10-20"').order('start_time ASC')
+    events = Event.where('start_time >= \'2013-10-13\' AND start_time <= \'2013-10-20\'').order('start_time ASC')
     group = Group.find(1)
     user = User.find(1)
 

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -33,11 +33,11 @@ class EventTest < ActiveSupport::TestCase
   end
 
   test "get events by group ID" do
-    events = Event.get_by_group_id(1)
+    events = Event.get_by_group_id(1).order('start_time ASC')
 
     assert events[0].class.to_s === 'Event', 'returned item is an event'
-    assert events[0].event_name === "Nashville Predators vs. St. Louis Blues", 'event title matches'
-    assert events.count === 7, 'event count equals five'
+    assert events[0].event_name === "Nashville Predators vs. Minnesota Wild", 'event title matches'
+    assert events.count === 7, 'event count equals seven'
   end
 
   test "get event by ticket ID" do


### PR DESCRIPTION
- Stop using SQLite3 for local data.
- Connect a default account for development and test.
- Fix a handful of sorting issues revealed with switch in database platform.
- Makes the switch to using Heroku for production relatively straightforward.
- Update README.md
