### PR TITLE
Remove / refactor class methods

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -38,7 +38,7 @@ ActiveAdmin.register_page "Dashboard" do
         panel "Recent Users" do
           ul do
             User.last(5).map do |user|
-              li link_to(user.full_name, admin_user_path(user))
+              li link_to(user.display_name, admin_user_path(user)) + " <small>joined #{user.created_at.strftime('%-m/%-d/%Y')}</small>".html_safe
             end
           end
         end
@@ -46,7 +46,7 @@ ActiveAdmin.register_page "Dashboard" do
         panel "Recent Groups" do
           ul do
             Group.last(5).map do |group|
-              li link_to(group.group_name, admin_group_path(group))
+              li link_to(group.group_name, admin_group_path(group)) + " <small>created #{group.created_at.strftime('%-m/%-d/%Y')}</small>".html_safe
             end
           end
         end

--- a/app/admin/ticket.rb
+++ b/app/admin/ticket.rb
@@ -18,7 +18,7 @@ ActiveAdmin.register Ticket do
     column :owner
     column :user
     column :event
-    column :section_row_seat
+    column :display_name
     column :cost do |ticket|
       number_to_currency ticket.cost
     end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -5,7 +5,7 @@ class ProfilesController < ApplicationController
 
   def show
     @user = User.find_by_id(params[:id]) || not_found
-    @page_title = "#{@user.full_name}"
+    @page_title = "#{@user.display_name}"
   end
 
   def edit

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -10,9 +10,9 @@ class TicketsController < ApplicationController
       :user_id => current_user.id
     })
 
-    @members = @group.users.order_by_name.collect {|p| [ p.full_name, p.id ] }
+    @members = @group.users.order_by_name.collect {|p| [ p.display_name, p.id ] }
     @members.unshift(['Unassigned', 0])
-    @user_aliases = current_user.user_aliases.order_by_name.collect {|p| [ p.full_name, p.id ] }
+    @user_aliases = current_user.user_aliases.order_by_name.collect {|p| [ p.display_name, p.id ] }
     @user_aliases.unshift(['Not Set', 0])
 
     if params[:event_id]
@@ -79,12 +79,12 @@ class TicketsController < ApplicationController
     end
 
     @ticket_stats = @event.ticket_stats(@group, current_user)
-    @members = @group.users.order_by_name.order_by_name.collect {|p| [ p.full_name, p.id ] }
+    @members = @group.users.order_by_name.order_by_name.collect {|p| [ p.display_name, p.id ] }
     @members.unshift(['Unassigned', 0])
-    @user_aliases = current_user.user_aliases.collect {|p| [ p.full_name, p.id ] }
+    @user_aliases = current_user.user_aliases.collect {|p| [ p.display_name, p.id ] }
     @user_aliases.unshift(['Unassigned', 0])
 
-    @page_title = "#{@event.event_name} - #{@ticket.section_row_seat}"
+    @page_title = "#{@event.event_name} - #{@ticket.display_name}"
   end
 
   def update
@@ -158,7 +158,7 @@ class TicketsController < ApplicationController
 
     @ticket_stats = @event.ticket_stats(@group, current_user)
 
-    @page_title = "#{@event.event_name} - #{@ticket.section_row_seat}"
+    @page_title = "#{@event.event_name} - #{@ticket.display_name}"
   end
 
   def do_request_ticket

--- a/app/mailers/schedule_notifier.rb
+++ b/app/mailers/schedule_notifier.rb
@@ -8,7 +8,7 @@ class ScheduleNotifier < ActionMailer::Base
     @user = user
 
     mail(
-      to: "#{user.full_name} <#{@user.email}>",
+      to: "#{user.display_name} <#{@user.email}>",
       subject: "Today's events for #{@group.group_name}"
     )
   end
@@ -29,7 +29,7 @@ class ScheduleNotifier < ActionMailer::Base
     @user = user
 
     mail(
-      to: "#{user.full_name} <#{@user.email}>",
+      to: "#{user.display_name} <#{@user.email}>",
       subject: "The week ahead for #{@group.group_name}"
     )
   end

