### PR TITLE
Refactor the schema.org email data

### DIFF
--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -6,6 +6,13 @@ class CustomDeviseMailer < Devise::Mailer
   include Devise::Controllers::UrlHelpers # Optional. eg. `confirmation_url`
 
   def confirmation_instructions(record, token, opts={})
+
+    @view_action = {
+      url: url_for(confirmation_url(record, confirmation_token: @token)),
+      action: 'Confirm Account',
+      description: 'Click to confirm your account.'
+    }
+
     headers['X-MC-Tags'] = 'ConfirmationInstructions'
     headers['X-MC-Subaccount'] = 'SeatShare'
     headers['X-MC-SigningDomain'] = 'myseatshare.com'
@@ -13,6 +20,13 @@ class CustomDeviseMailer < Devise::Mailer
   end
 
   def reset_password_instructions(record, token, opts={})
+
+    @view_action = {
+      url: url_for(edit_password_url(record, reset_password_token: @token)),
+      action: 'Reset Password',
+      description: 'Click to select a new password.'
+    }
+
     headers['X-MC-Tags'] = 'ResetPasswordInstructions'
     headers['X-MC-Subaccount'] = 'SeatShare'
     headers['X-MC-SigningDomain'] = 'myseatshare.com'
@@ -20,6 +34,13 @@ class CustomDeviseMailer < Devise::Mailer
   end
 
   def unlock_instructions(record, token, opts={})
+
+    @view_action = {
+      url: url_for(unlock_url(record, unlock_token: @token)),
+      action: 'Unlock Account',
+      description: 'Click to unlock your account.'
+    }
+
     headers['X-MC-Tags'] = 'UnlockInstructions'
     headers['X-MC-Subaccount'] = 'SeatShare'
     headers['X-MC-SigningDomain'] = 'myseatshare.com'

--- a/app/mailers/group_notifier.rb
+++ b/app/mailers/group_notifier.rb
@@ -8,6 +8,11 @@ class GroupNotifier < ActionMailer::Base
     @user = invite.user
     @group = invite.group
     @personalized = message
