### PR TITLE
Fix for invitation code being passed through registration process

### DIFF
--- a/app/assets/javascripts/registrations.js.coffee
+++ b/app/assets/javascripts/registrations.js.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/registrations.css.scss
+++ b/app/assets/stylesheets/registrations.css.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Registrations controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,7 +20,7 @@ class ApplicationController < ActionController::Base
 
   def configure_devise_permitted_parameters
 
-    registration_params = [:first_name, :last_name, :email, :password, :password_confirmation, :newsletter_signup]
+    registration_params = [:first_name, :last_name, :email, :password, :password_confirmation, :newsletter_signup, :invite_code]
 
     if params[:action] == 'update'
       devise_parameter_sanitizer.for(:account_update) { 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -108,6 +108,7 @@ class GroupsController < ApplicationController
   end
 
   def join
+    @invite_code = params[:invite_code]
     @page_title = "Join a Group"
   end
 

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,34 @@
+class RegistrationsController < Devise::RegistrationsController
+  def new
+    @page_title = "Create an Account"
+    super
+  end
+
+  def create
+    build_resource(sign_up_params)
+
+    if resource.save
+      yield resource if block_given?
+      if resource.active_for_authentication?
+        set_flash_message :notice, :signed_up if is_flashing_format?
+        sign_up(resource_name, resource)
+        if params[:user][:invite_code]
+          respond_with resource, location: groups_join_path + "?invite_code=" + params[:user][:invite_code]
+        else
+          respond_with resource, location: after_sign_up_path_for(resource)
+        end
+      else
+        set_flash_message :notice, :"signed_up_but_#{resource.inactive_message}" if is_flashing_format?
+        expire_data_after_sign_in!
+        respond_with resource, location: after_inactive_sign_up_path_for(resource)
+      end
+    else
+      clean_up_passwords resource
+      respond_with resource
+    end
+  end
+
+  def update
+    super
+  end
+end 

--- a/app/helpers/registrations_helper.rb
+++ b/app/helpers/registrations_helper.rb
@@ -1,0 +1,2 @@
+module RegistrationsHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,9 @@ class User < ActiveRecord::Base
 
   after_create :send_welcome_email
 
+  attr_accessor :newsletter_signup
+  attr_accessor :invite_code
+
   def active_for_authentication?
     super && status === 1
   end
@@ -35,9 +38,6 @@ class User < ActiveRecord::Base
     email_address = self.email.downcase
     hash = Digest::MD5.hexdigest(email_address)
     "https://www.gravatar.com/avatar/#{hash}?s=#{dimensions}&d=mm"
-  end
-
-  def newsletter_signup
   end
 
   def self.get_users_by_group_id(group_id=nil, role=nil)

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -64,6 +64,9 @@
 
   <div class="row">
     <div class="col-md-12">
+        <% if params[:invite_code] %>
+        <%= f.hidden_field :invite_code, :value => params[:invite_code] %>
+        <% end %>
         <p class="text-right">
           <%= f.submit 'Create Account', :class => 'btn btn-primary' %>
         </p>
@@ -76,12 +79,12 @@
 
 <% content_for :sidebar do %>
 
-<% if @invitation_code %>
+<% if params[:invite_code] %>
 <div class="alert alert-success">
   <h4>You've been invited join a group!</h4>
   <p>You are registering with an invitation code, so you will be ready to go here in just a bit!</p>
   <br />
-  <p class="text-lg">Invitation code: <strong><%= @invitation_code %></strong></p>
+  <p class="text-lg">Invitation code: <strong class="invite_code"><%= params[:invite_code] %></strong></p>
 </div>
 <% else %>
 <div class="alert alert-info">

--- a/app/views/group_notifier/create_invite.html.erb
+++ b/app/views/group_notifier/create_invite.html.erb
@@ -12,7 +12,7 @@
   <tr>
     <th style="width:150px;">Create an Account</th>
     <td>
-      <%= link_to 'Use Invitation ' + @invite.invitation_code, { :controller => 'devise/registrations', :action => 'new', :invite_code => @invite.invitation_code, :only_path => false } %>
+      <%= link_to 'Use Invitation ' + @invite.invitation_code, { :controller => 'registrations', :action => 'new', :invite_code => @invite.invitation_code, :only_path => false } %>
     </td>
   </tr>
 </table>

--- a/app/views/groups/join.html.erb
+++ b/app/views/groups/join.html.erb
@@ -6,7 +6,7 @@
   <div class="form-group">
   	<%= f.label :invitation_code, :class => 'col-md-3 control-label' %>
   	<div class="col-md-9">
-      <%= f.text_field :invitation_code, autofocus: true, :class => 'form-control', :placeholder => 'ABCDEFG123' %>
+      <%= f.text_field :invitation_code, autofocus: true, :class => 'form-control', :placeholder => 'ABCDEFG123', :value => @invite_code %>
   	</div>
   </div>
 </fieldset>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ SeatShare::Application.routes.draw do
   ActiveAdmin.routes(self)
   devise_for :admin_users, ActiveAdmin::Devise.config
 
-  devise_for :users, :path => '', :path_names => { :sign_in => 'login', :sign_out => 'logout', :sign_up => 'register' }
+  devise_for :users, :controllers => {:registrations => "registrations"}, :path => '', :path_names => { :sign_in => 'login', :sign_out => 'logout', :sign_up => 'register' }
 
   root 'public#index'
 

--- a/test/controllers/groups_controller_test.rb
+++ b/test/controllers/groups_controller_test.rb
@@ -38,6 +38,16 @@ class GroupsControllerTest < ActionController::TestCase
     assert_select 'title', 'Join a Group', 'page title matches'
   end
 
+  test "should see join page with pre-populated code" do
+    @user = User.find(1)
+    sign_in :user, @user
+
+    get :join, :invite_code => 'ABC123'
+    assert_response :success, 'got a 200 status'
+    assert_select 'title', 'Join a Group', 'page title matches'
+    assert_tag :tag => "input", :attributes => { :id => "group_invitation_code", :value => "ABC123" }
+  end
+
   test "should see invite page" do
     @user = User.find(1)
     sign_in :user, @user

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class RegistrationsControllerTest < ActionController::TestCase
+
+  test "get register route" do
+    @request.env["devise.mapping"] = Devise.mappings[:user]
+
+    get :new
+
+    assert_response :success
+    assert_select "title", "Create an Account"
+    assert_select "h4", "Joining a group?", 'invitation code block is empty'
+  end
+
+  test "get register route with invitation code" do
+    @request.env["devise.mapping"] = Devise.mappings[:user]
+
+    get :new, :invite_code => 'ABCDEFG'
+
+    assert_response :success
+    assert_select "title", "Create an Account"
+    assert_select "h4", "You've been invited join a group!", 'invitation code block appears'
+    assert_select "strong.invite_code", "ABCDEFG", 'invitation code appears'
+  end
+
+end

--- a/test/helpers/registrations_helper_test.rb
+++ b/test/helpers/registrations_helper_test.rb
@@ -1,0 +1,4 @@
+require 'test_helper'
+
+class RegistrationsHelperTest < ActionView::TestCase
+end


### PR DESCRIPTION
Needed to override the Devise registration controller a bit to pass data along if the user clicked an invitation link from an email. The code should not have to be re-entered after a successful signup if it was already provided in the query string.