--- a/app/mailers/ticket_notifier.rb
+++ b/app/mailers/ticket_notifier.rb
@@ -10,7 +10,7 @@ class TicketNotifier < ActionMailer::Base
     @user = user
 
     mail(
-      to: "#{@recipient.full_name} <#{@recipient.email}>",
+      to: "#{@recipient.display_name} <#{@recipient.email}>",
       subject: "#{@user.first_name} has assigned you a ticket via #{@group.group_name}"
     )
   end
@@ -24,7 +24,7 @@ class TicketNotifier < ActionMailer::Base
     @message = message
 
     mail(
-      to: "#{@recipient.full_name} <#{@recipient.email}>",
+      to: "#{@recipient.display_name} <#{@recipient.email}>",
       subject: "#{@user.first_name} has requested your ticket via #{@group.group_name}"
     )
   end

--- a/app/mailers/welcome_email.rb
+++ b/app/mailers/welcome_email.rb
@@ -6,7 +6,7 @@ class WelcomeEmail < ActionMailer::Base
     @recipient = user
 
     mail(
-      to: "#{@recipient.full_name} <#{@recipient.email}>",
+      to: "#{@recipient.display_name} <#{@recipient.email}>",
       subject: "Welcome to SeatShare, #{@recipient.first_name}!"
     )
   end

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -14,6 +14,12 @@ class Entity < ActiveRecord::Base
       :status => 0,
       :import_key => generate_import_key(attributes)
     }.merge(attributes)
+
+    # Prevent empty import key
+    if attributes[:import_key] === ''
+      attr_with_defaults[:import_key] = generate_import_key(attributes)
+    end
+
     super(attr_with_defaults)
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -25,7 +25,7 @@ class Event < ActiveRecord::Base
   end
 
   def display_name
-    "#{entity.entity_name}: #{event_name} #{date_time}"
+    "#{entity.entity_name}: #{event_name} - #{date_time}"
   end
 
   def tickets(group=nil)
@@ -77,11 +77,6 @@ class Event < ActiveRecord::Base
       out += self.start_time.strftime('%-I:%M %P')
     end
     return out
-  end
-
-  def self.get_by_ticket_id(ticket_id=nil)
-    ticket = Ticket.find(ticket_id)
-    Event.find(ticket.event_id)
   end
 
   def self.import(row=nil)

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -30,12 +30,6 @@ class Group < ActiveRecord::Base
     User.joins(:groups).where(group_users: { role: 'admin' })
   end
 
-  def self.get_by_ticket_id(ticket_id=nil)
-    ticket = Ticket.find(ticket_id)
-    group = Group.find(ticket.group_id)
-    return group
-  end
-
   def is_member(user=nil)
     group_user = GroupUser.where("group_id = #{self.id} AND user_id = #{user.id}").first
     if group_user.nil?

--- a/app/models/group_invitation.rb
+++ b/app/models/group_invitation.rb
@@ -13,7 +13,7 @@ class GroupInvitation < ActiveRecord::Base
   end
 
   def display_name
-    "#{group_name}"
+    "#{group.group_name}: #{email}"
   end
 
   def self.get_by_invitation_code(invitation_code=nil)

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -11,15 +11,11 @@ class Ticket < ActiveRecord::Base
   validates :cost, :numericality => { :greater_than_or_equal_to => 0 }
 
   def display_name
-    "#{section_row_seat}"
+    [self.section, self.row, self.seat].join(" ").strip
   end
 
   def assigned
     User.find_by_id(self.user_id)
-  end
-
-  def section_row_seat
-    [self.section, self.row, self.seat].join(" ").strip
   end
 
   def is_available?

--- a/app/models/ticket_history.rb
+++ b/app/models/ticket_history.rb
@@ -1,32 +1,19 @@
 class TicketHistory < ActiveRecord::Base
   belongs_to :ticket
+  belongs_to :user
+  belongs_to :event
+  belongs_to :group
 
   validates :ticket_id, :group_id, :event_id, :user_id, :entry, :presence => true
 
