### PR TITLE
Rewrite Team URLs to be more SEO friendly

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,7 +21,7 @@ class ApplicationController < ActionController::Base
 
   def configure_devise_permitted_parameters
 
-    registration_params = [:first_name, :last_name, :email, :password, :password_confirmation, :newsletter_signup, :invite_code]
+    registration_params = [:first_name, :last_name, :email, :password, :password_confirmation, :newsletter_signup, :invite_code, :entity_id]
 
     if params[:action] == 'update'
       devise_parameter_sanitizer.for(:account_update) { 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,7 @@ class User < ActiveRecord::Base
   scope :order_by_name, -> { order('LOWER(last_name) ASC, LOWER(first_name) ASC') }
   scope :active, -> { where('status = 1') }
 
+  attr_accessor :entity_id
   attr_accessor :newsletter_signup
   attr_accessor :invite_code
 

--- a/app/views/public/teams.html.erb
+++ b/app/views/public/teams.html.erb
@@ -1,5 +1,5 @@
 <div class="jumbotron">
-  <h2>Take home field advantage</h2>
+  <h1>Take home field advantage</h1>
   <p>With more than 2,200 pro and college team schedules available, SeatShare has your seats covered.</p>
   <%= link_to "Create Your SeatShare Account", new_user_registration_path, :class=>'btn btn-primary btn-lg' %>
 </div>
@@ -11,7 +11,7 @@
     <div class="row">
       <% for team in @teams_nfl %>
       <div class="col-md-4">
-        <div class="well well-sm"><%= link_to team.entity_name, new_user_registration_path(nil, :entity_id => team.id) %></div>
+        <div class="well well-sm"><%= link_to team.entity_name, register_with_entity_id_path(nil, { :entity_slug => team.display_name.parameterize, :entity_id => team.id}) %></div>
       </div>
       <% end %>
     </div>
@@ -25,7 +25,7 @@
     <div class="row">
       <% for team in @teams_mlb %>
       <div class="col-md-4">
-        <div class="well well-sm"><%= link_to team.entity_name, new_user_registration_path(nil, :entity_id => team.id) %></div>
+        <div class="well well-sm"><%= link_to team.entity_name, register_with_entity_id_path(nil, { :entity_slug => team.display_name.parameterize, :entity_id => team.id}) %></div>
       </div>
       <% end %>
     </div>
@@ -39,7 +39,7 @@
     <div class="row">
       <% for team in @teams_nba %>
       <div class="col-md-4">
-        <div class="well well-sm"><%= link_to team.entity_name, new_user_registration_path(nil, :entity_id => team.id) %></div>
+        <div class="well well-sm"><%= link_to team.entity_name, register_with_entity_id_path(nil, { :entity_slug => team.display_name.parameterize, :entity_id => team.id}) %></div>
       </div>
       <% end %>
     </div>
@@ -53,7 +53,7 @@
     <div class="row">
       <% for team in @teams_nhl %>
       <div class="col-md-4">
-        <div class="well well-sm"><%= link_to team.entity_name, new_user_registration_path(nil, :entity_id => team.id) %></div>
+        <div class="well well-sm"><%= link_to team.entity_name, register_with_entity_id_path(nil, { :entity_slug => team.display_name.parameterize, :entity_id => team.id}) %></div>
       </div>
       <% end %>
     </div>
@@ -67,7 +67,7 @@
     <div class="row">
       <% for team in @teams_ncaaf %>
       <div class="col-md-6">
-        <div class="well well-sm"><%= link_to team.entity_name, new_user_registration_path(nil, :entity_id => team.id) %></div>
+        <div class="well well-sm"><%= link_to team.entity_name, register_with_entity_id_path(nil, { :entity_slug => team.display_name.parameterize, :entity_id => team.id}) %></div>
       </div>
       <% end %>
     </div>
@@ -81,7 +81,7 @@
     <div class="row">
       <% for team in @teams_ncaamb %>
       <div class="col-md-6">
-        <div class="well well-sm"><%= link_to team.entity_name, new_user_registration_path(nil, :entity_id => team.id) %></div>
+        <div class="well well-sm"><%= link_to team.entity_name, register_with_entity_id_path(nil, { :entity_slug => team.display_name.parameterize, :entity_id => team.id}) %></div>
       </div>
       <% end %>
     </div>
@@ -95,7 +95,7 @@
     <div class="row">
       <% for team in @teams_cfl %>
       <div class="col-md-6">
-        <div class="well well-sm"><%= link_to team.entity_name, new_user_registration_path(nil, :entity_id => team.id) %></div>
+        <div class="well well-sm"><%= link_to team.entity_name, register_with_entity_id_path(nil, { :entity_slug => team.display_name.parameterize, :entity_id => team.id}) %></div>
       </div>
       <% end %>
     </div>
@@ -109,7 +109,7 @@
     <div class="row">
       <% for team in @teams_mls %>
       <div class="col-md-6">
-        <div class="well well-sm"><%= link_to team.entity_name, new_user_registration_path(nil, :entity_id => team.id) %></div>
+        <div class="well well-sm"><%= link_to team.entity_name, register_with_entity_id_path(nil, { :entity_slug => team.display_name.parameterize, :entity_id => team.id}) %></div>
       </div>
       <% end %>
     </div>
@@ -123,7 +123,7 @@
     <div class="row">
       <% for team in @teams_wftda %>
       <div class="col-md-6">
-        <div class="well well-sm"><%= link_to team.entity_name, new_user_registration_path(nil, :entity_id => team.id) %></div>
+        <div class="well well-sm"><%= link_to team.entity_name, register_with_entity_id_path(nil, { :entity_slug => team.display_name.parameterize, :entity_id => team.id}) %></div>
       </div>
       <% end %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,10 @@ SeatShare::Application.routes.draw do
   get 'privacy' => 'public#privacy'
   get 'contact' => 'public#contact'
 
+  devise_scope :user do
+    get "register/:entity_slug/:entity_id", to: "registrations#new", as: 'register_with_entity_id'
+  end
+
   get 'groups' => 'groups#index'
   get 'groups/new' => 'groups#new'
   post 'groups/new' => 'groups#create'

--- a/test/controllers/public_controller_test.rb
+++ b/test/controllers/public_controller_test.rb
@@ -47,4 +47,12 @@ class PublicControllerTest < ActionController::TestCase
     assert_select 'h1', 'Have questions or comments?', 'page heading matches'
   end
 
+
+  test "gets teams page" do
+    get :teams
+    assert_response :success, 'loaded page with a 200'
+    assert_select 'title', 'Manage Season Tickets for Your Favorite Team - SeatShare', 'title matches expected'
+    assert_select 'h1', 'Take home field advantage', 'page heading matches'
+  end
+
 end


### PR DESCRIPTION
Fixes #66

Made it so that the team-based registrations can use a better URL format (e.g. `/register/bowdoin-polar-bears-ncaaf/2497` instad of `/register?entity_id=2497`).
