### PR TITLE
Fix for incorrect group administrator

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -27,7 +27,7 @@ class Group < ActiveRecord::Base
   end
 
   def administrators
-    User.joins(:groups).where(group_users: { role: 'admin' })
+    users.where(group_users: { role: 'admin' })
   end
 
   def is_member(user=nil)

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -87,6 +87,14 @@ class GroupTest < ActiveSupport::TestCase
     assert group.is_admin(user) === true, 'user is an admin'
   end
 
+  test "gets correct list of administrators" do
+    group = Group.find(2)
+
+    assert group.administrators.count === 1
+    assert group.administrators.first.first_name === 'Rick'
+    assert group.administrators.first.last_name === 'Taylor'
+  end
+
   test "leave a group" do
     user = User.find(2)
     group = Group.find(1)


### PR DESCRIPTION
- List of administrators `(group_user.level = 'admin')` was using a bad query
- This caused the "Your group is administered by ..." message to be incorrect
