### PR TITLE
Allow group admins to reset invitation_code

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -199,6 +199,22 @@ class GroupsController < ApplicationController
     redirect_to :action => 'show', :id => group.id and return
   end
 
+  def do_reset_invite
+    group = Group.find(params[:id]) || not_found
+
+    if !group.is_admin(current_user)
+      raise "AccessDenied"
+    end
+
+    # Invoke default behavior if invitation_code is not set
+    group.invitation_code = nil;
+    group.save!
+
+    flash[:success] = 'Invitation code reset!'
+
+    redirect_to :action => 'edit', :id => group.id and return
+  end
+
   def message
     @group = Group.find(params[:id]) || not_found
     @members = @group.users.order_by_name

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -5,7 +5,8 @@ class Group < ActiveRecord::Base
   has_many :group_users
   has_many :users, through: :group_users
 
-  validates :entity_id, :group_name, :creator_id, :invitation_code, :presence => true
+  validates :entity_id, :group_name, :creator_id, :presence => true
+  before_save :clean_invitation_code
 
   scope :order_by_name, -> { order('LOWER(group_name) ASC') }
   scope :active, -> { where('status = 1') }
@@ -78,8 +79,14 @@ class Group < ActiveRecord::Base
 
   end
 
-
   private
+
+  def clean_invitation_code
+    if self.invitation_code.blank?
+      self.invitation_code = generate_invite_code(10)
+      puts self.invitation_code
+    end
+  end
 
   def generate_invite_code(size = 10)
     charset = %w{ 2 3 4 6 7 9 A C D E F G H J K M N P Q R T V W X Y Z}

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -15,7 +15,10 @@
   <div class="form-group">
     <%= f.label :invitation_code, :class => 'col-md-3 control-label' %>
     <div class="col-md-9">
-      <p class="form-control-static"><%= @group.invitation_code %></p>
+      <p class="form-control-static">
+        <%= @group.invitation_code %><br />
+        <small><%= link_to 'Reset invitation code', { :controller => 'groups', :action => 'do_reset_invite', :id => @group.id }, :class => 'text-muted confirm', :method => 'post' %>
+      </p></small>
     </div>
   </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ SeatShare::Application.routes.draw do
   post 'groups/:id/leave' => 'groups#do_leave'
   get 'groups/:id/invite' => 'groups#invite'
   post 'groups/:id/invite' => 'groups#do_invite'
+  post 'groups/:id/reset_invite' => 'groups#do_reset_invite'
   get 'groups/:id/message' => 'groups#message'
   post 'groups/:id/message' => 'groups#do_message'
   get 'groups/:id/events_feed' => 'groups#events_feed'


### PR DESCRIPTION
I don't understand why `flash[:success]` doesn't work through a redirect. This adds the desired functionality and prevents non-admins from resetting it.

![screen shot 2014-09-03 at 8 29 26 pm](https://cloud.githubusercontent.com/assets/80459/4143852/f5c510ca-33d2-11e4-9705-cbadb0f92189.png)

Fixes #48