-  def entry_to_string
+  def display_name
     entry = JSON.parse(self.entry)
     user = User.find(self.user_id)
-    "#{user.full_name} #{entry['text']}"
+    "#{user.display_name} #{entry['text']}"
   end
 
   def date_time
     self.created_at.strftime('%-m/%-d/%Y %-I:%M %P')
-  end
-
-  def ticket
-    Ticket.find(self.ticket_id)
-  end
-
-  def user
-    User.find(self.user_id)
-  end
-
-  def event
-    Event.find(self.event_id)
-  end
-
-  def group
-    Group.find(self.group_id)
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,10 +31,6 @@ class User < ActiveRecord::Base
     "#{first_name} #{last_name}"
   end
 
-  def full_name
-    "#{first_name} #{last_name}"
-  end
-
   def gravatar(dimensions='30x30')
     require 'digest/md5'
     email_address = self.email.downcase

--- a/app/models/user_alias.rb
+++ b/app/models/user_alias.rb
@@ -9,10 +9,6 @@ class UserAlias < ActiveRecord::Base
     "#{self.first_name} #{self.last_name}"
   end
 
-  def full_name
-    "#{self.first_name} #{self.last_name}"
-  end
-
   def destroy
     tickets = Ticket.where("alias_id = #{self.id}")
     for ticket in tickets

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -35,9 +35,9 @@
     <tr>
       <td>
         <% if ticket.assigned && ticket.owner.id != current_user.id && ticket.assigned.id != current_user.id %>
-        <%= link_to ticket.section_row_seat, { :controller => 'tickets', :action => 'request_ticket', :group_id => @group.id, :event_id => @event.id, :id => ticket.id } %>
+        <%= link_to ticket.display_name, { :controller => 'tickets', :action => 'request_ticket', :group_id => @group.id, :event_id => @event.id, :id => ticket.id } %>
         <% else %>
-        <%= link_to ticket.section_row_seat, { :controller => 'tickets', :action => 'edit', :id => ticket.id, :event_id => @event.id } %>
+        <%= link_to ticket.display_name, { :controller => 'tickets', :action => 'edit', :id => ticket.id, :event_id => @event.id } %>
         <% end %>
         <% if !ticket.note.nil? && ticket.note.length > 0 %>
         <span data-toggle="tooltip" title="<%= ticket.note %>" class="glyphicon glyphicon-comment"></span>
@@ -47,13 +47,13 @@
         <% end %>
       </td>
       <td>
-        <%= link_to ticket.owner.full_name, :controller => 'profiles', :action => 'show', :id => ticket.owner.id %>
+        <%= link_to ticket.owner.display_name, :controller => 'profiles', :action => 'show', :id => ticket.owner.id %>
       </td>
       <td>
         <% if ticket.assigned %>
-        <%= link_to ticket.assigned.full_name, :controller => 'profiles', :action => 'show', :id => ticket.assigned.id %>
+        <%= link_to ticket.assigned.display_name, :controller => 'profiles', :action => 'show', :id => ticket.assigned.id %>
         <% if ticket.alias %>
-        <br />(for <%= ticket.alias.full_name %>)
+        <br />(for <%= ticket.alias.display_name %>)
         <% end %>
         <% else %>
         <%= link_to raw('<span class="badge badge-lg">Available!</span>'), { :controller => 'tickets', :action => 'edit', :id => ticket.id, :event_id => @event.id }, { :data => { :toggle => 'tooltip'}, :title => 'Request Ticket' } %>

--- a/app/views/group_notifier/create_invite.html.erb
+++ b/app/views/group_notifier/create_invite.html.erb
@@ -6,7 +6,7 @@
 
 <p>Hi!</p>
  
-<p><%= @user.full_name %> has invited you to join our <strong><%= @group.entity.entity_name %></strong> group on <%= link_to 'SeatShare', :controller => 'public', :action => 'index', :only_path => false %>, a service that helps manage our season tickets.</p>
+<p><%= @user.display_name %> has invited you to join our <strong><%= @group.entity.entity_name %></strong> group on <%= link_to 'SeatShare', :controller => 'public', :action => 'index', :only_path => false %>, a service that helps manage our season tickets.</p>
 
 <table cellpadding="10px">
   <tr>
