### PR TITLE
Add Rubocop to Guard installation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,17 @@
+AllCops:
+  Include:
+    - '**/Rakefile'
+    - '**/config.ru'
+  Exclude:
+    - '.bundle/**/*'
+    - 'bin/**/*'
+    - 'config/**/*'
+    - 'config/**/*'
+    - 'db/**/*'
+    - 'log/**/*'
+    - 'public/**/*'
+    - 'test/**/*'
+    - 'vendor/**/*'
+
+Documentation:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -120,4 +120,5 @@ group :development do
   gem 'rack-livereload'
   gem 'guard-livereload'
   gem 'guard-bundler', :group => :development
+  gem 'guard-rubocop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,9 @@ GEM
     arbre (1.0.2)
       activesupport (>= 3.0.0)
     arel (5.0.1.20140414130214)
+    ast (2.0.0)
+    astrolabe (1.3.0)
+      parser (>= 2.2.0.pre.3, < 3.0)
     aws-sdk (1.57.0)
       aws-sdk-v1 (= 1.57.0)
     aws-sdk-v1 (1.57.0)
@@ -139,6 +142,9 @@ GEM
     guard-minitest (2.3.2)
       guard (~> 2.0)
       minitest (>= 3.0)
+    guard-rubocop (1.2.0)
+      guard (~> 2.0)
+      rubocop (~> 0.20)
     guard-spork (1.5.1)
       childprocess (>= 0.2.3)
       guard (>= 1.1)
@@ -203,10 +209,14 @@ GEM
       activesupport (>= 3.0.0)
       cocaine (~> 0.5.3)
       mime-types
+    parser (2.2.0.pre.8)
+      ast (>= 1.1, < 3.0)
+      slop (~> 3.4, >= 3.4.5)
     pg (0.17.1)
     polyamorous (1.1.0)
       activerecord (>= 3.0)
     polyglot (0.3.5)
+    powerpack (0.0.9)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -236,6 +246,7 @@ GEM
       activesupport (= 4.1.5)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    rainbow (2.0.0)
     rake (10.3.2)
     ransack (1.5.1)
       actionpack (>= 3.0)
@@ -253,6 +264,13 @@ GEM
       railties (>= 3.2, < 4.2)
     rest_client (1.8.1)
       netrc (~> 0.7.7)
+    rubocop (0.27.1)
+      astrolabe (~> 1.3)
+      parser (>= 2.2.0.pre.7, < 3.0)
+      powerpack (~> 0.0.6)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.4)
+    ruby-progressbar (1.7.0)
     sass (3.2.19)
     sass-rails (4.0.4)
       railties (>= 4.0.0, < 5.0)
@@ -332,6 +350,7 @@ DEPENDENCIES
   guard-bundler
   guard-livereload
   guard-minitest
+  guard-rubocop
   guard-spork
   jbuilder (~> 1.2)
   jquery-rails

--- a/Guardfile
+++ b/Guardfile
@@ -53,3 +53,8 @@ guard :minitest, :drb => true do
   # watch(%r{^app/helpers/(.*)\.rb$})     { |m| "test/helpers/#{m[1]}_test.rb" }
   # watch(%r{^app/models/(.*)\.rb$})      { |m| "test/unit/#{m[1]}_test.rb" }
 end
+
+guard :rubocop do
+  watch(%r{.+\.rb$})
+  watch(%r{(?:.+/)?\.rubocop\.yml$}) { |m| File.dirname(m[0]) }
+end


### PR DESCRIPTION
Adds the [guard-rubocop](https://github.com/yujinakayama/guard-rubocop) plugin so we can monitor the progress of syntax/style guide issues. Experience with it so far has been positive, even if I have NFI how to fix a good portion of the errors. I'll have a separate commit that brings down the count of issues from ~2300 to 237 by using the automatic syntax correction. All indications are it didn't break any of the tests, so that's :cool:. The configuration options for what to squelch/hide are
found in the `.rubocop.yml` file and in their documentation found [here](https://github.com/bbatsov/rubocop#configuration).
