### PR TITLE
Add available teams page to public site

### DIFF
--- a/app/controllers/public_controller.rb
+++ b/app/controllers/public_controller.rb
@@ -20,6 +20,19 @@ class PublicController < ApplicationController
     @meta_description = %q{SeatShare helps you manage your group's season tickets for sporting or performing arts events. Sign up for free.}
   end
 
+  def teams
+    @teams_nfl = Entity.where("entity_type = 'NFL'").order('entity_name ASC')
+    @teams_mlb = Entity.where("entity_type = 'MLB'").order('entity_name ASC')
+    @teams_nba = Entity.where("entity_type = 'NBA'").order('entity_name ASC')
+    @teams_nhl = Entity.where("entity_type = 'NHL'").order('entity_name ASC')
+    @teams_ncaaf = Entity.where("entity_type = 'NCAAF'").order('entity_name ASC')
+    @teams_ncaamb = Entity.where("entity_type = 'NCAAMB'").order('entity_name ASC')
+    @teams_wftda = Entity.where("entity_type = 'WFTDA'").order('entity_name ASC')
+
+    @page_title = %q{Manage Season Tickets for Your Favorite Team - SeatShare}
+    @meta_description = %{We import scheduled for all of the most popular sports teams, including NHL, NFL, NBA, MLB and college sports.}
+  end
+
   def tos
     @page_title = %q{Terms of Service - SeatShare}
     @meta_description = %q{The Terms of Service for SeatShare are the rules that govern access and use of the website.}

--- a/app/views/public/index.html.erb
+++ b/app/views/public/index.html.erb
@@ -22,7 +22,7 @@
             </div>
             <div class="col-md-4">
                 <h2>Events</h2>
-                <p>Your favorite teams and venues are available with up-to-date schedules. Plan the entire season.</p>
+                <p>Your <%= link_to 'favorite teams', teams_path %> and venues are available with up-to-date schedules. Plan the entire season.</p>
             </div>
             <div class="col-md-4">
                 <h2>Tickets</h2>

--- a/app/views/public/teams.html.erb
+++ b/app/views/public/teams.html.erb
@@ -1,0 +1,144 @@
+<div class="jumbotron">
+  <h2>Take home field advantage</h2>
+  <p>With more than 2,200 pro and college team schedules available, SeatShare has your seats covered.</p>
+  <%= link_to "Create Your SeatShare Account", new_user_registration_path, :class=>'btn btn-primary btn-lg' %>
+</div>
+
+<div class="row">
+  <div class="col-md-12">
+    <h3 id="nfl">National Footbal League</h3>
+    <hr />
+    <div class="row">
+      <% for team in @teams_nfl %>
+      <div class="col-md-4">
+        <div class="well well-sm"><%= team.entity_name %></div>
+      </div>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-12">
+    <h3 id="mlb">Major League Baseball</h3>
+    <hr />
+    <div class="row">
+      <% for team in @teams_mlb %>
+      <div class="col-md-4">
+        <div class="well well-sm"><%= team.entity_name %></div>
+      </div>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-12">
+    <h3 id="nba">National Basketball Association</h3>
+    <hr />
+    <div class="row">
+      <% for team in @teams_nba %>
+      <div class="col-md-4">
+        <div class="well well-sm"><%= team.entity_name %></div>
+      </div>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-12">
+    <h3 id="nhl">National Hockey League</h3>
+    <hr />
+    <div class="row">
+      <% for team in @teams_nhl %>
+      <div class="col-md-4">
+        <div class="well well-sm"><%= team.entity_name %></div>
+      </div>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-12">
+    <h3 id="ncaaf">NCAA Football</h3>
+    <hr />
+    <div class="row">
+      <% for team in @teams_ncaaf %>
+      <div class="col-md-6">
+        <div class="well well-sm"><%= team.entity_name %></div>
+      </div>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-12">
+    <h3 id="ncaamb">NCAA Men's Basketball</h3>
+    <hr />
+    <div class="row">
+      <% for team in @teams_ncaamb %>
+      <div class="col-md-6">
+        <div class="well well-sm"><%= team.entity_name %></div>
+      </div>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-12">
+    <h3 id="wftda">Women's Flat Track Derby Association</h3>
+    <hr />
+    <div class="row">
+      <% for team in @teams_wftda %>
+      <div class="col-md-6">
+        <div class="well well-sm"><%= team.entity_name %></div>
+      </div>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<% content_for :sidebar do %>
+
+<div data-spy="affix">
+
+  <div class="list-group col-md-12 team-list">
+    <a href="#nfl" class="list-group-item">
+      <span class="badge"><%= @teams_nfl.count %></span>
+      National Football League (NFL)
+    </a>
+    <a href="#mlb" class="list-group-item">
+      <span class="badge"><%= @teams_nfl.count %></span>
+      Major League Baseball (MLB)
+    </a>
+    <a href="#nba" class="list-group-item">
+      <span class="badge"><%= @teams_nba.count %></span>
+      National Basketball Assoc. (NBA)
+    </a>
+    <a href="#nhl" class="list-group-item">
+      <span class="badge"><%= @teams_nhl.count %></span>
+      National Hockey League (NHL)
+    </a>
+    <a href="#ncaaf" class="list-group-item">
+      <span class="badge"><%= @teams_ncaaf.count %></span>
+      NCAA Football (NCAAF)
+    </a>
+    <a href="#ncaamb" class="list-group-item">
+      <span class="badge"><%= @teams_ncaamb.count %></span>
+      NCAA Men's Basketball (NCAAMB)
+    </a>
+    <a href="#wftda" class="list-group-item">
+      <span class="badge"><%= @teams_wftda.count %></span>
+      Women's Flat Track Derby Assoc. (WFTDA)
+    </a>
+  </div>
+
+  <p><small><strong>Not seeing your team?</strong> Just <%= link_to 'contact us', contact_path %> and we will look into adding it!</small></p>
+
+</div>
+
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ SeatShare::Application.routes.draw do
 
   root 'public#index'
 
+  get 'teams' => 'public#teams'
   get 'tos' => 'public#tos'
   get 'privacy' => 'public#privacy'
   get 'contact' => 'public#contact'


### PR DESCRIPTION
Show off the somewhat impressive list of teams for which we can obtain schedules. The outlier is WFTDA (which would still be a manual process), but I'm not expecting a lot of traffic for that area of the site.
