### PR TITLE
Fix for Mixpanel JS bug, adds GA user tracking

### DIFF
--- a/app/views/layouts/_analytics.html.erb
+++ b/app/views/layouts/_analytics.html.erb
@@ -8,5 +8,9 @@
   ga('create', '<%= ENV['GOOGLE_ANALYTICS_ID'] %>', 'myseatshare.com');
   ga('send', 'pageview');
 
+  <% if user_signed_in? %>
+  ga('set', '&uid', '<%= current_user.id %>');
+  <% end %>
+
 </script>
 <% end %>

--- a/app/views/layouts/_mixpanel.html.erb
+++ b/app/views/layouts/_mixpanel.html.erb
@@ -7,11 +7,11 @@ mixpanel.init('<%= ENV['MIXPANEL_API_KEY'] %>');
 <% if user_signed_in? %>
 mixpanel.identify("<%= current_user.id %>");
 mixpanel.people.set({
-    "$first_name": <%= current_user.first_name.to_json %>,
-    "$last_name": <%= current_user.last_name.to_json %>,
-    "$created": <%= current_user.created_at.to_json %>,
-    "$email": <%= current_user.email.to_json %>,
-    "$username": <%= current_user.email.to_json %>
+    "$first_name": <%= current_user.first_name.to_json.html_safe %>,
+    "$last_name": <%= current_user.last_name.to_json.html_safe %>,
+    "$created": <%= current_user.created_at.to_json.html_safe %>,
+    "$email": <%= current_user.email.to_json.html_safe %>,
+    "$username": <%= current_user.email.to_json.html_safe %>
 });
 <% end %>
 </script>

--- a/app/views/layouts/login.html.erb
+++ b/app/views/layouts/login.html.erb
@@ -33,10 +33,6 @@
 
 </div>
 
-<div class="sr-only">
-  <p>Existing users can use this page to access their account. If you need an access, you can <%= link_to 'create an account', 'register' %>. You can also <%= link_to 'retrieve your password', new_password_path(resource_name) %>retrieve your username and password</a> if needed.</p>
-</div>
-
 <%= render 'layouts/analytics' %>
 
 <%= render 'layouts/growl' %>

--- a/config/local_env.yml.example
+++ b/config/local_env.yml.example
@@ -21,3 +21,10 @@ SIMPLE_FORM_FORM_API_TOKEN: 'the_public_token'
 SODA_USERNAME: 'the_soda_username'
 SODA_PASSWORD: 'the_soda_password'
 SODA_ENVIRONMENT: 'development'
+
+# These values are production only
+# MANDRILL_SMTP_USER: 'mandrill_user'
+# MANDRILL_SMTP_PASS: 'mandril_password'
+# MANDRILL_SMTP_HOST: 'mandrill_hostname'
+# GOOGLE_ANALYTICS_ID: 'google_analytics_id'
+# MIXPANEL_API_KEY: 'mixpanel_api_key'

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,3 @@
-# See http://www.robotstxt.org/wc/norobots.html for documentation on how to use the robots.txt file
-#
-# To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /
+User-agent: *
+Disallow: /login
+Disallow: /password


### PR DESCRIPTION
- Bad encoding on on how `.to_json` works caused JS failures on initial load
- Adds User-ID support to GA for additional measurement/metrics
- Adds a few ignore rules to robots.txt for non-SEO pages (such as /login)
- Updates default `local_env.yml` config to show all possible variables
