### PR TITLE
Update reply_to, from on mailers

### DIFF
--- a/app/mailers/group_notifier.rb
+++ b/app/mailers/group_notifier.rb
@@ -16,7 +16,8 @@ class GroupNotifier < ActionMailer::Base
 
     mail(
       to: @recipient,
-      subject: "You have been invited to join #{@group.group_name}"
+      subject: "You have been invited to join #{@group.group_name}",
+      reply_to: "#{@user.display_name} <#{@user.email}>"
     )
 
     headers['X-MC-Tags'] = 'InviteUser'
@@ -55,9 +56,9 @@ class GroupNotifier < ActionMailer::Base
     end
 
     mail(
-      from: "#{sender.display_name} <#{sender.email}>",
       to: @email_recipients.join(', '),
-      subject: subject
+      subject: subject,
+      reply_to: "#{sender.display_name} <#{sender.email}>"
     )
 
     headers['X-MC-Tags'] = 'GroupMessage'

--- a/app/mailers/ticket_notifier.rb
+++ b/app/mailers/ticket_notifier.rb
@@ -17,7 +17,8 @@ class TicketNotifier < ActionMailer::Base
 
     mail(
       to: "#{@recipient.display_name} <#{@recipient.email}>",
-      subject: "#{@user.first_name} has assigned you a ticket via #{@group.group_name}"
+      subject: "#{@user.first_name} has assigned you a ticket via #{@group.group_name}",
+      reply_to: "#{@user.display_name} <#{@user.email}>"
     )
 
     headers['X-MC-Tags'] = 'AssignTicket'
@@ -41,7 +42,8 @@ class TicketNotifier < ActionMailer::Base
 
     mail(
       to: "#{@recipient.display_name} <#{@recipient.email}>",
-      subject: "#{@user.first_name} has requested your ticket via #{@group.group_name}"
+      subject: "#{@user.first_name} has requested your ticket via #{@group.group_name}",
+      reply_to: "#{@user.display_name} <#{@user.email}>"
     )
 
     headers['X-MC-Tags'] = 'RequestTicket'

--- a/app/mailers/welcome_email.rb
+++ b/app/mailers/welcome_email.rb
@@ -7,7 +7,8 @@ class WelcomeEmail < ActionMailer::Base
 
     mail(
       to: "#{@recipient.display_name} <#{@recipient.email}>",
-      subject: "Welcome to SeatShare, #{@recipient.first_name}!"
+      subject: "Welcome to SeatShare, #{@recipient.first_name}!",
+      reply_to: "SeatShare Support <contact@myseatshare.com>"
     )
 
     headers['X-MC-Tags'] = 'NewUser'

--- a/test/mailers/group_notifier_test.rb
+++ b/test/mailers/group_notifier_test.rb
@@ -8,6 +8,7 @@ class GroupNotifierTest < ActionMailer::TestCase
 
     assert_not ActionMailer::Base.deliveries.empty?
     assert_equal ["no-reply@myseatshare.com"], email.from
+    assert_equal ["sarahb@example.org"], email.reply_to
     assert_equal ["bob@example.com"], email.to
     assert_equal "You have been invited to join Geeks Watching Hockey", email.subject
     assert_includes email.body.to_s, "<title>You have been invited to join Geeks Watching Hockey</title>"
@@ -23,7 +24,8 @@ class GroupNotifierTest < ActionMailer::TestCase
     email = GroupNotifier.send_group_message(group, sending_user, recipient_users, 'Anyone want to go to the game on Friday?', "I'll have an extra ticket to spare.\n\nFree to a good home.").deliver
 
     assert_not ActionMailer::Base.deliveries.empty?
-    assert_equal ["stonej@example.net"], email.from
+    assert_equal ["no-reply@myseatshare.com"], email.from
+    assert_equal ["stonej@example.net"], email.reply_to
     assert_equal ["stonej@example.net", "jillsmith83@us.example.org", "rick.taylor@example.net"], email.to
     assert_equal "[Geeks Watching Hockey] Anyone want to go to the game on Friday?", email.subject
     assert_includes email.body.to_s, "<title>[Geeks Watching Hockey] Anyone want to go to the game on Friday?</title>"


### PR DESCRIPTION
Fixes #82

When using a third-party mailer, you won't want to change the raw "from" address because it will likely not be "approved" to send email on behalf of that domain. Instead, leave it as a `no-reply@example.com` and just update the `reply_to` attribute. This increases the deliverability of the email by reducing the chance it will be marked as spam.
