### PR TITLE
Auto-populate event schedule on group creation

### DIFF
--- a/app/admin/event.rb
+++ b/app/admin/event.rb
@@ -32,7 +32,7 @@ ActiveAdmin.register Event do
 
     # Build entity list
     @entities = {}
-    Entity.where("import_key LIKE 'l.%'").active.group_by(&:entity_type).each do |entity_type, entity|
+    Entity.active.is_soda.group_by(&:entity_type).each do |entity_type, entity|
       if @entities[entity_type].nil?
         @entities[entity_type] = []
       end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -31,6 +31,9 @@ class GroupsController < ApplicationController
       @group.join_group current_user, 'admin'
       flash.keep
       flash[:notice] = "Group created!"
+      if @group.entity.events.count === 0
+        status = @group.entity.retrive_schedule
+      end
       redirect_to :action => 'show', :id => @group.id
     else
       flash.keep

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -9,6 +9,7 @@ class Entity < ActiveRecord::Base
 
   scope :order_by_name, -> { order('LOWER(entity_type) ASC, LOWER(entity_name) ASC') }
   scope :active, -> { where('status = 1') }
+  scope :is_soda, -> { where("import_key LIKE 'l.%'") }
 
   def initialize(attributes={})
     attr_with_defaults = {
@@ -20,6 +21,17 @@ class Entity < ActiveRecord::Base
 
   def display_name
     "#{entity_name} (#{entity_type})"
+  end
+
+  def retrive_schedule
+    importer = SodaScheduleImport.new
+    importer.run({
+      team_id: import_key,
+      start_datetime: DateTime.now.beginning_of_day - 30.days,
+      end_datetime: DateTime.now.end_of_day,
+      force_update: false
+    })
+    return importer
   end
 
   private

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,7 @@
 class Event < ActiveRecord::Base
 	belongs_to :entity
   has_many :tickets
+  has_many :groups, through: :entity
 
   validates :entity_id, :event_name, :start_time, :presence => true
   before_save :clean_import_key

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -4,6 +4,7 @@ class Group < ActiveRecord::Base
 
   has_many :group_users
   has_many :users, through: :group_users
+  has_many :events, through: :entity
 
   validates :entity_id, :group_name, :creator_id, :presence => true
   before_save :clean_invitation_code
@@ -21,10 +22,6 @@ class Group < ActiveRecord::Base
 
   def display_name
     "#{group_name}"
-  end
-
-  def events
-    Event.where("entity_id = #{self.entity.id}")
   end
 
   def administrators


### PR DESCRIPTION
The SODA service works off a pre-paid budget of tokens for retrieving team schedules. To make it easier for new users, let's go ahead and retrieve the latest schedule available when they first create a group. Worst-case scenario is that the user is presented with the "Notify me when the schedule is available" screen instead of a list of events (which is the current behavior). We would then be able to handle any cases where the budget may have been depleted.
