### PR TITLE
Add workflow for fast group creation after sign-up

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -12,6 +12,7 @@ class GroupsController < ApplicationController
   end
 
   def new
+    @entity = Entity.find_by_id(params[:entity_id])
     @page_title = "Create a Group"
     @entities = Entity.order_by_name.active.inject({}) do |options, entity|
       (options[entity.entity_type] ||= []) << [entity.entity_name, entity.id]

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,5 +1,16 @@
 class RegistrationsController < Devise::RegistrationsController
   def new
+    if (params[:invite_code])
+      @invite = GroupInvitation.find_by_invitation_code(params[:invite_code])
+    else
+      @invite = nil
+    end
+    if (params[:entity_id])
+      @entity = Entity.find_by_id(params[:entity_id])
+    else
+      @entity = nil
+    end
+
     @page_title = "Create Your SeatShare Account"
     @meta_description = %q{Register for an account with SeatShare to start managing your season tickets.}
     super
@@ -38,6 +49,8 @@ class RegistrationsController < Devise::RegistrationsController
         sign_up(resource_name, resource)
         if params[:user][:invite_code]
           respond_with resource, location: groups_join_path + "?invite_code=" + params[:user][:invite_code]
+        elsif params[:user][:entity_id]
+          respond_with resource, location: groups_new_path + "?entity_id=" + params[:user][:entity_id]
         else
           respond_with resource, location: after_sign_up_path_for(resource)
         end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -61,8 +61,10 @@
 
   <div class="row">
     <div class="col-md-12">
-        <% if params[:invite_code] %>
-        <%= f.hidden_field :invite_code, :value => params[:invite_code] %>
+        <% if @invite %>
+        <%= f.hidden_field :invite_code, :value => @invite.invitation_code %>
+        <% elsif @entity %>
+        <%= f.hidden_field :entity_id, :value => @entity.id %>
         <% end %>
         <p class="text-right">
           <%= hidden_field_tag 'ga_client_id', '', :class => 'ga-client-id' %>
@@ -77,12 +79,17 @@
 
 <% content_for :sidebar do %>
 
-<% if params[:invite_code] %>
+<% if @invite %>
 <div class="alert alert-success">
   <h4>You've been invited join a group!</h4>
-  <p>You are registering with an invitation code, so you will be ready to go here in just a bit!</p>
+  <p><%= @invite.user.display_name %> invited you to join <%= @invite.group.group_name %>, so you will be ready to go here in just a bit!</p>
   <br />
-  <p class="text-lg">Invitation code: <strong class="invite_code"><%= params[:invite_code] %></strong></p>
+  <p class="text-lg">Invitation code: <strong class="invite_code"><%= @invite.invitation_code %></strong></p>
+</div>
+<% elsif @entity %>
+<div class="alert alert-success">
+  <h4>Create a <%= @entity.entity_name %> group!</h4>
+  <p>After sign up, you will be ready to invite people to your new season ticket group!</p>
 </div>
 <% else %>
 <div class="alert alert-info">

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -14,8 +14,13 @@
   <div class="form-group">
     <%= f.label :entity_id, :class => 'col-md-3 control-label'  %>
     <div class="col-md-9">
+      <% if @entity %>
+      <p class="form-control-static"><%= @entity.display_name %></p>
+      <%= f.hidden_field :entity_id, :value => @entity.id %>
+      <% else %>
       <%= select_tag 'group[entity_id]', grouped_options_for_select(@entities), { :class => 'form-control' } %>
       <p class="help-block"><strong>Choose carefully!</strong> You cannot change your team / venue after the group is created.</p>
+      <% end %>
     </div>
   </div>
 

--- a/app/views/public/teams.html.erb
+++ b/app/views/public/teams.html.erb
@@ -11,7 +11,7 @@
     <div class="row">
       <% for team in @teams_nfl %>
       <div class="col-md-4">
-        <div class="well well-sm"><%= team.entity_name %></div>
+        <div class="well well-sm"><%= link_to team.entity_name, new_user_registration_path(nil, :entity_id => team.id) %></div>
       </div>
       <% end %>
     </div>
@@ -25,7 +25,7 @@
     <div class="row">
       <% for team in @teams_mlb %>
       <div class="col-md-4">
-        <div class="well well-sm"><%= team.entity_name %></div>
+        <div class="well well-sm"><%= link_to team.entity_name, new_user_registration_path(nil, :entity_id => team.id) %></div>
       </div>
       <% end %>
     </div>
@@ -39,7 +39,7 @@
     <div class="row">
       <% for team in @teams_nba %>
       <div class="col-md-4">
-        <div class="well well-sm"><%= team.entity_name %></div>
+        <div class="well well-sm"><%= link_to team.entity_name, new_user_registration_path(nil, :entity_id => team.id) %></div>
       </div>
       <% end %>
     </div>
@@ -53,7 +53,7 @@
     <div class="row">
       <% for team in @teams_nhl %>
       <div class="col-md-4">