+    @view_action = {
+      url: url_for(:controller => 'registrations', :action => 'new', :invite_code => @invite.invitation_code, :only_path => false),
+      action: 'Accept Invitation',
+      description: 'You have received an invitation.'
+    }
 
     mail(
       to: @recipient,
@@ -37,6 +42,12 @@ class GroupNotifier < ActionMailer::Base
     @recipients = recipients
     @subject = subject
     @message = message
+
+    @view_action = {
+      url: url_for(:controller => 'groups', :id => @group.id, :only_path => false),
+      action: 'View Group',
+      description: 'You have received a message.'
+    }
 
     @email_recipients = []
     for recipient in recipients

--- a/app/mailers/schedule_notifier.rb
+++ b/app/mailers/schedule_notifier.rb
@@ -10,6 +10,12 @@ class ScheduleNotifier < ActionMailer::Base
     @group = group
     @user = user
 
+    @view_action = {
+      url: url_for(:controller => 'groups', :action => 'show', :id => @group.id, :only_path => false),
+      action: 'View Tickets',
+      description: 'See available tickets.'
+    }
+
     mail(
       to: "#{user.display_name} <#{@user.email}>",
       subject: "Today's events for #{@group.group_name}"
@@ -35,6 +41,12 @@ class ScheduleNotifier < ActionMailer::Base
     @events_day_of_week = events_day_of_week
     @group = group
     @user = user
+
+    @view_action = {
+      url: url_for(:controller => 'groups', :action => 'show', :id => @group.id, :only_path => false),
+      action: 'View Tickets',
+      description: 'See available tickets.'
+    }
 
     mail(
       to: "#{user.display_name} <#{@user.email}>",

--- a/app/mailers/ticket_notifier.rb
+++ b/app/mailers/ticket_notifier.rb
@@ -9,6 +9,12 @@ class TicketNotifier < ActionMailer::Base
     @group = ticket.group
     @user = acting_user
 
+    @view_action = {
+      url: url_for(:controller => 'tickets', :action => 'edit', :group_id => @ticket.group_id, :event_id => @ticket.event_id, :id => @ticket.id, :only_path => false),
+      action: 'View Ticket',
+      description: 'You have been assigned a ticket.'
+    }
+
     mail(
       to: "#{@recipient.display_name} <#{@recipient.email}>",
       subject: "#{@user.first_name} has assigned you a ticket via #{@group.group_name}"
@@ -26,6 +32,12 @@ class TicketNotifier < ActionMailer::Base
     @group = ticket.group
     @user = user
     @message = message
+
+    @view_action = {
+      url: url_for(:controller => 'tickets', :action => 'edit', :group_id => @ticket.group_id, :event_id => @ticket.event_id, :id => @ticket.id, :only_path => false),
+      action: 'Assign Ticket',
+      description: 'Your ticket has been requested.'
+    }
 
     mail(
       to: "#{@recipient.display_name} <#{@recipient.email}>",

--- a/app/views/custom_devise_mailer/reset_password_instructions.html.erb
+++ b/app/views/custom_devise_mailer/reset_password_instructions.html.erb
@@ -1,19 +1,3 @@
-<script type="application/ld+json">
-{
-  "@context": "http://schema.org",
-  "@type": "EmailMessage",
-  "action": {
-    "@type": "ConfirmAction",
-    "name": "Reset Password",
-    "handler": {
-      "@type": "HttpActionHandler",
-      "url": "<%= url_for edit_password_url(@resource, reset_password_token: @token) %>"
-    }
-  },
-  "description": "Reset your SeatShare password."
-}
-</script>
-
 <p>Hello <%= @resource.email %>!</p>
 
 <p>Someone has requested a link to change your password. You can do this through the link below.</p>

--- a/app/views/group_notifier/create_invite.html.erb
+++ b/app/views/group_notifier/create_invite.html.erb
@@ -1,19 +1,3 @@
-<script type="application/ld+json">
-{
-  "@context": "http://schema.org",
-  "@type": "EmailMessage",
-  "action": {
-    "@type": "ConfirmAction",
-    "name": "View Invitation",
-    "handler": {
-      "@type": "HttpActionHandler",
-      "url": "<%= url_for :controller => 'registrations', :action => 'new', :invite_code => @invite.invitation_code, :only_path => false %>"
-    }
-  },
-  "description": "<%= @user_display_name %> has invited you to join a group."
-}
-</script>
-
 <% if !@personalized.blank? %>
 <p><%= @personalized %></p>
 

--- a/app/views/layouts/email.html.erb
+++ b/app/views/layouts/email.html.erb
@@ -157,9 +157,9 @@
         font-weight:normal;
         text-decoration:underline;
       }
-            @media only screen and (max-width: 480px){
+      @media only screen and (max-width: 480px){
         body, table, td, p, a, li, blockquote{-webkit-text-size-adjust:none !important;} /* Prevent Webkit platforms from changing default text sizes */
-                body{width:100% !important; min-width:100% !important;} /* Prevent iOS Mail from adding padding to the body */
+        body{width:100% !important; min-width:100% !important;} /* Prevent iOS Mail from adding padding to the body */
         #bodyCell{padding:10px !important;}
         #templateContainer{
           max-width:600px !important;
@@ -202,8 +202,22 @@
         .footerContent a{display:block !important;} /* Place footer social and utility links on their own lines, for easier access */
       }
     </style>
+
   </head>
   <body leftmargin="0" marginwidth="0" topmargin="0" marginheight="0" offset="0">
+    <% if !@view_action.blank? %>
+    <div itemscope itemtype="http://schema.org/EmailMessage">
+      <meta itemprop="description" content="<%= @view_action[:description] %>"/>
+      <div itemprop="action" itemscope itemtype="http://schema.org/ViewAction">
+        <link itemprop="url" href="<%= @view_action[:url] %>"/>
+        <meta itemprop="name" content="<%= @view_action[:action] %>"/>
+      </div>
+      <div itemprop="publisher" itemscope itemtype="http://schema.org/Organization">
+        <meta itemprop="name" content="SeatShare"/>
+        <link itemprop="url" href="https://myseatshare.com"/>
+      </div>
+    </div>
+    <% end %>
     <center>
       <table align="center" border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" id="bodyTable">
         <tr>

--- a/app/views/schedule_notifier/daily_schedule.html.erb
+++ b/app/views/schedule_notifier/daily_schedule.html.erb
@@ -1,19 +1,3 @@
-<script type="application/ld+json">
-{
-  "@context": "http://schema.org",
-  "@type": "EmailMessage",
-  "action": {
-    "@type": "ConfirmAction",
-    "name": "View Tickets",
-    "handler": {
-      "@type": "HttpActionHandler",
-      "url": "<%= url_for :controller => 'groups', :action => 'show', :id => @group.id, :only_path => false %>"
-    }
-  },
-  "description": "<%= @group.group_name %> has upcoming events."
-}
-</script>
-
 <p><%= @user.first_name; %>,</p>
 
 <p>This is your daily summary for <%= link_to @group.group_name, :controller => 'groups', :action => 'show', :id => @group.id, :only_path => false %>. We send these every morning if there are events that day. You can update your reminder settings on <%= link_to 'the group page', { :controller => 'groups', :action => 'edit', :id => @group.id, :only_path => false } %>.</p>
@@ -21,51 +5,53 @@
 <% for event in @events %>
 <hr />
 <table cellpadding="10px">
-	<tr>
-		<th style="width:100px">Event</th>
-		<td><%= link_to event.event_name, { :controller => 'events', :action => 'show', :group_id => @group.id, :id => event.id, :only_path => false } %></td>
-	</tr>
-	<tr>
-		<th>Starts</th>
-		<td><%= event.date_time %></td>
-	</tr>
-	<% if !event.description.blank? %>
-	<tr>
-		<th>Description</th>
-		<td><%= event.description %></td>
-	</tr>
-	<% end %>
+  <tr>
+    <th style="width:100px">Event</th>
+    <td><%= link_to event.event_name, { :controller => 'events', :action => 'show', :group_id => @group.id, :id => event.id, :only_path => false } %></td>
+  </tr>
+  <tr>
+    <th>Starts</th>
+    <td><%= event.date_time %></td>
+  </tr>
+  <% if !event.description.blank? %>
+  <tr>
+    <th>Description</th>
+    <td><%= event.description %></td>
+  </tr>
+  <% end %>
 
-	<% tickets = event.tickets(@group) %>
-	<% ticket_stats = event.ticket_stats(@group, @user) %>
+  <% tickets = event.tickets(@group) %>
+  <% ticket_stats = event.ticket_stats(@group, @user) %>
 
-	<tr>
-		<th>Tickets</th>
-		<td>
-			<ul>
-				<li><span style="font-weight:bold;"><%= ticket_stats[:available] %></span> available in the group</li>
-				<li><span style="font-weight:bold;"><%= ticket_stats[:total] %></span> total in the group</li>
-				<li><span style="font-weight:bold;"><%= ticket_stats[:held] %></span> held by you</li>
-			</ul>
-			<table width="100%" cellpadding="10px">
-				<tbody>
-					<% for ticket in tickets %>
-					<% next if ticket.is_assigned? %>
-					<tr>
-						<td><%= link_to ticket.display_name, { :controller => 'tickets', :action => 'edit', :group_id => @group.id, :event_id => ticket.event_id, :id => ticket.id, :only_path => false } %></td>
-						<td>via <%= ticket.owner.display_name; %></td>
-						<td>
-							<%= link_to number_to_currency(ticket.cost), { :controller => 'tickets', :action => 'edit', :group_id => @group.id, :event_id => ticket.event_id, :id => ticket.id, :only_path => false } %>
-						</td>
-					</tr>
-					<% end %>
-				</tbody>
-			</table>
-		</td>
-	</tr>
+  <tr>
+    <th>Tickets</th>
+    <td>
+      <ul>
+        <li><span style="font-weight:bold;"><%= ticket_stats[:available] %></span> available in the group</li>
+        <li><span style="font-weight:bold;"><%= ticket_stats[:total] %></span> total in the group</li>
+        <li><span style="font-weight:bold;"><%= ticket_stats[:held] %></span> held by you</li>
+      </ul>
+      <table width="100%" cellpadding="10px">
+        <tbody>
+          <% for ticket in tickets %>
+          <% next if ticket.is_assigned? %>
+          <tr>
+            <td>
+              <%= link_to ticket.display_name, { :controller => 'tickets', :action => 'edit', :group_id => @group.id, :event_id => ticket.event_id, :id => ticket.id, :only_path => false } %>
+            </td>
+            <td>via <%= ticket.owner.display_name; %></td>
+            <td>
+              <%= link_to number_to_currency(ticket.cost), { :controller => 'tickets', :action => 'edit', :group_id => @group.id, :event_id => ticket.event_id, :id => ticket.id, :only_path => false } %>
+            </td>
+          </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </td>
+  </tr>
 </table>
 <% end %>
 
 <% content_for :footer do %>
-	<%= link_to 'Manage My Reminders', { :controller => 'groups', :action => 'edit', :id => @group.id, :only_path => false } %>
+  <%= link_to 'Manage My Reminders', { :controller => 'groups', :action => 'edit', :id => @group.id, :only_path => false } %>
 <% end %>

--- a/app/views/schedule_notifier/weekly_schedule.html.erb
+++ b/app/views/schedule_notifier/weekly_schedule.html.erb
@@ -1,19 +1,3 @@
-<script type="application/ld+json">
-{
-  "@context": "http://schema.org",
-  "@type": "EmailMessage",
-  "action": {
-    "@type": "ConfirmAction",
-    "name": "View Tickets",
-    "handler": {
-      "@type": "HttpActionHandler",
-      "url": "<%= url_for :controller => 'groups', :action => 'show', :id => @group.id, :only_path => false %>"
-    }
-  },
-  "description": "<%= @group.group_name %> has upcoming events."
-}
-</script>
-
 <p><%= @user.first_name; %>,</p>
 
 <p>This is your week ahead for <%= link_to @group.group_name, :controller => 'groups', :action => 'show', :id => @group.id, :only_path => false %>. We send these every every Monday morning if there are events that week. You can update your reminder settings on <%= link_to 'the group page', :controller => 'groups', :action => 'edit', :id => @group.id, :only_path => false %>.</p>

--- a/app/views/ticket_notifier/assign.html.erb
+++ b/app/views/ticket_notifier/assign.html.erb
@@ -1,19 +1,3 @@
-<script type="application/ld+json">
-{
-  "@context": "http://schema.org",
-  "@type": "EmailMessage",
-  "action": {
-    "@type": "ConfirmAction",
-    "name": "View Ticket",
-    "handler": {
-      "@type": "HttpActionHandler",
-      "url": "<%= url_for :controller => 'tickets', :action => 'edit', :group_id => @ticket.group_id, :event_id => @ticket.event_id, :id => @ticket.id, :only_path => false %>"
-    }
-  },
-  "description": "<%= @user_display_name %> has assigned you a ticket."
-}
-</script>
-
 <p><%= @recipient.first_name %>,</p>
 
 <p><%= @user.display_name %> (<%= mail_to @user.email, @user.email %>) has assigned a ticket to you for the following event in your group <%= @group.group_name %>.</p>

--- a/app/views/ticket_notifier/request_ticket.html.erb
+++ b/app/views/ticket_notifier/request_ticket.html.erb
@@ -1,19 +1,3 @@
-<script type="application/ld+json">
-{
-  "@context": "http://schema.org",
-  "@type": "EmailMessage",
-  "action": {
-    "@type": "ConfirmAction",
-    "name": "Assign Ticket",
-    "handler": {
-      "@type": "HttpActionHandler",
-      "url": "<%= url_for :controller => 'tickets', :action => 'edit', :group_id => @ticket.group_id, :event_id => @ticket.event_id, :id => @ticket.id, :only_path => false %>"
-    }
-  },
-  "description": "<%= @user_display_name %> has requested a ticket."
-}
-</script>
-
 <% if @message != '' %>
 <%= simple_format sanitize(@message) %>
 <hr />

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -6,7 +6,7 @@ class EventTest < ActiveSupport::TestCase
       event_name: 'A New Event',
       description: 'This describes the event',
       entity_id: 1,
-      start_time: '2013-01-01 18:00:00'
+      start_time: '2013-01-01 18:00:00 CST'
     })
     event.save!
 


### PR DESCRIPTION
Well, it looks like Gmail Actions aren't going to work as expected. You have to apply to be accepted into the program and meet a sending volume specificly to Gmail. At any rate, I refactored it a bit so that that the email template picks up variables rather than having it specfied directly in the templates. Also switched away from the JSON data source and used standard markup. I'll fill out the form anyway (and send a sample invitation) just to see what happens.

Also, http://schema.org/Ticket may come in handy some day if a "List this ticket for sale publicly" feature comes around.