@@ -44,6 +44,6 @@
 <p>
   ---<br />
   <%= link_to 'SeatShare', :controller => 'public', :action => 'index', :only_path => false %>, on behalf of
-  <%= @user.full_name %><br />
+  <%= @user.display_name %><br />
   <%= mail_to @user.email, @user.email %>
 </p>

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -62,7 +62,7 @@
       <% for member in @members %>
       <tr>
         <td><%= image_tag member.gravatar %></td>
-        <td><%= link_to member.full_name, {:controller => 'profiles', :action => 'show', :id => member.id } %></td>
+        <td><%= link_to member.display_name, {:controller => 'profiles', :action => 'show', :id => member.id } %></td>
         <td><%= mail_to member.email %></td>
       </tr>
       <% end %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,6 +1,6 @@
 <div class="panel panel-default">
   <div class="panel-heading">
-    Your <strong><%= @group.entity.entity_name %></strong> group is administered by <%= link_to @group.administrators.first.full_name, {:controller => 'profiles', :action => 'show', :id => @group.administrators.first.id } %>
+    Your <strong><%= @group.entity.entity_name %></strong> group is administered by <%= link_to @group.administrators.first.display_name, {:controller => 'profiles', :action => 'show', :id => @group.administrators.first.id } %>
     <div class="pull-right">
       <%= link_to raw('<span class="glyphicon glyphicon-cog"></span>'), { :controller => 'groups', :action => 'edit', :id => @group.id }, :class => 'btn btn-xs btn-default' %>
     </div>
@@ -43,7 +43,7 @@
         <% next if ticket.is_assigned? %>
         <tr>
           <td>
-            <%= link_to ticket.section_row_seat, :controller => 'tickets', :action => 'edit', :group_id => @group.id, :event_id => event.id, :id => ticket.id %>
+            <%= link_to ticket.display_name, :controller => 'tickets', :action => 'edit', :group_id => @group.id, :event_id => event.id, :id => ticket.id %>
             <% if ticket.note? %>
             <span data-toggle="tooltip" title="<%= ticket.note %>" class="glyphicon glyphicon-comment"></span>
             <% end %>
@@ -51,7 +51,7 @@
             <span data-toggle="tooltip" title="Attachments" class="glyphicon glyphicon-paperclip"></span>
             <% end %>
           </td>
-          <td>via <%= ticket.owner.full_name %></td>
+          <td>via <%= ticket.owner.display_name %></td>
           <td class="text-right">
             <%= link_to number_to_currency(ticket.cost), { :controller => 'tickets', :action => 'edit', :group_id => @group.id, :event_id => event.id, :id => ticket.id }, :class => 'btn btn-primary', :data => {:toggle => 'tooltip' }, :title => 'Request Ticket' %>
           </td>
@@ -100,7 +100,7 @@
           <% next if ticket.is_assigned? %>
           <tr>
             <td>
-              <%= link_to ticket.section_row_seat, :controller => 'tickets', :action => 'edit', :group_id => @group.id, :event_id => event.id, :id => ticket.id %>
+              <%= link_to ticket.display_name, :controller => 'tickets', :action => 'edit', :group_id => @group.id, :event_id => event.id, :id => ticket.id %>
               <% if ticket.note? %>
               <span data-toggle="tooltip" title="<%= ticket.note %>" class="glyphicon glyphicon-comment"></span>
               <% end %>
@@ -108,7 +108,7 @@
               <span data-toggle="tooltip" title="Attachments" class="glyphicon glyphicon-paperclip"></span>
               <% end %>
             </td>
-            <td>via <%= ticket.owner.full_name %></td>
+            <td>via <%= ticket.owner.display_name %></td>
             <td class="text-right">
               <%= link_to number_to_currency(ticket.cost), { :controller => 'tickets', :action => 'edit', :group_id => @group.id, :event_id => event.id, :id => ticket.id }, :class => 'btn btn-primary', :data => {:toggle => 'tooltip' }, :title => 'Request Ticket' %>
             </td>