-        <div class="well well-sm"><%= team.entity_name %></div>
+        <div class="well well-sm"><%= link_to team.entity_name, new_user_registration_path(nil, :entity_id => team.id) %></div>
       </div>
       <% end %>
     </div>
@@ -67,7 +67,7 @@
     <div class="row">
       <% for team in @teams_ncaaf %>
       <div class="col-md-6">
-        <div class="well well-sm"><%= team.entity_name %></div>
+        <div class="well well-sm"><%= link_to team.entity_name, new_user_registration_path(nil, :entity_id => team.id) %></div>
       </div>
       <% end %>
     </div>
@@ -81,7 +81,7 @@
     <div class="row">
       <% for team in @teams_ncaamb %>
       <div class="col-md-6">
-        <div class="well well-sm"><%= team.entity_name %></div>
+        <div class="well well-sm"><%= link_to team.entity_name, new_user_registration_path(nil, :entity_id => team.id) %></div>
       </div>
       <% end %>
     </div>
@@ -95,7 +95,7 @@
     <div class="row">
       <% for team in @teams_cfl %>
       <div class="col-md-6">
-        <div class="well well-sm"><%= team.entity_name %></div>
+        <div class="well well-sm"><%= link_to team.entity_name, new_user_registration_path(nil, :entity_id => team.id) %></div>
       </div>
       <% end %>
     </div>
@@ -109,7 +109,7 @@
     <div class="row">
       <% for team in @teams_mls %>
       <div class="col-md-6">
-        <div class="well well-sm"><%= team.entity_name %></div>
+        <div class="well well-sm"><%= link_to team.entity_name, new_user_registration_path(nil, :entity_id => team.id) %></div>
       </div>
       <% end %>
     </div>
@@ -123,7 +123,7 @@
     <div class="row">
       <% for team in @teams_wftda %>
       <div class="col-md-6">
-        <div class="well well-sm"><%= team.entity_name %></div>
+        <div class="well well-sm"><%= link_to team.entity_name, new_user_registration_path(nil, :entity_id => team.id) %></div>
       </div>
       <% end %>
     </div>

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -15,12 +15,22 @@ class RegistrationsControllerTest < ActionController::TestCase
   test "get register route with invitation code" do
     @request.env["devise.mapping"] = Devise.mappings[:user]
 
-    get :new, :invite_code => 'ABCDEFG'
+    get :new, :invite_code => 'ABCDEFG123'
 
     assert_response :success
     assert_select "title", "Create Your SeatShare Account"
     assert_select "h4", "You've been invited join a group!", 'invitation code block appears'
-    assert_select "strong.invite_code", "ABCDEFG", 'invitation code appears'
+    assert_select "strong.invite_code", "ABCDEFG123", 'invitation code appears'
+  end
+
+  test "get register route with team id" do
+    @request.env["devise.mapping"] = Devise.mappings[:user]
+
+    get :new, :entity_id => '1'
+
+    assert_response :success
+    assert_select "title", "Create Your SeatShare Account"
+    assert_select "h4", "Create a Nashville Predators group!"
   end
 
 end

--- a/test/integration/user_signup_test.rb
+++ b/test/integration/user_signup_test.rb
@@ -14,7 +14,7 @@ class UserSignupTest < ActionDispatch::IntegrationTest
     assert_equal '/groups', path
   end
 
-  test "signup for an account - existing email" do
+  test "signup for an account with an existing email" do
     get "/register"
     assert_response :success
 
@@ -23,6 +23,30 @@ class UserSignupTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_equal 'There were errors with your registration.', flash[:alert]
     assert_equal '/', path
+  end
+
+  test "signup for an account with an invite code" do
+    get "/register"
+    assert_response :success
+
+    post_via_redirect "/", {:user => { :first_name => 'New', :last_name => 'User', :email => 'newuser@example.com', :password => 'testing123', :password_confirm => 'testing123', :invite_code => 'ABCDEFG123' }}
+
+    assert_response :success
+    assert_equal nil, flash[:alert]
+    assert_equal 'Welcome! You have signed up successfully.', flash[:notice]
+    assert_equal '/groups/join', path
+  end
+
+  test "signup for an account with an team ID" do
+    get "/register"
+    assert_response :success
+
+    post_via_redirect "/", {:user => { :first_name => 'New', :last_name => 'User', :email => 'newuser@example.com', :password => 'testing123', :password_confirm => 'testing123', :entity_id => 1 }}
+
+    assert_response :success
+    assert_equal nil, flash[:alert]
+    assert_equal 'Welcome! You have signed up successfully.', flash[:notice]
+    assert_equal '/groups/new', path
   end
 
 end


### PR DESCRIPTION
Fixes #63

When the Team page is redesigned, a user that selects a particular team will be routed to a workflow that makes it faster to create a new group.

![screenshot](http://cl.ly/image/1q3f0R2Z070L/Screen%20Shot%202014-09-18%20at%205.17.00%20PM.png)
