### PR TITLE
Restore group messaging feature

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -178,7 +178,6 @@ class GroupsController < ApplicationController
     @page_title = "Invite Member to #{@group.group_name}"
   end
 
-
   def do_invite
     group = Group.find(params[:id]) || not_found
 
@@ -198,6 +197,34 @@ class GroupsController < ApplicationController
     end
 
     redirect_to :action => 'show', :id => group.id and return
+  end
+
+  def message
+    @group = Group.find(params[:id]) || not_found
+    @page_title = "Send a Group Message to #{@group.group_name}"
+  end
+
+  def do_message
+    group = Group.find(params[:id]) || not_found
+
+    if params[:message][:recipients].nil?
+      flash[:error] = "You must select at least one recipient."
+      redirect_to :action => 'message', :id => group.id and return
+    end
+
+    subject = params[:message][:subject]
+    message = params[:message][:message]
+    recipients = User.find(params[:message][:recipients])
+
+    email = GroupNotifier.send_group_message(group, current_user, recipients, subject, message).deliver
+    if email
+      flash[:success] = "Message sent!"
+      redirect_to :action => 'show', :id => group.id and return
+    else
+      flash[:error] = "Message delivery failed."
+      redirect_to :action => 'message', :id => group.id and return
+    end
+
   end
 
   private

--- a/app/mailers/group_notifier.rb
+++ b/app/mailers/group_notifier.rb
@@ -15,4 +15,35 @@ class GroupNotifier < ActionMailer::Base
     )
   end
 
+  def send_group_message(group, sender, recipients, subject=nil, message=nil)
+
+    if group.blank? || sender.blank? || recipients.blank? || message.blank?
+      return false
+    end
+
+    if subject.blank?
+      subject = "[#{group.display_name}] A message from #{sender.display_name}"
+    else
+      subject = "[#{group.display_name}] #{subject}"
+    end
+
+    @group = group
+    @sender = sender
+    @recipients = recipients
+    @subject = subject
+    @message = message
+
+    @email_recipients = []
+    for recipient in recipients
+      @email_recipients << "#{recipient.display_name} <#{recipient.email}>"
+    end
+
+    mail(
+      from: "#{sender.display_name} <#{sender.email}>",
+      to: @email_recipients.join(', '),
+      subject: subject
+    )
+
+  end
+
 end

--- a/app/views/group_notifier/send_group_message.html.erb
+++ b/app/views/group_notifier/send_group_message.html.erb
@@ -1,0 +1,8 @@
+<%= simple_format(@message) %>
+ 
+<p>
+  ---<br />
+  <%= link_to 'SeatShare', :controller => 'public', :action => 'index', :only_path => false %>, on behalf of
+  <%= @sender.display_name %><br />
+  <%= mail_to @sender.email, @sender.email %>
+</p>

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -80,7 +80,10 @@
   </table>
 
 <div class="text-right">
-  <%= link_to raw('<span class="glyphicon glyphicon-plus"></span> Invite Member'), { :controller => 'groups', :action => 'invite', :id => @group.id }, :class => 'btn btn-default' %>
+  <ul class="list-inline">
+    <li><%= link_to raw('<span class="glyphicon glyphicon-envelope"></span> Group Message'), { :controller => 'groups', :action => 'message', :id => @group.id }, :class => 'btn btn-default' %></li>
+    <li><%= link_to raw('<span class="glyphicon glyphicon-plus"></span> Invite Member'), { :controller => 'groups', :action => 'invite', :id => @group.id }, :class => 'btn btn-default' %></li>
+  </ul>
 </div>
 
 

--- a/app/views/groups/message.html.erb
+++ b/app/views/groups/message.html.erb
@@ -1,0 +1,48 @@
+<%= form_for :message, html: {class: "form-horizontal", role: "form"}, url: { :controller => 'groups', :action => 'message', :id => @group.id } do |f| %>
+
+<div class="row">
+  <div class="col-md-12">
+    <fieldset>
+      <legend>Send a Group Message</legend>
+      <div class="form-group">
+        <%= f.label :subject, :class => 'col-md-3 control-label' %>
+        <div class="col-md-9">
+          <%= f.text_field :subject, :class => 'form-control', :placeholder => 'Your message subject (optional)' %>
+        </div>
+      </div>
+      <div class="form-group">
+        <%= f.label :message, :class => 'col-md-3 control-label' %>
+        <div class="col-md-9">
+          <%= f.text_area :message, :class => 'form-control', :placeholder => 'Write a short message to be sent to the recipients below.', :rows => 10 %>
+        </div>
+      </div>
+      <div class="form-group">
+        <%= f.label :recipients, :class => 'col-md-3 control-label' %>
+        <div class="col-md-9">
+        	<% for member in @group.users %>
+        	<div class="checkbox">
+			  <label>
+			    <%= f.check_box :recipients, { :multiple => true, :checked => (member.id != current_user.id)}, member.id, nil %>
+			    <%= image_tag member.gravatar, :alt => member.display_name, :title => member.display_name %> <%= member.display_name %>
+			  </label>
+			</div>
+        	<% end %>
+        </div>
+    </div>
+    </fieldset>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-12">
+    <p class="text-right">
+      <%= f.submit 'Send Message', :class => 'btn btn-primary' %>
+    </p>
+  </div>
+</div>
+
+<% end %>
+
+<% content_for :page_footer do %>
+<script>if (typeof mixpanel != 'undefined') { mixpanel.track("View group message"); }</script>
+<% end %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -145,8 +145,9 @@
 
 <div class="well well-sm text-center">
   <ul class="list-inline" style="margin-bottom:0;">