@@ -175,7 +175,7 @@
 
 <ul class="list-unstyled group-members">
   <% for member in @members %>
-  <li><%= image_tag member.gravatar %> <%= link_to member.full_name, {:controller => 'profiles', :action => 'show', :id => member.id } %></li>
+  <li><%= image_tag member.gravatar %> <%= link_to member.display_name, {:controller => 'profiles', :action => 'show', :id => member.id } %></li>
   <% end %>
   <li class="text-right"><%= link_to raw('<span class="glyphicon glyphicon-plus"></span> Invite Member'), { :controller => 'groups', :action => 'invite', :id => @group.id }, :class => 'btn btn-default btn-sm' %></li>
 </ul>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -24,7 +24,7 @@
         <li class=""><%= link_to "Groups", :groups %></li>
       </ul>
       <ul class="nav navbar-nav pull-right">
-        <li class=""><%= link_to current_user.full_name, profile_path %></li>
+        <li class=""><%= link_to current_user.display_name, profile_path %></li>
         <li><%= link_to "Logout", destroy_user_session_path, :method => :delete %></li>
       </ul>
       <% else %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -52,7 +52,7 @@
     <tbody>
       <% for user_alias in @user_aliases %>
       <tr>
-        <td><%= link_to user_alias.full_name, :controller => 'user_aliases', :action => 'edit', :id => user_alias.id %></td>
+        <td><%= link_to user_alias.display_name, :controller => 'user_aliases', :action => 'edit', :id => user_alias.id %></td>
         <td><%= link_to raw('<span class="glyphicon glyphicon-trash"></span>'), { :controller => 'user_aliases', :action => 'delete', :id => user_alias.id }, :class => 'btn btn-sm btn-danger confirm' %></td>
       </tr>
       <% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -13,7 +13,7 @@
       <%= link_to raw('<span class="glyphicon glyphicon-pencil"></span> Edit Profile'), { :action => 'edit' }, :class => 'btn btn-default' %>
     </p>
     <% end %>
-    <h2><%= @user.full_name %></h2>
+    <h2><%= @user.display_name %></h2>
     <ul class="list-unstyled">
       <li><span class="glyphicon glyphicon-envelope"></span> <%= mail_to @user.email, @user.email %></li>
     </ul>

--- a/app/views/schedule_notifier/daily_schedule.html.erb
+++ b/app/views/schedule_notifier/daily_schedule.html.erb
@@ -36,8 +36,8 @@
 					<% for ticket in tickets %>
 					<% next if ticket.is_assigned? %>
 					<tr>
-						<td><%= link_to ticket.section_row_seat, { :controller => 'tickets', :action => 'show', :group_id => @group.id, :event_id => ticket.event_id, :id => ticket.id, :only_path => false } %></td>
-						<td>via <%= ticket.owner.full_name; %></td>
+						<td><%= link_to ticket.display_name, { :controller => 'tickets', :action => 'show', :group_id => @group.id, :event_id => ticket.event_id, :id => ticket.id, :only_path => false } %></td>
+						<td>via <%= ticket.owner.display_name; %></td>
 						<td>
 							<%= link_to number_to_currency(ticket.cost), { :controller => 'tickets', :action => 'show', :group_id => @group.id, :event_id => ticket.event_id, :id => ticket.id, :only_path => false } %>
 						</td>

--- a/app/views/schedule_notifier/weekly_schedule.html.erb
+++ b/app/views/schedule_notifier/weekly_schedule.html.erb
@@ -45,8 +45,8 @@
           <% for ticket in tickets %>
           <% next if ticket.is_assigned? %>
           <tr>
-            <td><%= link_to ticket.section_row_seat, { :controller => 'tickets', :action => 'show', :group_id => @group.id, :event_id => ticket.event_id, :id => ticket.id, :only_path => false } %></td>
-            <td>via <%= ticket.owner.full_name; %></td>
+            <td><%= link_to ticket.display_name, { :controller => 'tickets', :action => 'show', :group_id => @group.id, :event_id => ticket.event_id, :id => ticket.id, :only_path => false } %></td>
+            <td>via <%= ticket.owner.display_name; %></td>
             <td>
               <%= link_to number_to_currency(ticket.cost), { :controller => 'tickets', :action => 'show', :group_id => @group.id, :event_id => ticket.event_id, :id => ticket.id, :only_path => false } %>
             </td>

