### PR TITLE
Extract importer from admin model, store XML in S3

### DIFF
--- a/app/admin/event.rb
+++ b/app/admin/event.rb
@@ -1,3 +1,5 @@
+require 'soda_schedule_import'
+
 ActiveAdmin.register Event do
 
   index do
@@ -49,73 +51,19 @@ ActiveAdmin.register Event do
       # Used to flash messages describing error or success
       @messages = []
 
-      # Connect to SODA
-      soda = SodaXmlTeam::Client.new(ENV['SODA_USERNAME'], ENV['SODA_PASSWORD'])
-
-      # First, we're going to work with each entity individually
+      # Loop through team ids and run importer
       for team_id in params[:team_id]
 
-        entity = Entity.find_by_import_key(team_id) || @messages << "Team #{team_id} not found in database!"
-        league_id = team_id.split("-")[0]
-
-        listing = soda.get_listing({
-          sandbox: ENV['SODA_ENVIRONMENT'] != 'production',
-          league_id: league_id,
+        importer = SodaScheduleImport.new
+        importer.run({
           team_id: team_id,
-          type: 'schedule-single-team',
-          start_datetime: DateTime.parse(params[:start_datetime]),
-          end_datetime: DateTime.parse(params[:end_datetime])
+          start_datetime: params[:start_datetime],
+          end_datetime: params[:end_datetime],
+          force_update: params[:force_update]
         })
 
-        # See if there were any documents at all
-        if listing.css('item link').length === 0
-          @messages << "No events were available for #{entity.entity_name}."
-          next
-        end
-
-        # Grab the latest URI available
-        latest = URI.parse(listing.css('item link').first)
-        document_id = CGI.parse(latest.query)['doc-ids'].first
-
-        # Check to see if you already have this document ID
-        if File.exists? File.join(Rails.root, 'tmp', 'soda', document_id)
-          if params[:force_update] != "1"
-            @messages << "Already downloaded schedule for #{entity.entity_name} as #{document_id}."
-            next
-          end
-        end
-
-        # Retrieve the document (this counts as using an API credit)
-        schedule_document = soda.get_document({
-          sandbox: ENV['SODA_ENVIRONMENT'] != 'production',
-          document_id: document_id
-        })
-
-        # Cache the document to prevent re-downloads
-        File.open File.join(Rails.root, 'tmp', 'soda', document_id), 'w' do |f|
-          f.write schedule_document.to_s
-        end
-
-        # Parse the schedule and create the events
-        schedule = SodaXmlTeam::Schedule.parse_schedule(schedule_document)
-        for row in schedule
-
-          # Map in entity_id for import
-          row[:entity_id] = entity.id
-
-          # Skip the away games
-          if row[:home_team_id] != team_id
-            next
-          end
-
-          # Create or update the row
-          event = Event.import row
-
-          @events_list << event
-        end
-
-        # Done with that team
-        @messages << "#{entity.entity_name} schedule imported!"
+        @events_list += importer.events_list
+        @messages += importer.messages
 
       end
 

--- a/lib/soda_schedule_import.rb
+++ b/lib/soda_schedule_import.rb
@@ -1,0 +1,82 @@
+class SodaScheduleImport
+
+  attr_accessor :soda_client, :messages, :events_list
+
+  def initialize
+    self.soda_client = SodaXmlTeam::Client.new(ENV['SODA_USERNAME'], ENV['SODA_PASSWORD'])
+    self.messages = []
+    self.events_list = []
+  end
+
+  def run(options={})
+    entity = Entity.find_by_import_key(options[:team_id])
+    if entity.blank?
+      self.messages << "Could not find an entity that matched #{options[:team_id]}"
+      return
+    end
+
+    # Get listing for desired league
+    listing = self.soda_client.get_listing({
+      sandbox: ENV['SODA_ENVIRONMENT'] != 'production',
+      league_id: options[:team_id].split("-")[0],
+      team_id: options[:team_id],
+      type: 'schedule-single-team',
+      start_datetime: DateTime.parse(options[:start_datetime]),
+      end_datetime: DateTime.parse(options[:end_datetime])
+    })
+
+    # See if there were any documents at all
+    if listing.css('item link').length === 0
+      self.messages << "No events were available for #{entity.entity_name}."
+      return
+    end
+
+    # Grab the latest URI available
+    latest = URI.parse(listing.css('item link').first)
+    document_id = CGI.parse(latest.query)['doc-ids'].first
+
+    # Check to see if you already have this document ID in S3
+    if AWS::S3::S3Object.exists? "soda/#{document_id}", ENV['SEATSHARE_S3_BUCKET']
+      if !options[:force_update]
+        self.messages << "The latest schedule for #{entity.entity_name} (#{document_id}) has already been processed."
+        return
+      end
+    end
+
+    # Retrieve the document (this counts as using an API credit)
+    schedule_document = self.soda_client.get_document({
+      sandbox: ENV['SODA_ENVIRONMENT'] != 'production',
+      document_id: document_id
+    })
+
+    # Cache the document to prevent re-downloads
+    File.open File.join(Rails.root, 'tmp', 'soda', document_id), 'w' do |file|
+      file.write schedule_document.to_s
+    end
+
+    # Store this file in S3
+    File.open File.join(Rails.root, 'tmp', 'soda', document_id), 'rb' do |file|
+      AWS::S3::S3Object.store "soda/#{document_id}", open(file), ENV['SEATSHARE_S3_BUCKET']
+    end
+
+    # Parse the schedule and create the events
+    schedule = SodaXmlTeam::Schedule.parse_schedule(schedule_document)
+    for row in schedule
+
+      # Map in entity_id for import
+      row[:entity_id] = entity.id
+
+      # Skip the away games
+      if row[:home_team_id] != options[:team_id]
+        next
+      end
+
+      # Create or update the row
+      self.events_list << Event.import(row)
+    end
+
+    # Done with that team
+    self.messages << "#{entity.entity_name} schedule imported!"
+  end
+
+end


### PR DESCRIPTION
Fixes #56

This was a lousy design to begin with, but it served its purpose. This PR creates a single-purpose class that handles the interactions with the SODA XML Team for schedule importing. It also fixes the referenced bug by using S3 as the file store instead of the local `tmp` directory (which now only serves as a holding location prior to being uploaded to S3). There are no admin user-facing changes.