-    <li>Have tickets to share?</li>
     <li><%= link_to raw('<span class="glyphicon glyphicon-calendar"></span> Add Tickets'), { :controller => 'tickets', :action => 'new', :group_id => @group.id }, :class => 'btn btn-default btn-sm' %></li>
+    <li><%= link_to raw('<span class="glyphicon glyphicon-envelope"></span> Group Message'), { :controller => 'groups', :action => 'message', :id => @group.id }, :class => 'btn btn-default btn-sm' %></li>
+
   </ul>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,8 @@ SeatShare::Application.routes.draw do
   post 'groups/:id/leave' => 'groups#do_leave'
   get 'groups/:id/invite' => 'groups#invite'
   post 'groups/:id/invite' => 'groups#do_invite'
+  get 'groups/:id/message' => 'groups#message'
+  post 'groups/:id/message' => 'groups#do_message'
   get 'groups/:id/events_feed' => 'groups#events_feed'
 
   get 'groups/:group_id/event-:id' => 'events#show'

--- a/test/controllers/groups_controller_test.rb
+++ b/test/controllers/groups_controller_test.rb
@@ -148,4 +148,16 @@ class GroupsControllerTest < ActionController::TestCase
     assert_equal flash[:error], 'You do not have permission to remove other users.'
   end
 
+  test "should see group message window" do
+    @user = User.find(1)
+    @group = Group.find(1)
+
+    sign_in :user, @user
+
+    get :message, { :id => @group.id }
+
+    assert_response :success, 'got a 200 status'
+    assert_select 'title', 'Send a Group Message to Geeks Watching Hockey'
+  end
+
 end

--- a/test/mailers/group_notifier_test.rb
+++ b/test/mailers/group_notifier_test.rb
@@ -7,11 +7,28 @@ class GroupNotifierTest < ActionMailer::TestCase
     email = GroupNotifier.create_invite(invite).deliver
 
     assert_not ActionMailer::Base.deliveries.empty?
-    assert_equal ['no-reply@myseatshare.com'], email.from
-    assert_equal ['bob@example.com'], email.to
-    assert_equal 'You have been invited to join Geeks Watching Hockey', email.subject
-    assert_includes email.body.to_s, '<title>You have been invited to join Geeks Watching Hockey</title>'
-    assert_includes email.body.to_s, '<a href="http://localhost:3000/register?invite_code=ABCDEFG123">Use Invitation ABCDEFG123</a>'
-    assert_includes email.body.to_s, 'Sarah Becker has invited you to join our <strong>Nashville Predators</strong> group on <a href="http://localhost:3000/">SeatShare</a>, a service that helps manage our season tickets.'
+    assert_equal ["no-reply@myseatshare.com"], email.from
+    assert_equal ["bob@example.com"], email.to
+    assert_equal "You have been invited to join Geeks Watching Hockey", email.subject
+    assert_includes email.body.to_s, "<title>You have been invited to join Geeks Watching Hockey</title>"
+    assert_includes email.body.to_s, "<a href=\"http://localhost:3000/register?invite_code=ABCDEFG123\">Use Invitation ABCDEFG123</a>"
+    assert_includes email.body.to_s, "Sarah Becker has invited you to join our <strong>Nashville Predators</strong> group on <a href=\"http://localhost:3000/\">SeatShare</a>, a service that helps manage our season tickets."
   end
+
+  test "send group message" do
+    sending_user = User.find(1)
+    group = Group.find(1)
+    recipient_users = group.users
+
+    email = GroupNotifier.send_group_message(group, sending_user, recipient_users, 'Anyone want to go to the game on Friday?', "I'll have an extra ticket to spare.\n\nFree to a good home.").deliver
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    assert_equal ["stonej@example.net"], email.from
+    assert_equal ["stonej@example.net", "jillsmith83@us.example.org", "rick.taylor@example.net"], email.to
+    assert_equal "[Geeks Watching Hockey] Anyone want to go to the game on Friday?", email.subject
+    assert_includes email.body.to_s, "<title>[Geeks Watching Hockey] Anyone want to go to the game on Friday?</title>"
+    assert_includes email.body.to_s, "<p>I'll have an extra ticket to spare.</p>"
+    assert_includes email.body.to_s, "<p>Free to a good home.</p>"
+  end
+
 end


### PR DESCRIPTION
Fixes #46
- Was rarely used last year
- Still a good tool to have at an administrator's disposal
- Sends messages through Mandrill
- Could likely tie into push notification system in later versions
