### PR TITLE
Allow SODA import to handle uncertain times

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ gem 'activeadmin', github: 'gregbell/active_admin'
 gem 'mailchimp-api', '~> 2.0.5'
 
 # SeatShare's own SODA gem
-gem 'soda_xml_team', '~> 1.0.7'
+gem 'soda_xml_team', '~> 1.0.8'
 
 # Capistrano
 gem 'capistrano', '~> 3.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,7 +179,7 @@ GEM
       rdoc (~> 4.0)
     select2-rails (3.5.9)
       thor (~> 0.14)
-    soda_xml_team (1.0.7)
+    soda_xml_team (1.0.8)
       httparty (>= 0.13)
       nokogiri (>= 1.6.3)
     sprockets (2.11.0)
@@ -241,7 +241,7 @@ DEPENDENCIES
   sass-rails (~> 4.0.0)
   sdoc
   select2-rails
-  soda_xml_team (~> 1.0.7)
+  soda_xml_team (~> 1.0.8)
   thin
   turbolinks
   uglifier (>= 1.3.0)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -83,6 +83,9 @@ class Event < ActiveRecord::Base
     event.event_name = "#{row[:away_team]} vs. #{row[:home_team]}"
     event.start_time = row[:start_date_time]
     event.import_key = row[:event_key]
+    if !row[:time_certainty].blank? && row[:time_certainty] != 'certain'
+      event.time_tba = 1
+    end
     event.save!
 
     return event

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -81,4 +81,31 @@ class EventTest < ActiveSupport::TestCase
 
   end
 
+  test "imported row matches output" do
+    row1 = {
+      entity_id: 1,
+      home_team: 'Nashville Predators',
+      away_team: 'Colorado Avalanche',
+      start_date_time: '20091008T200000-0400',
+      time_certainty: 'not certain'
+    }
+    record = Event.import row1
+    assert record[:event_name] === 'Colorado Avalanche vs. Nashville Predators'
+    assert record[:start_time] === DateTime.parse('October 8, 2009 7:00 PM CDT')
+    assert record[:date_tba] === 0
+    assert record[:time_tba] === 1
+
+    row2 = {
+      entity_id: 1,
+      home_team: 'Nashville Predators',
+      away_team: 'San Jose Sharks',
+      start_date_time: '20091022T200000-0400',
+      time_certainty: 'certain'
+    }
+    record = Event.import row2
+    assert record[:event_name] === 'San Jose Sharks vs. Nashville Predators'
+    assert record[:start_time] === DateTime.parse('October 22, 2009 7:00 PM CDT')
+    assert record[:date_tba] === 0
+    assert record[:time_tba] === 0
+  end
 end


### PR DESCRIPTION
- Pretty much expecting the basketball schedules to be incomplete when released
- This will at least flag them as such upon release
- Cover import class method with tests