--- a/app/views/ticket_notifier/assign.html.erb
+++ b/app/views/ticket_notifier/assign.html.erb
@@ -1,6 +1,6 @@
 <p><%= @recipient.first_name %>,</p>
 
-<p><%= @user.full_name %> (<%= mail_to @user.email, @user.email %>) has assigned a ticket to you for the following event in your group <%= @group.group_name %>.</p>
+<p><%= @user.display_name %> (<%= mail_to @user.email, @user.email %>) has assigned a ticket to you for the following event in your group <%= @group.group_name %>.</p>
 
 <table cellpadding="10px">
   <tr>
@@ -13,7 +13,7 @@
   </tr>
   <tr>
     <th>Ticket</th>
-    <td><%= link_to @ticket.section_row_seat, { :controller => 'tickets', :action => 'edit', :group_id => @ticket.group_id, :event_id => @ticket.event_id, :id => @ticket.id, :only_path => false } %></td>
+    <td><%= link_to @ticket.display_name, { :controller => 'tickets', :action => 'edit', :group_id => @ticket.group_id, :event_id => @ticket.event_id, :id => @ticket.id, :only_path => false } %></td>
   </tr>
 </table>
 
@@ -36,6 +36,6 @@
  
 <p>
   ---<br />
-  <%= link_to 'SeatShare', { :controller => 'public', :action => 'index', :only_path => false } %>  on behalf of <%= @user.full_name %><br />
+  <%= link_to 'SeatShare', { :controller => 'public', :action => 'index', :only_path => false } %>  on behalf of <%= @user.display_name %><br />
   <%= mail_to @user.email, @user.email %></a>
 </p>

--- a/app/views/ticket_notifier/request_ticket.html.erb
+++ b/app/views/ticket_notifier/request_ticket.html.erb
@@ -4,7 +4,7 @@
 <% end %>
 <p><%= @recipient.first_name %>,</p>
 
-<p><%= @user.full_name %> (<%= mail_to @user.email, @user.email %>) has requested your ticket for the following event in your group <%= @group.group_name %>.</p>
+<p><%= @user.display_name %> (<%= mail_to @user.email, @user.email %>) has requested your ticket for the following event in your group <%= @group.group_name %>.</p>
 
 <table cellpadding="10px">
   <tr>
@@ -17,12 +17,12 @@
   </tr>
   <tr>
     <th>Ticket</th>
-    <td><%= link_to @ticket.section_row_seat, { :controller => 'tickets', :action => 'edit', :group_id => @ticket.group_id, :event_id => @ticket.event_id, :id => @ticket.id, :only_path => false } %></td>
+    <td><%= link_to @ticket.display_name, { :controller => 'tickets', :action => 'edit', :group_id => @ticket.group_id, :event_id => @ticket.event_id, :id => @ticket.id, :only_path => false } %></td>
   </tr>
 </table>
 
 <p>
   ---<br />
-  <%= link_to 'SeatShare', { :controller => 'public', :action => 'index', :only_path => false } %>  on behalf of <%= @user.full_name %><br />
+  <%= link_to 'SeatShare', { :controller => 'public', :action => 'index', :only_path => false } %>  on behalf of <%= @user.display_name %><br />
   <%= mail_to @user.email, @user.email %></a>
 </p>

--- a/app/views/tickets/edit.html.erb
+++ b/app/views/tickets/edit.html.erb
@@ -5,7 +5,7 @@
   <div class="form-group">
     <%= f.label 'Ticket Purchaser', :class => 'col-md-3 control-label' %>
     <div class="col-md-9">
-      <p class="form-control-static"><%= @ticket.owner.full_name %></p>
+      <p class="form-control-static"><%= @ticket.owner.display_name %></p>
     </div>
   </div>
   <div class="form-group">
@@ -84,7 +84,7 @@
 <h3>Ticket History</h3>
 <ul class="list-unstyled">
   <% for history in @ticket.ticket_histories %>
-  <li><%= history.entry_to_string %> <%= history.date_time %></li>
+  <li><%= history.display_name %> <%= history.date_time %></li>
   <% end %>
 </ul>
 <% end %>

--- a/app/views/tickets/request_ticket.html.erb
+++ b/app/views/tickets/request_ticket.html.erb
@@ -5,14 +5,14 @@
   <div class="form-group">
     <%= f.label :owner_id, :class => 'col-md-3 control-label' %>
     <div class="col-md-9">
-      <p class="form-control-static"><%= @ticket.owner.full_name %></p>
+      <p class="form-control-static"><%= @ticket.owner.display_name %></p>
     </div>
   </div>
   <div class="form-group">
     <%= f.label :user_id, :class => 'col-md-3 control-label' %>
     <div class="col-md-9">
       <% if !@ticket.assigned.nil? %>
-      <p class="form-control-static"><%= @ticket.assigned.full_name %></p>
+      <p class="form-control-static"><%= @ticket.assigned.display_name %></p>
       <% else %>
       <p class="form-control-static">Unassigned</p>
       <% end %>

--- a/lib/tasks/send_reminders.rake
+++ b/lib/tasks/send_reminders.rake
@@ -11,7 +11,7 @@ namespace :send_reminders do
         for group_user in group.group_users
           if group_user.daily_reminder === 1
             user = User.find(group_user.user_id)
-            puts "- Sending #{user.full_name} for #{group.group_name}"
+            puts "- Sending #{user.display_name} for #{group.group_name}"
             ScheduleNotifier.daily_schedule(events, group, user).deliver
           end
         end
@@ -34,7 +34,7 @@ namespace :send_reminders do
         for group_user in group.group_users
           if group_user.weekly_reminder === 1
             user = User.find(group_user.user_id)
-            puts "- Sending #{user.full_name} for #{group.group_name}"
+            puts "- Sending #{user.display_name} for #{group.group_name}"
             ScheduleNotifier.daily_schedule(events, group, user).deliver
           end
         end

--- a/test/integration/group_flow_test.rb
+++ b/test/integration/group_flow_test.rb
@@ -39,4 +39,17 @@ class GroupFlowTest < ActionDispatch::IntegrationTest
     assert_equal 'You have left Geeks Watching Hockey', flash[:success]
   end
 
+  test "invite a user" do
+    post_via_redirect "/login", {:user => { :email => users(:jim).email, :password => "testing123" }}
+
+    get '/groups/1/invite'
+    assert_response :success
+
+    post_via_redirect '/groups/1/invite', {:group_invitation => { :email => 'rick@example.net', :message => 'Join us!'}}
+    assert_response :success
+    assert_equal '/groups/1', path
+    assert_equal 'Group invitation sent!', flash[:success]
+
+  end
+
 end

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -25,7 +25,7 @@ class GroupTest < ActiveSupport::TestCase
   end
 
   test "get group by ticket ID" do
-    group = Group.get_by_ticket_id(1)
+    group = Ticket.find(1).group
 
     assert group.id === 1, 'fixture group ID matches'
     assert group.group_name === 'Geeks Watching Hockey', 'fixture group name matches'

--- a/test/models/ticket_history_test.rb
+++ b/test/models/ticket_history_test.rb
@@ -22,7 +22,7 @@ class TicketHistoryTest < ActiveSupport::TestCase
   test "ticket property is set" do
     ticket_history = TicketHistory.find(1)
 
-    assert ticket_history.ticket.section_row_seat === '326 K 9'
+    assert ticket_history.ticket.display_name === '326 K 9'
   end
 
   test "event property is set" do
@@ -40,7 +40,7 @@ class TicketHistoryTest < ActiveSupport::TestCase
   test "user property is set" do
     ticket_history = TicketHistory.find(1)
 
-    assert ticket_history.user.full_name === 'Jim Stone'
+    assert ticket_history.user.display_name === 'Jim Stone'
   end
 
 end

--- a/test/models/ticket_test.rb
+++ b/test/models/ticket_test.rb
@@ -16,9 +16,9 @@ class TicketTest < ActiveSupport::TestCase
     ticket.save!
 
     assert ticket.cost === 45.00
-    assert ticket.section_row_seat === '301 Q 3'
-    assert ticket.owner.full_name === 'Jim Stone'
-    assert ticket.assigned.full_name === 'Jill Smith'
+    assert ticket.display_name === '301 Q 3'
+    assert ticket.owner.display_name === 'Jim Stone'
+    assert ticket.assigned.display_name === 'Jill Smith'
     assert ticket.group.group_name === 'Geeks Watching Hockey'
     assert ticket.event.event_name === 'Nashville Predators vs. St. Louis Blues'
   end
@@ -26,13 +26,13 @@ class TicketTest < ActiveSupport::TestCase
   test "owner property is set" do
     ticket = Ticket.find(1)
 
-    assert ticket.owner.full_name === 'Jim Stone'
+    assert ticket.owner.display_name === 'Jim Stone'
   end
 
   test "assigned property is set" do
     ticket = Ticket.find(1)
 
-    assert ticket.assigned.full_name === 'Jim Stone'
+    assert ticket.assigned.display_name === 'Jim Stone'
 
     ticket = Ticket.find(2)
 
@@ -42,7 +42,7 @@ class TicketTest < ActiveSupport::TestCase
   test "alias property is set" do
     ticket = Ticket.find(4)
 
-    assert ticket.alias.full_name === 'Jennifer Newton'
+    assert ticket.alias.display_name === 'Jennifer Newton'
 
     ticket = Ticket.find(1)
 
@@ -55,14 +55,14 @@ class TicketTest < ActiveSupport::TestCase
     assert ticket.group.group_name === 'Geeks Watching Hockey'
   end
 
-  test "section_row_seat property is set" do
+  test "display_name property is set" do
     ticket = Ticket.find(1)
 
-    assert ticket.section_row_seat === '326 K 9'
+    assert ticket.display_name === '326 K 9'
 
     ticket = Ticket.find(5)
 
-    assert ticket.section_row_seat === 'VIP'
+    assert ticket.display_name === 'VIP'
   end
 
   test "is_available? check" do

--- a/test/models/user_alias_test.rb
+++ b/test/models/user_alias_test.rb
@@ -10,7 +10,7 @@ class UserAliasTest < ActiveSupport::TestCase
 
     assert user_alias.first_name === 'Amanda', 'new user alias first name matches'
     assert user_alias.last_name === 'Goodlaw', 'new user alias last name matches'
-    assert user_alias.full_name === 'Amanda Goodlaw', 'new user alias full name matches'
+    assert user_alias.display_name === 'Amanda Goodlaw', 'new user alias full name matches'
     assert user_alias.user_id === 1, 'new user alias user ID matches'
   end
 
@@ -19,7 +19,7 @@ class UserAliasTest < ActiveSupport::TestCase
 
     assert user_alias.first_name === 'Kevin', 'fixture user alias first name matches'
     assert user_alias.last_name === 'Jones', 'fixture user alias last name matches'
-    assert user_alias.full_name === 'Kevin Jones', 'new user alias full name matches'
+    assert user_alias.display_name === 'Kevin Jones', 'new user alias full name matches'
     assert user_alias.user_id === 4, 'fixture user alias user ID matches'
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -26,7 +26,7 @@ class UserTest < ActiveSupport::TestCase
   test "get full name of user" do
     user = User.find(2)
 
-    assert user.full_name === 'Jill Smith'
+    assert user.display_name === 'Jill Smith'
   end
 
   test "group users match group ID" do


### PR DESCRIPTION
Goal of this PR is to simplify the models back down to a reasonable size and rely more on the built-in capabilities of ActiveRecord relationships. It also cut down on duplicated code to do string formatting. The user invitation process is now under test, though there is some UI issue where the growl `flash` notifications are not displaying.
