### PR TITLE
Massive ruby syntax cleanup

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ AllCops:
     - '**/config.ru'
   Exclude:
     - '.bundle/**/*'
+    - 'app/admin/**/*'
     - 'bin/**/*'
     - 'config/**/*'
     - 'config/**/*'

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
-# for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
+# for example lib/tasks/capistrano.rake, and they will automatically
+# be available to Rake.
 
 require File.expand_path('../config/application', __FILE__)
 

--- a/app/admin/admin_user.rb
+++ b/app/admin/admin_user.rb
@@ -17,7 +17,7 @@ ActiveAdmin.register AdminUser do
   filter :created_at
 
   form do |f|
-    f.inputs "Admin Details" do
+    f.inputs 'Admin Details' do
       f.input :email
       f.input :password
       f.input :password_confirmation
@@ -25,6 +25,6 @@ ActiveAdmin.register AdminUser do
     f.actions
   end
 
-  menu :parent => 'Users'
+  menu parent: 'Users'
 
 end

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -1,44 +1,44 @@
-ActiveAdmin.register_page "Dashboard" do
+ActiveAdmin.register_page 'Dashboard' do
 
-  menu priority: 1, label: proc{ I18n.t("active_admin.dashboard") }
+  menu priority: 1, label: proc { I18n.t('active_admin.dashboard') }
 
-  content title: proc{ I18n.t("active_admin.dashboard") } do
+  content title: proc { I18n.t('active_admin.dashboard') } do
 
     columns do
 
       column do
 
-        panel "Recent Contact Messages" do
+        panel 'Recent Contact Messages' do
 
           contact_form_messages = HTTParty.get("http://getsimpleform.com/messages.json?api_token=#{ENV['SIMPLE_FORM_API_TOKEN']}").first(5) || []
 
           div do
             if !contact_form_messages.nil? && contact_form_messages.count > 0
               for message in contact_form_messages
-                h4 mail_to(message["data"]["email"], message["data"]["name"] + " - " + message["data"]["email"])
+                h4 mail_to(message['data']['email'], message['data']['name'] + ' - ' + message['data']['email'])
                 div do
-                  simple_format "#{message["data"]["message"]}"
+                  simple_format "#{message['data']['message']}"
                 end
-                div "#{message["created_at"]} - #{message["request_ip"]}"
+                div "#{message['created_at']} - #{message['request_ip']}"
                 hr
               end
             else
-              div "No recent messages. Messages sent through the contact form appear here."
+              div 'No recent messages. Messages sent through the contact form appear here.'
               hr
             end
           end
-          div :style => "text-align: right" do
-            link_to("Manage Messages", "http://getsimpleform.com/messages?api_token=#{ENV['SIMPLE_FORM_API_TOKEN']}", :target => "_blank")
+          div style: 'text-align: right' do
+            link_to('Manage Messages', "http://getsimpleform.com/messages?api_token=#{ENV['SIMPLE_FORM_API_TOKEN']}", target: '_blank')
           end
         end
 
-        panel "Twilio" do
+        panel 'Twilio' do
           client = TwilioSMS.new
 
           attributes_table_for :usage do
-            usage = client.get_sms_usage
+            usage = client.sms_usage
             if usage.is_a? String
-              row "Error" do
+              row 'Error' do
                 usage
               end
             else
@@ -54,7 +54,7 @@ ActiveAdmin.register_page "Dashboard" do
           attributes_table_for :messages do
             usage = client.recent_messages
             if usage.is_a? String
-              row "Error" do
+              row 'Error' do
                 usage
               end
             else
@@ -68,24 +68,24 @@ ActiveAdmin.register_page "Dashboard" do
 
         end
 
-        panel "System Stats" do
+        panel 'System Stats' do
           attributes_table_for :stats do
-            row "Entities" do
+            row 'Entities' do
               Entity.all.count
             end
-            row "Active Entities" do
+            row 'Active Entities' do
               Entity.active.count
             end
-            row "Users" do
+            row 'Users' do
               User.all.count
             end
-            row "Active Users" do
+            row 'Active Users' do
               User.active.count
             end
-            row "Events" do
+            row 'Events' do
               Event.all.count
             end
-            row "Tickets" do
+            row 'Tickets' do
               Ticket.all.count
             end
           end
@@ -94,16 +94,16 @@ ActiveAdmin.register_page "Dashboard" do
 
       column do
 
-        panel "Recent Users" do
+        panel 'Recent Users' do
           table do
             thead do
-              th "User"
-              th "Email"
-              th "Joined"
+              th 'User'
+              th 'Email'
+              th 'Joined'
             end
             tbody do
               User.all.order('created_at DESC').first(5).map do |user|
-                tr :class => cycle('even', 'odd') do
+                tr class: cycle('even', 'odd') do
                   td link_to(user.display_name, admin_user_path(user))
                   td mail_to(user.email, user.email)
                   td user.created_at.strftime('%-m/%-d/%Y')
@@ -113,17 +113,17 @@ ActiveAdmin.register_page "Dashboard" do
           end
         end
 
-        panel "Recent Groups" do
+        panel 'Recent Groups' do
           table do
             thead do
-              th "Group"
-              th "Members"
-              th "Entity"
-              th "Created"
+              th 'Group'
+              th 'Members'
+              th 'Entity'
+              th 'Created'
             end
             tbody do
               Group.all.order('created_at DESC').limit(5).map do |group|
-                tr :class => cycle('even', 'odd') do
+                tr class: cycle('even', 'odd') do
                   td link_to(group.group_name, admin_group_path(group))
                   td group.users.count
                   td auto_link(group.entity)
@@ -134,16 +134,16 @@ ActiveAdmin.register_page "Dashboard" do
           end
         end
 
-        panel "Upcoming Events" do
+        panel 'Upcoming Events' do
           table do
             thead do
-              th "Event"
-              th "Entity"
-              th "Date & Time"
+              th 'Event'
+              th 'Entity'
+              th 'Date & Time'
             end
             tbody do
               Event.order_by_date.where("start_time > '#{Date.today}'").limit(5).map do |event|
-                tr :class => cycle('even', 'odd') do
+                tr class: cycle('even', 'odd') do
                   td link_to(event.event_name, admin_event_path(event))
                   td auto_link(event.entity)
                   td event.date_time

--- a/app/admin/entity.rb
+++ b/app/admin/entity.rb
@@ -23,7 +23,7 @@ ActiveAdmin.register Entity do
     actions
   end
 
-  sidebar 'Entity Groups', :only => :show do
+  sidebar 'Entity Groups', only: :show do
     ul do
       Entity.find(resource.id).groups.order_by_name.collect do |group|
         li auto_link(group)

--- a/app/admin/event.rb
+++ b/app/admin/event.rb
@@ -21,12 +21,12 @@ ActiveAdmin.register Event do
   filter :start_time
   filter :import_key
 
-  action_item :only => :index do
-    link_to 'Import from SODA', :action => 'import_soda'
+  action_item only: :index do
+    link_to 'Import from SODA', action: 'import_soda'
   end
 
-  collection_action :import_soda, :method => :get
-  collection_action :import_soda, :method => :post do
+  collection_action :import_soda, method: :get
+  collection_action :import_soda, method: :post do
 
     @page_title = 'Import from SODA'
 
@@ -39,11 +39,11 @@ ActiveAdmin.register Event do
       @entities[entity_type] << entity
     end
 
-    @start_datetime = params[:start_datetime] || Time.new - 60*60*24*30
+    @start_datetime = params[:start_datetime] || Time.new - 60 * 60 * 24 * 30
     @end_datetime = params[:end_datetime] || Time.new
     @force_update = params[:force_update] || false
 
-    if !params[:team_id].nil?
+    unless params[:team_id].nil?
 
       # Used to display the list back upon completion
       @events_list = []
@@ -55,12 +55,12 @@ ActiveAdmin.register Event do
       for team_id in params[:team_id]
 
         importer = SodaScheduleImport.new
-        importer.run({
+        importer.run(
           team_id: team_id,
           start_datetime: params[:start_datetime],
           end_datetime: params[:end_datetime],
           force_update: params[:force_update]
-        })
+        )
 
         @events_list += importer.events_list
         @messages += importer.messages
@@ -71,7 +71,7 @@ ActiveAdmin.register Event do
 
   end
 
-  sidebar 'Tickets', :only => :show do
+  sidebar 'Tickets', only: :show do
     ul do
       Event.find(resource.id).tickets.collect do |ticket|
         li auto_link(ticket)

--- a/app/admin/group.rb
+++ b/app/admin/group.rb
@@ -25,7 +25,7 @@ ActiveAdmin.register Group do
   filter :invitation_code
   filter :status
 
-  sidebar 'Group Members', :only => :show do
+  sidebar 'Group Members', only: :show do
     ul do
       Group.find(resource.id).users.order_by_name.collect do |user|
         li auto_link(user)

--- a/app/admin/group_invitation.rb
+++ b/app/admin/group_invitation.rb
@@ -1,6 +1,6 @@
 ActiveAdmin.register GroupInvitation do
-  
-  menu :parent => 'Groups'
+
+  menu parent: 'Groups'
 
   index do
     selectable_column

--- a/app/admin/ticket.rb
+++ b/app/admin/ticket.rb
@@ -11,7 +11,7 @@ ActiveAdmin.register Ticket do
   filter :seat
   filter :cost
   filter :note
- 
+
   index do
     selectable_column
     id_column

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -27,14 +27,14 @@ ActiveAdmin.register User do
   filter :created_at
 
   form do |f|
-    f.inputs "Admin Details" do
+    f.inputs 'Admin Details' do
       f.input :first_name
       f.input :last_name
       f.input :email
       f.input :timezone
       f.input :status
       f.inputs do
-        f.has_many :profile, :allow_destroy => false, :new_record => false do |pf|
+        f.has_many :profile, allow_destroy: false, new_record: false do |pf|
           pf.input :bio
           pf.input :location
           pf.input :mobile
@@ -43,8 +43,8 @@ ActiveAdmin.register User do
     end
     f.actions
   end
- 
-  sidebar 'User Groups', :only => :show do
+
+  sidebar 'User Groups', only: :show do
     ul do
       User.find(resource.id).groups.order_by_name.collect do |group|
         li auto_link(group)

--- a/app/admin/user_alias.rb
+++ b/app/admin/user_alias.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register UserAlias do
-  
-  menu :parent => 'Users'
+
+  menu parent: 'Users'
 
 end

--- a/app/controllers/admin_api/v1/admin_api_controller.rb
+++ b/app/controllers/admin_api/v1/admin_api_controller.rb
@@ -5,65 +5,66 @@ module AdminApi
       respond_to :json
 
       def index
-        respond_with json_response("methods", [
-          "user_count", "group_count", "total_invites", "accepted_invites",
-          "recent_groups", "recent_users", "total_tickets",
-          "tickets_transferred", "tickets_unused"
-        ])
+        respond_with json_response(
+          'methods',
+          %w(
+            user_count group_count total_invites accepted_invites
+            recent_groups recent_users total_tickets tickets_transferred
+            tickets_unused
+          )
+        )
       end
 
       def user_count
-        respond_with json_response("user_count", User.active.count)
+        respond_with json_response('user_count', User.active.count)
       end
 
       def group_count
-        respond_with json_response("group_count", Group.active.count)
+        respond_with json_response('group_count', Group.active.count)
       end
 
       def total_invites
-        respond_with json_response("total_invites", GroupInvitation.count)
+        respond_with json_response('total_invites', GroupInvitation.count)
       end
 
       def accepted_invites
         respond_with json_response(
-          "accepted_invites",
+          'accepted_invites',
           GroupInvitation.accepted.count
         )
       end
 
       def recent_groups
         respond_with json_response(
-          "recent_groups",
-          Group.all.order("created_at DESC").limit(5)
+          'recent_groups',
+          Group.all.order('created_at DESC').limit(5)
         )
       end
 
       def recent_users
         respond_with json_response(
-          "recent_users",
-          User.all.order("created_at DESC").first(5)
+          'recent_users',
+          User.all.order('created_at DESC').first(5)
         )
       end
 
       def total_tickets
-        respond_with json_response("total_tickets", Ticket.count)
+        respond_with json_response('total_tickets', Ticket.count)
       end
 
       def tickets_transferred
         if params[:days]
           since = DateTime.now - params[:days].to_i.days
-          tickets = Ticket.where("user_id != owner_id").where("user_id > 0")
+          tickets = Ticket.where('user_id != owner_id').where('user_id > 0')
           count = 0
-          for ticket in tickets
-            if ticket.event.start_time > since
-              count += 1
-            end
+          tickets.each do |ticket|
+            count += 1 if ticket.event.start_time > since
           end
-          respond_with json_response("tickets_transferred", count)
+          respond_with json_response('tickets_transferred', count)
         else
           respond_with json_response(
-            "tickets_transferred",
-            Ticket.where("user_id != owner_id").where("user_id > 0").count
+            'tickets_transferred',
+            Ticket.where('user_id != owner_id').where('user_id > 0').count
           )
         end
       end
@@ -71,18 +72,16 @@ module AdminApi
       def tickets_unused
         if params[:days]
           since = DateTime.now - params[:days].to_i.days
-          tickets = Ticket.where("user_id != owner_id").where("user_id = 0")
+          tickets = Ticket.where('user_id != owner_id').where('user_id = 0')
           count = 0
-          for ticket in tickets
-            if ticket.event.start_time > since
-              count += 1
-            end
+          tickets.each do |ticket|
+            count += 1 if ticket.event.start_time > since
           end
-          respond_with json_response("tickets_unused", count)
+          respond_with json_response('tickets_unused', count)
         else
           respond_with json_response(
-            "tickets_unused",
-            Ticket.where("user_id != owner_id").where("user_id = 0").count
+            'tickets_unused',
+            Ticket.where('user_id != owner_id').where('user_id = 0').count
           )
         end
       end
@@ -91,25 +90,24 @@ module AdminApi
 
       def json_response(method, value)
         response = {
-          status: "success",
+          status: 'success',
           version: 1,
           method: method,
           data: value
         }
-        return response
+        response
       end
 
       def require_api_key
-        if !params[:api_key] || params[:api_key] != ENV["ADMIN_API_KEY"]
-          response = {
-            status: "error",
-            version: 1,
-            error: "Invalid API key"
-          }
-          respond_with response
-        end
+        api_key = params[:api_key]
+        return true if !api_key || api_key != ENV['ADMIN_API_KEY']
+        response = {
+          status: 'error',
+          version: 1,
+          error: 'Invalid API key'
+        }
+        respond_with response
       end
-
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,44 +10,44 @@ class ApplicationController < ActionController::Base
   layout :layout_by_resource
 
   def not_found
-    raise ActionController::RoutingError.new("Not Found")
+    not_found_message = ActionController::RoutingError.new('Not Found')
+    fail not_found_message
   end
 
   protected
 
   def load_shared_interface_variables
-    @group_selector = current_user.groups.order_by_name.active.collect {|p|
-      [ p.group_name, p.id ]
-    }
+    @group_selector = current_user.groups.order_by_name.active.collect do|p|
+      [p.group_name, p.id]
+    end
   end
 
   def configure_devise_permitted_parameters
-
     registration_params = [
       :first_name, :last_name, :email, :password, :password_confirmation,
       :newsletter_signup, :invite_code, :entity_id
     ]
 
-    if params[:action] == "update"
-      devise_parameter_sanitizer.for(:account_update) { 
+    if params[:action] == 'update'
+      devise_parameter_sanitizer.for(:account_update) do
         |u| u.permit(registration_params << :current_password)
-      }
-    elsif params[:action] == "create"
-      devise_parameter_sanitizer.for(:sign_up) { 
-        |u| u.permit(registration_params) 
-      }
+      end
+    elsif params[:action] == 'create'
+      devise_parameter_sanitizer.for(:sign_up) do
+        |u| u.permit(registration_params)
+      end
     end
   end
 
   def layout_by_resource
     if devise_controller?
-      if ["devise/sessions", "devise/sessions"].include? params[:controller]
-        "login"
+      if ['devise/sessions', 'devise/sessions'].include? params[:controller]
+        'login'
       else
-        "two-column"
+        'two-column'
       end
     else
-      "application"
+      'application'
     end
   end
 
@@ -56,10 +56,9 @@ class ApplicationController < ActionController::Base
   def set_timezone
     tz = current_user ? current_user.timezone : nil
     if tz.blank?
-      Time.zone = ActiveSupport::TimeZone["Central Time (US & Canada)"]
+      Time.zone = ActiveSupport::TimeZone['Central Time (US & Canada)']
     else
       Time.zone = tz
     end
   end
-
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,21 +1,16 @@
 class ProfilesController < ApplicationController
-
   before_action :authenticate_user!
   layout 'two-column'
 
   def show
     @user = User.find_by_id(params[:id]) || not_found
-    if @user.profile.nil?
-      @user.profile = Profile.new
-    end
+    @user.profile = Profile.new if @user.profile.nil?
   end
 
   def edit
     @user = current_user
-    if @user.profile.nil?
-      @user.profile = Profile.new
-    end
-    @user_aliases = current_user.user_aliases
+    @user.profile = Profile.new if @user.profile.nil?
+    @user_aliases = current_user.user_aliases.order_by_name
   end
 
   def update
@@ -23,8 +18,8 @@ class ProfilesController < ApplicationController
     user.update_attributes!(user_params)
 
     flash.keep
-    flash[:notice] = "Profile updated!"
-    redirect_to :action => 'show', :id => @current_user.id and return
+    flash[:notice] = 'Profile updated!'
+    redirect_to(action: 'show', id: @current_user.id) && return
   end
 
   private
@@ -35,5 +30,4 @@ class ProfilesController < ApplicationController
       profile_attributes: [:bio, :location, :mobile, :sms_notify]
     )
   end
-
 end

--- a/app/controllers/public_controller.rb
+++ b/app/controllers/public_controller.rb
@@ -1,5 +1,4 @@
 class PublicController < ApplicationController
-
   layout :layout_by_resource
   before_action :authenticate_user!, only: :token
 
@@ -7,20 +6,20 @@ class PublicController < ApplicationController
     if user_signed_in?
       if session[:current_group_id].is_a? Numeric
         redirect_to(
-          :controller => 'groups', :action => 'show',
-          :id => session[:current_group_id], :status => 302
-        ) and return
+          controller: 'groups', action: 'show',
+          id: session[:current_group_id], status: 302
+        ) && return
       else
         groups = current_user.groups.active
         if groups.count == 0
           redirect_to(
-            :controller => 'groups', :action => 'index', :status => 302
-          ) and return
+            controller: 'groups', action: 'index', status: 302
+          ) && return
         else
           redirect_to(
-            :controller => 'groups', :action => 'show', :id => groups.first.id,
-            :status => 302
-          ) and return
+            controller: 'groups', action: 'show', id: groups.first.id,
+            status: 302
+          ) && return
         end
       end
     end
@@ -51,10 +50,9 @@ class PublicController < ApplicationController
 
   def layout_by_resource
     if params[:action] === 'index'
-      "home"
+      'home'
     else
-      "two-column"
+      'two-column'
     end
   end
-
 end

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -1,50 +1,59 @@
 class TicketsController < ApplicationController
-
   before_action :authenticate_user!
   layout 'two-column'
 
   def index
     if params[:filter] == 'past'
-      @tickets = Ticket.where("owner_id = #{current_user.id}").order_by_seat.joins(:event).where("start_time < '#{Date.today}'").order_by_date
-      @page_title = "My Past Tickets"
+      @tickets = Ticket.where("owner_id = #{current_user.id}")
+                 .order_by_seat.joins(:event)
+                 .where("start_time < '#{Date.today}'")
+                 .order_by_date
+      @page_title = 'My Past Tickets'
     else
-      @tickets = Ticket.where("owner_id = #{current_user.id}").order_by_seat.joins(:event).where("start_time > '#{Date.today}'").order_by_date
-      @page_title = "My Tickets"
+      @tickets = Ticket.where("owner_id = #{current_user.id}")
+                 .order_by_seat.joins(:event)
+                 .where("start_time > '#{Date.today}'")
+                 .order_by_date
+      @page_title = 'My Tickets'
     end
-    render :layout => 'single-column'
+    render layout: 'single-column'
   end
 
   def bulk_update
-    if !params[:ticket_cost].nil?
-      for ticket_id, cost in params[:ticket_cost]
+    unless params[:ticket_cost].nil?
+      params[:ticket_cost].each do |ticket_id, cost|
         ticket = Ticket.find(ticket_id)
         next if ticket.cost.to_f == cost.to_f
         if ticket.owner_id != current_user.id
-          flash[:error] = "Ticket cost could not be updated."
+          flash[:error] = 'Ticket cost could not be updated.'
           next
         end
         ticket.cost = cost
         if ticket.save
           log_ticket_history ticket, 'updated'
-          flash[:notice] = "Tickets updated!"
+          flash[:notice] = 'Tickets updated!'
         else
-          flash[:error] = "Ticket cost could not be updated."
+          flash[:error] = 'Ticket cost could not be updated.'
         end
       end
     end
-    redirect_to :controller => 'tickets', :action => 'index', :filter => params[:tickets][:filter]
+    redirect_to(
+      controller: 'tickets', action: 'index', filter: params[:tickets][:filter]
+    )
   end
 
   def new
     @group = Group.find_by_id(params[:group_id]) || not_found
-    @ticket = Ticket.new({
-      :owner_id => current_user.id,
-      :user_id => current_user.id
-    })
+    @ticket = Ticket.new(
+      owner_id: current_user.id,
+      user_id: current_user.id
+    )
 
-    @members = @group.users.order_by_name.collect {|p| [ p.display_name, p.id ] }
+    @members = @group.users.order_by_name.collect { |p| [p.display_name, p.id] }
     @members.unshift(['Unassigned', 0])
-    @user_aliases = current_user.user_aliases.order_by_name.collect {|p| [ p.display_name, p.id ] }
+    @user_aliases = current_user.user_aliases
+                    .order_by_name
+                    .collect { |p| [p.display_name, p.id] }
     @user_aliases.unshift(['Not Set', 0])
 
     if params[:event_id]
@@ -52,25 +61,25 @@ class TicketsController < ApplicationController
       @ticket_stats = @event.ticket_stats(@group, current_user)
       @page_title = "#{@event.event_name}"
     else
-      @events = @group.events.order('start_time ASC').where("start_time > '#{Date.today}'")
-      @page_title = "Add Tickets"
+      @events = @group.events
+                .order('start_time ASC')
+                .where("start_time > '#{Date.today}'")
+      @page_title = 'Add Tickets'
     end
   end
 
   def create
     group = Group.find(params[:group_id])
-    if !group.is_member(current_user)
-      raise "NotGroupMember"
-    end
-    ticket = Ticket.new({
-      :group_id => params[:group_id],
-      :section => ticket_params[:section],
-      :row => ticket_params[:row],
-      :seat => ticket_params[:seat],
-      :cost => ticket_params[:cost].gsub(/[^0-9\.]/,'').to_f,
-      :user_id => ticket_params[:user_id].to_i,
-      :owner_id => current_user.id
-    })
+    fail 'NotGroupMember' unless group.member?(current_user)
+    ticket = Ticket.new(
+      group_id: params[:group_id],
+      section: ticket_params[:section],
+      row: ticket_params[:row],
+      seat: ticket_params[:seat],
+      cost: ticket_params[:cost].gsub(/[^0-9\.]/, '').to_f,
+      user_id: ticket_params[:user_id].to_i,
+      owner_id: current_user.id
+    )
     if !ticket_params[:alias_id].nil? && ticket_params[:user_id].to_i == current_user.id
       ticket.alias_id = ticket_params[:alias_id].to_i
     else
@@ -81,28 +90,37 @@ class TicketsController < ApplicationController
       ticket.event_id = ticket_params[:event_id]
       if ticket.valid? && ticket.save
         log_ticket_history ticket, 'created'
-        flash[:notice] = "Ticket added!"
-        redirect_to :controller => 'events', :action => 'show', :id => ticket_params[:event_id], :group_id => group.id and return
+        flash[:notice] = 'Ticket added!'
+        redirect_to(
+          controller: 'events', action: 'show', id: ticket_params[:event_id],
+          group_id: group.id
+        ) && return
       else
-        flash[:error] = "Could not create ticket."
-        redirect_to :controller => 'tickets', :action => 'new', :group_id => group.id and return
+        flash[:error] = 'Could not create ticket.'
+        redirect_to(
+          controller: 'tickets', action: 'new', group_id: group.id
+        ) && return
       end
     elsif params[:ticket][:event_id].is_a? Array
-      for event_id in params[:ticket][:event_id]
+      params[:ticket][:event_id].each do |event_id|
         season_ticket = ticket.dup
         season_ticket.event_id = event_id
         if season_ticket.valid? && season_ticket.save
           log_ticket_history season_ticket, 'created'
         else
-          flash[:error] = "Could not create tickets."
-          redirect_to :controller => 'tickets', :action => 'new', :group_id => group.id and return
+          flash[:error] = 'Could not create tickets.'
+          redirect_to(
+            controller: 'tickets', action: 'new', group_id: group.id
+          ) && return
         end
       end
-      flash[:notice] = "Tickets added!"
-      redirect_to :controller => 'groups', :action => 'show', :id => group.id and return
+      flash[:notice] = 'Tickets added!'
+      redirect_to(controller: 'groups', action: 'show', id: group.id) && return
     else
-      flash[:error] = "No events selected."
-      redirect_to :controller => 'tickets', :action => 'new', :group_id => group.id and return
+      flash[:error] = 'No events selected.'
+      redirect_to(
+        controller: 'tickets', action: 'new', group_id: group.id
+      ) && return
     end
   end
 
@@ -111,23 +129,25 @@ class TicketsController < ApplicationController
     @event = Event.find_by_id(params[:event_id]) || not_found
     @ticket = Ticket.find_by_id(params[:id]) || not_found
     if @ticket.assigned != current_user && @ticket.owner != current_user
-      redirect_to :action => 'request_ticket', :id => @ticket.id
+      redirect_to action: 'request_ticket', id: @ticket.id
     end
     @ticket_stats = @event.ticket_stats(@group, current_user)
-    @members = @group.users.order_by_name.order_by_name.collect {|p| [ p.display_name, p.id ] }
+    @members = @group.users
+               .order_by_name
+               .order_by_name
+               .collect { |p| [p.display_name, p.id] }
     @members.unshift(['Unassigned', 0])
-    @user_aliases = current_user.user_aliases.collect {|p| [ p.display_name, p.id ] }
+    @user_aliases = current_user.user_aliases
+                    .collect { |p| [p.display_name, p.id] }
     @user_aliases.unshift(['Unassigned', 0])
   end
 
   def update
     group = Group.find(params[:group_id])
-    if !group.is_member(current_user)
-      raise "NotGroupMember"
-    end
+    fail 'NotGroupMember' unless group.member?(current_user)
     ticket = Ticket.find(params[:id])
     original_ticket = ticket.dup
-    ticket.cost = ticket_params[:cost].gsub(/[^0-9\.]/,'').to_f
+    ticket.cost = ticket_params[:cost].gsub(/[^0-9\.]/, '').to_f
     ticket.user_id = ticket_params[:user_id].to_i
     ticket.note = ticket_params[:note]
     if !ticket_params[:alias_id].nil? && ticket_params[:user_id].to_i == current_user.id
@@ -135,25 +155,28 @@ class TicketsController < ApplicationController
     else
       ticket.alias_id = 0
     end
-    if !ticket_params[:ticket_file].nil?
+    unless ticket_params[:ticket_file].nil?
       uploaded_io = ticket_params[:ticket_file]
-      File.open(Rails.root.join('tmp', 'uploads', uploaded_io.original_filename), 'wb') do |file|
+      File.open(Rails.root.join(
+        'tmp', 'uploads', uploaded_io.original_filename), 'wb'
+      ) do |file|
         file.write(uploaded_io.read)
       end
-      if !File.exists?(Rails.root.join('tmp', 'uploads', uploaded_io.original_filename))
-        raise "TicketFileNotSaved"
-      end
-      File.open(Rails.root.join('tmp', 'uploads', uploaded_io.original_filename), 'rb') do |file|
+      fail 'TicketFileNotSaved' unless File.exist?(
+        Rails.root.join('tmp', 'uploads', uploaded_io.original_filename)
+      )
+      path = Rails.root.join('tmp', 'uploads', uploaded_io.original_filename)
+      File.open(path, 'rb') do |file|
         file_s3_key = "#{params[:id]}-#{SecureRandom.hex}/#{uploaded_io.original_filename}"
         s3 = AWS::S3.new
         object = s3.buckets[ENV['SEATSHARE_S3_BUCKET']].objects[file_s3_key]
         object.write(open(file))
-        ticket_file = TicketFile.new({
+        ticket_file = TicketFile.new(
           file_name: uploaded_io.original_filename,
           user_id: ticket.owner_id,
           ticket_id: ticket.id,
           path: file_s3_key
-        })
+        )
         ticket_file.save!
       end
     end
@@ -161,9 +184,7 @@ class TicketsController < ApplicationController
     if ticket.save
       flash[:notice] = 'Ticket updated!'
       if ticket.user_id != current_user.id && ticket.user_id != 0 && original_ticket.user_id != ticket.user_id
-        if !group.is_member(ticket.assigned)
-          raise "NotGroupMember"
-        end
+        fail 'NotGroupMember' unless group.member?(ticket.assigned)
         TicketNotifier.assign(ticket, current_user).deliver
         TwilioSMS.new.assign_ticket(ticket, current_user)
         log_ticket_history ticket, 'assigned'
@@ -173,16 +194,17 @@ class TicketsController < ApplicationController
     else
       flash[:error] = 'Ticket could not be updated.'
     end
-    redirect_to :controller => 'events', :action => 'show', :group_id => group.id, :id => ticket.event_id and return
+    redirect_to(
+      controller: 'events', action: 'show', group_id: group.id,
+      id: ticket.event_id
+    ) && return
   end
 
   def request_ticket
     @group = Group.find_by_id(params[:group_id]) || not_found
     @event = Event.find_by_id(params[:event_id]) || not_found
     @ticket = Ticket.find_by_id(params[:id]) || not_found
-    if !@group.is_member(current_user)
-      raise "NotGroupMember"
-    end
+    fail 'NotGroupMember' unless @group.member?(current_user)
     @ticket_stats = @event.ticket_stats(@group, current_user)
   end
 
@@ -190,71 +212,73 @@ class TicketsController < ApplicationController
     group = Group.find_by_id(params[:group_id]) || not_found
     event = Event.find_by_id(params[:event_id]) || not_found
     ticket = Ticket.find_by_id(params[:id]) || not_found
-    if !group.is_member(current_user)
-      raise "NotGroupMember"
-    end
+    fail 'NotGroupMember' unless group.member?(current_user)
     message = params[:message][:personalization]
     TicketNotifier.request_ticket(ticket, current_user, message).deliver
     TwilioSMS.new.request_ticket(ticket, current_user)
     log_ticket_history ticket, 'requested'
     flash.keep
     flash[:notice] = 'Ticket request sent!'
-    redirect_to :controller => 'events', :action => 'show', :group_id => group.id, :id => event.id and return
+    redirect_to(
+      controller: 'events', action: 'show', group_id: group.id, id: event.id
+    ) && return
   end
 
   def unassign
     group = Group.find_by_id(params[:group_id]) || not_found
     event = Event.find_by_id(params[:event_id]) || not_found
     ticket = Ticket.find_by_id(params[:id]) || not_found
-    if ticket.owner_id != current_user.id && !ticket.assigned.nil? && ticket.assigned.id != current_user.id
-      raise 'AccessDenied'
-    end
+    fail 'AccessDenied' if ticket.owner_id != current_user.id && !ticket.assigned.nil? && ticket.assigned.id != current_user.id
     ticket.user_id = 0
     ticket.save!
     log_ticket_history ticket, 'unassigned'
     flash.keep
     flash[:notice] = 'Ticket unassigned!'
-    redirect_to :controller => 'events', :action => 'show', :group_id => group.id, :id => event.id and return
+    redirect_to(
+      controller: 'events', action: 'show', group_id: group.id, id: event.id
+    ) && return
   end
 
   def delete
     group = Group.find_by_id(params[:group_id]) || not_found
     event = Event.find_by_id(params[:event_id]) || not_found
     ticket = Ticket.find_by_id(params[:id]) || not_found
-    if ticket.owner_id != current_user.id
-      raise 'AccessDenied'
-    end
+    fail 'AccessDenied' if ticket.owner_id != current_user.id
     ticket.destroy!
     flash.keep
     flash[:notice] = 'Ticket deleted!'
-    redirect_to :controller => 'events', :action => 'show', :group_id => group.id, :id => event.id and return
+    redirect_to(
+      controller: 'events', action: 'show', group_id: group.id, id: event.id
+    ) && return
   end
 
   private
 
-  def log_ticket_history(ticket=nil, action=nil)
+  def log_ticket_history(ticket = nil, action = nil)
     user = User.find_by_id(ticket.user_id)
     if !user.nil?
       user_record = user.attributes
     else
       user_record = nil
     end
-    ticket_history = TicketHistory.new({
-      :event_id => ticket.event_id,
-      :user_id => current_user.id,
-      :ticket_id => ticket.id,
-      :group_id => ticket.group_id,
-      :entry => JSON.generate({
+    ticket_history = TicketHistory.new(
+      event_id: ticket.event_id,
+      user_id: current_user.id,
+      ticket_id: ticket.id,
+      group_id: ticket.group_id,
+      entry: JSON.generate(
         text: action,
         user: user_record,
         ticket: ticket.attributes
-      })
-    })
+      )
+    )
     ticket_history.save
   end
 
   def ticket_params
-    params.require(:ticket).permit(:section, :row, :seat, :cost, :user_id, :alias_id, :event_id, :note, :ticket_file)
+    params.require(:ticket).permit(
+      :section, :row, :seat, :cost, :user_id, :alias_id, :event_id, :note,
+      :ticket_file
+    )
   end
-
 end

--- a/app/controllers/user_aliases_controller.rb
+++ b/app/controllers/user_aliases_controller.rb
@@ -1,5 +1,4 @@
 class UserAliasesController < ApplicationController
-
   before_action :authenticate_user!
   layout 'two-column'
 
@@ -8,21 +7,21 @@ class UserAliasesController < ApplicationController
   end
 
   def create
-    user_alias = UserAlias.new({
+    user_alias = UserAlias.new(
       first_name: user_alias_params[:first_name],
       last_name: user_alias_params[:last_name],
       user_id: current_user.id
-    })
+    )
     user_alias.save!
     flash.keep
     flash[:notice] = 'User alias created!'
-    redirect_to :controller => 'profiles', :action => 'edit' and return
+    redirect_to(controller: 'profiles', action: 'edit') && return
   end
 
   def edit
     @user_alias = UserAlias.find_by_id(params[:id]) || not_found
     if @user_alias.user_id != current_user.id
-      redirect_to :controller => 'profiles', :action => 'edit' and return
+      redirect_to(controller: 'profiles', action: 'edit') && return
     end
   end
 
@@ -33,18 +32,18 @@ class UserAliasesController < ApplicationController
     user_alias.save!
     flash.keep
     flash[:notice] = 'User Alias updated!'
-    redirect_to :controller => 'profiles', :action => 'edit' and return
+    redirect_to(controller: 'profiles', action: 'edit') && return
   end
 
   def delete
     user_alias = UserAlias.find_by_id(params[:id]) || not_found
     if user_alias.user_id != current_user.id
-      redirect_to :controller => 'profiles', :action => 'edit' and return
+      redirect_to(controller: 'profiles', action: 'edit') && return
     end
     user_alias.destroy
     flash.keep
     flash[:notice] = 'User Alias deleted.'
-    redirect_to :controller => 'profiles', :action => 'edit' and return
+    redirect_to(controller: 'profiles', action: 'edit') && return
   end
 
   private
@@ -52,5 +51,4 @@ class UserAliasesController < ApplicationController
   def user_alias_params
     params.require(:user_alias).permit(:first_name, :last_name, :user_id)
   end
-
 end

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -1,12 +1,11 @@
 class CustomDeviseMailer < Devise::Mailer
-  default from: "no-reply@myseatshare.com"
+  default from: 'no-reply@myseatshare.com'
   layout 'email'
 
-  helper :application # gives access to all helpers defined within `application_helper`.
-  include Devise::Controllers::UrlHelpers # Optional. eg. `confirmation_url`
+  helper :application
+  include Devise::Controllers::UrlHelpers
 
-  def confirmation_instructions(record, token, opts={})
-
+  def confirmation_instructions(record, token, opts = {})
     @view_action = {
       url: url_for(confirmation_url(record, confirmation_token: @token)),
       action: 'Confirm Account',
@@ -19,8 +18,7 @@ class CustomDeviseMailer < Devise::Mailer
     super
   end
 
-  def reset_password_instructions(record, token, opts={})
-
+  def reset_password_instructions(record, token, opts = {})
     @view_action = {
       url: url_for(edit_password_url(record, reset_password_token: @token)),
       action: 'Reset Password',
@@ -33,8 +31,7 @@ class CustomDeviseMailer < Devise::Mailer
     super
   end
 
-  def unlock_instructions(record, token, opts={})
-
+  def unlock_instructions(record, token, opts = {})
     @view_action = {
       url: url_for(unlock_url(record, unlock_token: @token)),
       action: 'Unlock Account',
@@ -46,5 +43,4 @@ class CustomDeviseMailer < Devise::Mailer
     headers['X-MC-SigningDomain'] = 'myseatshare.com'
     super
   end
-
 end

--- a/app/mailers/group_notifier.rb
+++ b/app/mailers/group_notifier.rb
@@ -1,15 +1,18 @@
 class GroupNotifier < ActionMailer::Base
-  default from: "no-reply@myseatshare.com"
+  default from: 'no-reply@myseatshare.com'
   layout 'email'
 
-  def create_invite(invite, message=nil)
+  def create_invite(invite, message = nil)
     @invite = invite
     @recipient = invite.email
     @user = invite.user
     @group = invite.group
     @personalized = message
     @view_action = {
-      url: url_for(:controller => 'registrations', :action => 'new', :invite_code => @invite.invitation_code, :only_path => false),
+      url: url_for(
+        controller: 'registrations', action: 'new',
+        invite_code: @invite.invitation_code, only_path: false
+      ),
       action: 'Accept Invitation',
       description: 'You have received an invitation.'
     }
@@ -23,11 +26,9 @@ class GroupNotifier < ActionMailer::Base
     headers['X-MC-Tags'] = 'InviteUser'
     headers['X-MC-Subaccount'] = 'SeatShare'
     headers['X-MC-SigningDomain'] = 'myseatshare.com'
-
   end
 
-  def send_group_message(group, sender, recipients, subject=nil, message=nil)
-
+  def send_group_message(group, sender, recipients, subject, message)
     if group.blank? || sender.blank? || recipients.blank? || message.blank?
       return false
     end
@@ -45,13 +46,13 @@ class GroupNotifier < ActionMailer::Base
     @message = message
 
     @view_action = {
-      url: url_for(:controller => 'groups', :id => @group.id, :only_path => false),
+      url: url_for(controller: 'groups', id: @group.id, only_path: false),
       action: 'View Group',
       description: 'You have received a message.'
     }
 
     @email_recipients = []
-    for recipient in recipients
+    recipients.each do |recipient|
       @email_recipients << "#{recipient.display_name} <#{recipient.email}>"
     end
 
@@ -64,7 +65,5 @@ class GroupNotifier < ActionMailer::Base
     headers['X-MC-Tags'] = 'GroupMessage'
     headers['X-MC-Subaccount'] = 'SeatShare'
     headers['X-MC-SigningDomain'] = 'myseatshare.com'
-
   end
-
 end

--- a/app/mailers/schedule_notifier.rb
+++ b/app/mailers/schedule_notifier.rb
@@ -1,17 +1,19 @@
 class ScheduleNotifier < ActionMailer::Base
-  default from: "no-reply@myseatshare.com"
+  default from: 'no-reply@myseatshare.com'
   layout 'email'
 
   def daily_schedule(events, group, user)
-
-    set_timezone user
+    timezone user
 
     @events = events
     @group = group
     @user = user
 
     @view_action = {
-      url: url_for(:controller => 'groups', :action => 'show', :id => @group.id, :only_path => false),
+      url: url_for(
+        controller: 'groups', action: 'show',
+        id: @group.id, only_path: false
+      ),
       action: 'View Tickets',
       description: 'See available tickets.'
     }
@@ -27,23 +29,17 @@ class ScheduleNotifier < ActionMailer::Base
   end
 
   def weekly_schedule(events, group, user)
-    events_day_of_week = []
-    for day_of_week, index in Date::DAYNAMES.each_with_index.to_a.rotate(1)
-      events_day_of_week[index] = []
-      for event in events
-        next if event.start_time.wday != index
-        events_day_of_week[index] << event
-      end
-    end
+    timezone user
 
-    set_timezone user
-
-    @events_day_of_week = events_day_of_week
+    @events_day_of_week = events_day_of_week(events)
     @group = group
     @user = user
 
     @view_action = {
-      url: url_for(:controller => 'groups', :action => 'show', :id => @group.id, :only_path => false),
+      url: url_for(
+        controller: 'groups', action: 'show', id: @group.id,
+        only_path: false
+      ),
       action: 'View Tickets',
       description: 'See available tickets.'
     }
@@ -60,13 +56,24 @@ class ScheduleNotifier < ActionMailer::Base
 
   private
 
-  def set_timezone(user)
+  def events_day_of_week(events)
+    events_day_of_week = []
+    for day_of_week, index in Date::DAYNAMES.each_with_index.to_a.rotate(1)
+      events_day_of_week[index] = []
+      events.each do |event|
+        next if event.start_time.wday != index
+        events_day_of_week[index] << event
+      end
+    end
+    events_day_of_week
+  end
+
+  def timezone(user)
     tz = user ? user.timezone : nil
     if tz.blank?
-      Time.zone = ActiveSupport::TimeZone["Central Time (US & Canada)"]
+      Time.zone = ActiveSupport::TimeZone['Central Time (US & Canada)']
     else
       Time.zone = tz
     end
   end
-
 end

--- a/app/mailers/ticket_notifier.rb
+++ b/app/mailers/ticket_notifier.rb
@@ -1,8 +1,8 @@
 class TicketNotifier < ActionMailer::Base
-  default from: "no-reply@myseatshare.com"
+  default from: 'no-reply@myseatshare.com'
   layout 'email'
 
-  def assign(ticket=nil, acting_user=nil)
+  def assign(ticket = nil, acting_user = nil)
     @ticket = ticket
     @event = ticket.event
     @recipient = ticket.assigned
@@ -10,14 +10,19 @@ class TicketNotifier < ActionMailer::Base
     @user = acting_user
 
     @view_action = {
-      url: url_for(:controller => 'tickets', :action => 'edit', :group_id => @ticket.group_id, :event_id => @ticket.event_id, :id => @ticket.id, :only_path => false),
+      url: url_for(
+        controller: 'tickets', action: 'edit', group_id: @ticket.group_id,
+        event_id: @ticket.event_id, id: @ticket.id, only_path: false
+      ),
       action: 'View Ticket',
       description: 'You have been assigned a ticket.'
     }
 
     mail(
       to: "#{@recipient.display_name} <#{@recipient.email}>",
-      subject: "#{@user.first_name} has assigned you a ticket via #{@group.group_name}",
+      subject:
+        "#{@user.first_name} has assigned you a ticket via "\
+        "#{@group.group_name}",
       reply_to: "#{@user.display_name} <#{@user.email}>"
     )
 
@@ -26,7 +31,7 @@ class TicketNotifier < ActionMailer::Base
     headers['X-MC-SigningDomain'] = 'myseatshare.com'
   end
 
-  def request_ticket(ticket=nil, user=nil, message=nil)
+  def request_ticket(ticket = nil, user = nil, message = nil)
     @ticket = ticket
     @event = ticket.event
     @recipient = ticket.owner
@@ -35,14 +40,19 @@ class TicketNotifier < ActionMailer::Base
     @message = message
 
     @view_action = {
-      url: url_for(:controller => 'tickets', :action => 'edit', :group_id => @ticket.group_id, :event_id => @ticket.event_id, :id => @ticket.id, :only_path => false),
+      url: url_for(
+        controller: 'tickets', action: 'edit', group_id: @ticket.group_id,
+        event_id: @ticket.event_id, id: @ticket.id, only_path: false
+      ),
       action: 'Assign Ticket',
       description: 'Your ticket has been requested.'
     }
 
     mail(
       to: "#{@recipient.display_name} <#{@recipient.email}>",
-      subject: "#{@user.first_name} has requested your ticket via #{@group.group_name}",
+      subject:
+        "#{@user.first_name} has requested your ticket via"\
+        " #{@group.group_name}",
       reply_to: "#{@user.display_name} <#{@user.email}>"
     )
 

--- a/app/mailers/welcome_email.rb
+++ b/app/mailers/welcome_email.rb
@@ -1,19 +1,18 @@
 class WelcomeEmail < ActionMailer::Base
-  default from: "no-reply@myseatshare.com"
+  default from: 'no-reply@myseatshare.com'
   layout 'email'
 
-  def welcome(user=nil)
+  def welcome(user = nil)
     @recipient = user
 
     mail(
       to: "#{@recipient.display_name} <#{@recipient.email}>",
       subject: "Welcome to SeatShare, #{@recipient.first_name}!",
-      reply_to: "SeatShare Support <contact@myseatshare.com>"
+      reply_to: 'SeatShare Support <contact@myseatshare.com>'
     )
 
     headers['X-MC-Tags'] = 'NewUser'
     headers['X-MC-Subaccount'] = 'SeatShare'
     headers['X-MC-SigningDomain'] = 'myseatshare.com'
   end
-
 end

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -1,6 +1,6 @@
 class AdminUser < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, 
+  devise :database_authenticatable,
          :recoverable, :rememberable, :trackable, :validatable
 end

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -3,18 +3,18 @@ class Entity < ActiveRecord::Base
   has_many :groups
   has_many :events
 
-  validates :entity_name, :presence => true
+  validates :entity_name, presence: true
   validates_uniqueness_of :entity_name, scope: :entity_type
   before_save :clean_import_key
 
-  scope :order_by_name, -> { order('LOWER(entity_type) ASC, LOWER(entity_name) ASC') }
+  scope :order_by_name, -> { order_by_name }
   scope :active, -> { where('status = 1') }
   scope :is_soda, -> { where("import_key LIKE 'l.%'") }
 
-  def initialize(attributes={})
+  def initialize(attributes = {})
     attr_with_defaults = {
-      :status => 0,
-      :import_key => generate_import_key(attributes)
+      status: 0,
+      import_key: generate_import_key(attributes)
     }.merge(attributes)
     super(attr_with_defaults)
   end
@@ -25,13 +25,13 @@ class Entity < ActiveRecord::Base
 
   def retrive_schedule
     importer = SodaScheduleImport.new
-    importer.run({
+    importer.run(
       team_id: import_key,
       start_datetime: DateTime.now.beginning_of_day - 30.days,
       end_datetime: DateTime.now.end_of_day,
       force_update: false
-    })
-    return importer
+    )
+    importer
   end
 
   private
@@ -41,9 +41,10 @@ class Entity < ActiveRecord::Base
   end
 
   def clean_import_key
-    if self.import_key.blank?
-      self.import_key = generate_import_key(self)
-    end
+    self.import_key = generate_import_key(self) if import_key.blank?
   end
 
+  def self.order_by_name
+    order('LOWER(entity_type) ASC, LOWER(entity_name) ASC')
+  end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,37 +1,39 @@
 class Group < ActiveRecord::Base
   belongs_to :entity
-  belongs_to :creator, :class_name => 'User'
+  belongs_to :creator, class_name: 'User'
 
   has_many :group_users
   has_many :users, through: :group_users
   has_many :events, through: :entity
 
-  validates :entity_id, :group_name, :creator_id, :presence => true
+  validates :entity_id, :group_name, :creator_id, presence: true
   before_save :clean_invitation_code
 
-  has_attached_file :avatar,
-                    :styles => { :medium => "300x300>", :thumb => "100x100>" },
-                    :default_url => ':placeholder_group',
-                    :storage => :s3,
-                    :s3_credentials => {
-                      :bucket => ENV['SEATSHARE_S3_BUCKET'],
-                      :access_key_id => ENV['SEATSHARE_S3_KEY'],
-                      :secret_access_key => ENV['SEATSHARE_S3_SECRET']
-                    },
-                    :url => ':s3_alias_url',
-                    :s3_host_alias => ENV['SEATSHARE_S3_PUBLIC'].gsub("http://",""),
-                    :path => ":class-avatars/:id-:style-:hash.:extension",
-                    :hash_secret => "obfusticateOurAvatarUrlsPlz"
+  has_attached_file(
+    :avatar,
+    styles: { medium: '300x300>', thumb: '100x100>' },
+    default_url: ':placeholder_group',
+    storage: :s3,
+    s3_credentials: {
+      bucket: ENV['SEATSHARE_S3_BUCKET'],
+      access_key_id: ENV['SEATSHARE_S3_KEY'],
+      secret_access_key: ENV['SEATSHARE_S3_SECRET']
+    },
+    url: ':s3_alias_url',
+    s3_host_alias: ENV['SEATSHARE_S3_PUBLIC'].gsub('http://', ''),
+    path: ':class-avatars/:id-:style-:hash.:extension',
+    hash_secret: 'obfusticateOurAvatarUrlsPlz'
+  )
 
-  validates_attachment_content_type :avatar, :content_type => /\Aimage\/.*\Z/
+  validates_attachment_content_type :avatar, content_type: /\Aimage\/.*\Z/
 
   scope :order_by_name, -> { order('LOWER(group_name) ASC') }
   scope :active, -> { where('status = 1') }
 
-  def initialize(attributes={})
+  def initialize(attributes = {})
     attr_with_defaults = {
-      :status => 1,
-      :invitation_code => generate_invite_code(10)
+      status: 1,
+      invitation_code: generate_invite_code(10)
     }.merge(attributes)
     super(attr_with_defaults)
   end
@@ -44,66 +46,59 @@ class Group < ActiveRecord::Base
     users.where(group_users: { role: 'admin' })
   end
 
-  def is_member(user=nil)
-    group_user = GroupUser.where("group_id = #{self.id} AND user_id = #{user.id}").first
-    if group_user.nil?
-      return false
-    end
-    return group_user.user_id == user.id
+  def member?(user = nil)
+    group_user = GroupUser.where(
+      "group_id = #{id} AND user_id = #{user.id}"
+    ).first
+    return false if group_user.nil?
+    group_user.user_id == user.id
   end
 
-  def is_admin(user=nil)
-    group_user = GroupUser.where("group_id = #{self.id} AND user_id = #{user.id} AND role = 'admin'").first
-    if group_user.nil?
-      return false
-    end
-    return group_user.user_id == user.id
+  def admin?(user = nil)
+    group_user = GroupUser.where(
+      "group_id = #{id} AND user_id = #{user.id} AND role = 'admin'"
+    ).first
+    return false if group_user.nil?
+    group_user.user_id == user.id
   end
 
-  def join_group(user=nil, role=nil)
-    if role != 'admin'
-      role = 'member'
-    end
-    if self.id === nil
-      return "NotValidGroup"
-    end
-    user_group = GroupUser.new({
-      :user_id => user.id,
-      :group_id => self.id,
-      :role => role
-    })
+  def join_group(user = nil, role = nil)
+    role = 'member' if role != 'admin'
+    fail 'NotValidGroup' if id.nil?
+    user_group = GroupUser.new(
+      user_id: user.id,
+      group_id: id,
+      role: role
+    )
     user_group.save!
-    return user_group
+    user_group
   end
 
-  def leave_group(user=nil)
-    group_user = GroupUser.where("user_id = #{user.id} AND group_id = #{self.id}").first
-    if group_user.role == 'admin'
-      raise "AdminUserCannotLeave"
-    end
+  def leave_group(user = nil)
+    group_user = GroupUser.where(
+      "user_id = #{user.id} AND group_id = #{id}"
+    ).first
+    fail 'AdminUserCannotLeave' if group_user.role == 'admin'
 
-    Ticket.where("group_id = #{self.id} AND owner_id = #{user.id}").delete_all
-    Ticket.where("group_id = #{self.id} AND user_id = #{user.id}").update_all({
-      :user_id => 0,
-      :alias_id => 0
-    })
+    Ticket.where("group_id = #{id} AND owner_id = #{user.id}").delete_all
+    Ticket.where("group_id = #{id} AND user_id = #{user.id}").update_all(
+      user_id: 0,
+      alias_id: 0
+    )
 
-    ActiveRecord::Base.connection.execute("DELETE FROM group_users WHERE group_id = #{self.id} AND user_id = #{user.id}")
-
+    ActiveRecord::Base.connection.execute(
+      "DELETE FROM group_users WHERE group_id = #{id} AND user_id = #{user.id}"
+    )
   end
 
   private
 
   def clean_invitation_code
-    if self.invitation_code.blank?
-      self.invitation_code = generate_invite_code(10)
-      puts self.invitation_code
-    end
+    self.invitation_code = generate_invite_code(10) if invitation_code.blank?
   end
 
   def generate_invite_code(size = 10)
-    charset = %w{ 2 3 4 6 7 9 A C D E F G H J K M N P Q R T V W X Y Z}
-    (0...size).map{ charset.to_a[rand(charset.size)] }.join
+    charset = %w(2 3 4 6 7 9 A C D E F G H J K M N P Q R T V W X Y Z)
+    (0...size).map { charset.to_a[rand(charset.size)] }.join
   end
-
 end

--- a/app/models/group_invitation.rb
+++ b/app/models/group_invitation.rb
@@ -2,15 +2,15 @@ class GroupInvitation < ActiveRecord::Base
   belongs_to :group
   belongs_to :user
 
-  validates :email, :user_id, :group_id, :invitation_code, :presence => true
+  validates :email, :user_id, :group_id, :invitation_code, presence: true
 
   scope :accepted, -> { where('status = 0') }
   attr_accessor :message
 
-  def initialize(attributes={})
+  def initialize(attributes = {})
     attr_with_defaults = {
-      :status => 1,
-      :invitation_code => generate_invite_code
+      status: 1,
+      invitation_code: generate_invite_code
     }.merge(attributes)
     super(attr_with_defaults)
   end
@@ -19,38 +19,33 @@ class GroupInvitation < ActiveRecord::Base
     "#{group.group_name}: #{email}"
   end
 
-  def self.get_by_invitation_code(invitation_code=nil)
-    if invitation_code.length != 10
-      raise "InvalidInvitation"
-    end
-    invitation = GroupInvitation.where("invitation_code = '#{invitation_code}'").first
-    if invitation.nil?
-      raise "InvalidInvitation"
-    end
-    return invitation
+  def self.get_by_invitation_code(invitation_code = nil)
+    fail 'InvalidInvitation' if invitation_code.length != 10
+    invitation = GroupInvitation.where(
+      "invitation_code = '#{invitation_code}'"
+    ).first
+    fail 'InvalidInvitation' if invitation.nil?
+    invitation
   end
 
   def use_invitation
-    if self.status === 0
-      raise "InvitationAlreadyUsed"
-    end
+    fail 'InvitationAlreadyUsed' if status == 0
     self.status = 0
     self.save!
   end
 
   def user
-    User.find_by_id(self.user_id)
+    User.find_by_id(user_id)
   end
 
   def group
-    Group.find_by_id(self.group_id)
+    Group.find_by_id(group_id)
   end
 
   private
 
   def generate_invite_code(size = 10)
-    charset = %w{ 2 3 4 6 7 9 A C D E F G H J K M N P Q R T V W X Y Z}
-    (0...size).map{ charset.to_a[rand(charset.size)] }.join
+    charset = %w(2 3 4 6 7 9 A C D E F G H J K M N P Q R T V W X Y Z)
+    (0...size).map { charset.to_a[rand(charset.size)] }.join
   end
-
 end

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -2,10 +2,10 @@ class GroupUser < ActiveRecord::Base
   belongs_to :group
   belongs_to :user
 
-  def initialize(attributes={})
+  def initialize(attributes = {})
     attr_with_defaults = {
-      :daily_reminder => 1,
-      :weekly_reminder => 1
+      daily_reminder: 1,
+      weekly_reminder: 1
     }.merge(attributes)
     super(attr_with_defaults)
   end
@@ -13,5 +13,4 @@ class GroupUser < ActiveRecord::Base
   def display_name
     "#{user} - #{group}"
   end
-
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -4,5 +4,4 @@ class Profile < ActiveRecord::Base
   def mobile_e164
     GlobalPhone.normalize(mobile)
   end
-
 end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -2,40 +2,42 @@ class Ticket < ActiveRecord::Base
   has_many :ticket_files
   has_many :ticket_histories
   belongs_to :event
-  belongs_to :group, :class_name => 'Group'
-  belongs_to :user, :class_name => 'User'
-  belongs_to :owner, :class_name => 'User'
-  belongs_to :alias, :class_name => 'UserAlias'
-  
-  validate :has_seat_location
-  validates :group_id, :event_id, :owner_id, :user_id, :presence => true
-  validates :cost, :numericality => { :greater_than_or_equal_to => 0 }
+  belongs_to :group, class_name: 'Group'
+  belongs_to :user, class_name: 'User'
+  belongs_to :owner, class_name: 'User'
+  belongs_to :alias, class_name: 'UserAlias'
+
+  validate :seat_location?
+  validates :group_id, :event_id, :owner_id, :user_id, presence: true
+  validates :cost, numericality: { greater_than_or_equal_to: 0 }
 
   scope :order_by_date, -> { order('start_time ASC') }
-  scope :order_by_seat, -> { order('section ASC').order('row ASC').order('seat ASC') }
+  scope :order_by_seat, -> { order_by_seat }
 
   def display_name
-    [self.section, self.row, self.seat].join(" ").strip
+    [section, row, seat].join(' ').strip
   end
 
   def assigned
-    User.find_by_id(self.user_id)
+    User.find_by_id(user_id)
   end
 
-  def is_available?
-    !!(self.user_id === 0)
+  def available?
+    user_id == 0
   end
 
-  def is_assigned?
-    !!(self.user_id > 0)
+  def assigned?
+    user_id > 0
   end
 
   private
 
-  def has_seat_location
-    if [self.section, self.row, self.seat].reject(&:blank?).size == 0
-      errors[:base] << ("Ticket must have a section, row or seat")
-    end
+  def seat_location?
+    empty_error = 'Ticket must have a section, row or seat'
+    errors[:base] << (empty_error) if display_name.blank?
   end
 
+  def self.order_by_seat
+    order('section ASC').order('row ASC').order('seat ASC')
+  end
 end

--- a/app/models/ticket_file.rb
+++ b/app/models/ticket_file.rb
@@ -1,10 +1,9 @@
 class TicketFile < ActiveRecord::Base
   belongs_to :ticket
 
-  validates :user_id, :ticket_id, :path, :file_name, :presence => true
+  validates :user_id, :ticket_id, :path, :file_name, presence: true
 
   def download_link
-    "#{ENV['SEATSHARE_S3_PUBLIC']}/#{self.path}"
+    "#{ENV['SEATSHARE_S3_PUBLIC']}/#{path}"
   end
-
 end

--- a/app/models/ticket_history.rb
+++ b/app/models/ticket_history.rb
@@ -4,16 +4,15 @@ class TicketHistory < ActiveRecord::Base
   belongs_to :event
   belongs_to :group
 
-  validates :ticket_id, :group_id, :event_id, :user_id, :entry, :presence => true
+  validates :ticket_id, :group_id, :event_id, :user_id, :entry, presence: true
 
   def display_name
     entry = JSON.parse(self.entry)
-    user = User.find(self.user_id)
+    user = User.find(user_id)
     "#{user.display_name} #{entry['text']}"
   end
 
   def date_time
-    self.created_at.strftime('%-m/%-d/%Y %-I:%M %P')
+    created_at.strftime('%-m/%-d/%Y %-I:%M %P')
   end
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,12 +9,12 @@ class User < ActiveRecord::Base
   has_many :group_users
   has_many :groups, through: :group_users
   has_one :profile
-  
+
   accepts_nested_attributes_for :profile
 
-  validates :first_name, :last_name, :email, :presence => true
+  validates :first_name, :last_name, :email, presence: true
 
-  scope :order_by_name, -> { order('LOWER(last_name) ASC, LOWER(first_name) ASC') }
+  scope :order_by_name, -> { order_by_name }
   scope :active, -> { where('status = 1') }
 
   attr_accessor :entity_id
@@ -22,12 +22,12 @@ class User < ActiveRecord::Base
   attr_accessor :invite_code
 
   def active_for_authentication?
-    super && status === 1
+    super && status == 1
   end
 
-  def initialize(attributes={})
+  def initialize(attributes = {})
     attr_with_defaults = {
-      :status => 1,
+      status: 1
     }.merge(attributes)
     super(attr_with_defaults)
   end
@@ -36,11 +36,14 @@ class User < ActiveRecord::Base
     "#{first_name} #{last_name}"
   end
 
-  def gravatar(dimensions='30x30')
+  def gravatar(dimensions = '30x30')
     require 'digest/md5'
-    email_address = self.email.downcase
+    email_address = email.downcase
     hash = Digest::MD5.hexdigest(email_address)
     "https://www.gravatar.com/avatar/#{hash}?s=#{dimensions}&d=mm"
   end
 
+  def self.order_by_name
+    order('LOWER(last_name) ASC, LOWER(first_name) ASC')
+  end
 end

--- a/app/models/user_alias.rb
+++ b/app/models/user_alias.rb
@@ -1,21 +1,24 @@
 class UserAlias < ActiveRecord::Base
   belongs_to :user
 
-  validates :first_name, :last_name, :user_id, :presence => true
+  validates :first_name, :last_name, :user_id, presence: true
 
-  scope :order_by_name, -> { order('LOWER(last_name) ASC, LOWER(first_name) ASC') }
+  scope :order_by_name, -> { order_by_name }
 
   def display_name
-    "#{self.first_name} #{self.last_name}"
+    "#{first_name} #{last_name}"
   end
 
   def destroy
-    tickets = Ticket.where("alias_id = #{self.id}")
-    for ticket in tickets
+    tickets = Ticket.where("alias_id = #{id}")
+    tickets.each do |ticket|
       ticket.alias_id = 0
       ticket.save!
     end
     super
   end
 
+  def self.order_by_name
+    order('LOWER(last_name) ASC, LOWER(first_name) ASC')
+  end
 end

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title do %>Edit Group<% end %>
 
-<% if @group.is_admin(current_user) %>
+<% if @group.admin?(current_user) %>
 
 <%= form_for @group, url: edit_group_path, html: { class: "form-horizontal", role: "form", multipart: true } do |f| %>
 
@@ -74,7 +74,7 @@
           <th class="action"></th>
           <th>Name</th>
           <th>Email</th>
-          <% if @group.is_admin(current_user) %>
+          <% if @group.admin?(current_user) %>
             <th class="action"></th>
           <% end %>
         </tr>
@@ -85,7 +85,7 @@
           <td><%= image_tag member.gravatar, :alt => member.display_name, :title => member.display_name %></td>
           <td><%= link_to member.display_name, {:controller => 'profiles', :action => 'show', :id => member.id } %></td>
           <td><%= mail_to member.email %></td>
-          <% if @group.is_admin(current_user) %>
+          <% if @group.admin?(current_user) %>
             <td class="remove-user">
               <% if member != current_user %>
                 <%= link_to raw('<span class="fa fa-trash"></span>'), { :action => 'leave', :user_id => member.id, :id => @group.id }, :class => 'btn btn-sm btn-danger confirm', :method => 'post' %>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -11,7 +11,7 @@
 		<div class="panel panel-default">
 			<div class="panel-heading">
 				<div class="pull-right">
-					<% if group.is_admin(current_user) %>
+					<% if group.admin?(current_user) %>
 					<%= link_to raw('<span class="label label-primary">Administrator</span>'), :action => 'edit', :id => group.id %>
 					<% else %>
 					<%= link_to raw('<span class="label label-default">Member</span>'), :action => 'edit', :id => group.id %>
@@ -29,7 +29,7 @@
 				<hr />
 				<ul class="list-inline text-center">
 					<li><%= link_to 'Switch to Group', {:action => 'show', :id => group.id }, :class => 'btn btn-default' %></li>
-					<% if !group.is_admin(current_user) %>
+					<% if !group.admin?(current_user) %>
 					<li><%= link_to 'Leave Group', {:action => 'leave', :id => group.id }, :class => 'btn btn-default' %></li>
 					<% end %>
 				</ul>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -47,7 +47,7 @@
     <table class="table">
       <tbody>
         <% for ticket in tickets %>
-        <% next if ticket.is_assigned? %>
+        <% next if ticket.assigned? %>
         <tr>
           <td>
             <%= link_to ticket.display_name, :controller => 'tickets', :action => 'edit', :group_id => @group.id, :event_id => event.id, :id => ticket.id %>
@@ -104,7 +104,7 @@
       <table class="table">
         <tbody>
           <% for ticket in tickets %>
-          <% next if ticket.is_assigned? %>
+          <% next if ticket.assigned? %>
           <tr>
             <td>
               <%= link_to ticket.display_name, :controller => 'tickets', :action => 'edit', :group_id => @group.id, :event_id => event.id, :id => ticket.id %>

--- a/app/views/schedule_notifier/daily_schedule.html.erb
+++ b/app/views/schedule_notifier/daily_schedule.html.erb
@@ -34,7 +34,7 @@
       <table width="100%" cellpadding="10px">
         <tbody>
           <% for ticket in tickets %>
-          <% next if ticket.is_assigned? %>
+          <% next if ticket.assigned? %>
           <tr>
             <td>
               <%= link_to ticket.display_name, { :controller => 'tickets', :action => 'edit', :group_id => @group.id, :event_id => ticket.event_id, :id => ticket.id, :only_path => false } %>

--- a/app/views/schedule_notifier/weekly_schedule.html.erb
+++ b/app/views/schedule_notifier/weekly_schedule.html.erb
@@ -43,7 +43,7 @@
       <table width="100%" cellpadding="10px">
         <tbody>
           <% for ticket in tickets %>
-          <% next if ticket.is_assigned? %>
+          <% next if ticket.assigned? %>
           <tr>
             <td><%= link_to ticket.display_name, { :controller => 'tickets', :action => 'edit', :group_id => @group.id, :event_id => ticket.event_id, :id => ticket.id, :only_path => false } %></td>
             <td>via <%= ticket.owner.display_name; %></td>

--- a/lib/google_analytics_api.rb
+++ b/lib/google_analytics_api.rb
@@ -2,25 +2,30 @@ require 'rest_client'
 
 # https://deveo.com/blog/2013/05/07/server-side-google-analytics-event-tracking-with-rails/
 class GoogleAnalyticsApi
-
   def event(category, action, client_id = '555')
     return unless ENV['GOOGLE_ANALYTICS_ID'].present?
-
     params = {
       v: 1,
       tid: ENV['GOOGLE_ANALYTICS_ID'],
       cid: client_id,
-      t: "event",
+      t: 'event',
       ec: category,
       ea: action
     }
-
-    begin
-      RestClient.get('http://www.google-analytics.com/collect', params: params, timeout: 4, open_timeout: 4)
-      return true
-    rescue  RestClient::Exception => rex
-      return false
-    end
+    send_event params
   end
 
+  private
+
+  def send_event
+    RestClient.get(
+      'http://www.google-analytics.com/collect',
+      params: params,
+      timeout: 4,
+      open_timeout: 4
+    )
+    return true
+  rescue RestClient::Exception
+    return false
+  end
 end

--- a/lib/soda_schedule_import.rb
+++ b/lib/soda_schedule_import.rb
@@ -1,37 +1,38 @@
 class SodaScheduleImport
-
   attr_accessor :soda_client, :messages, :events_list
 
   def initialize
-    self.soda_client = SodaXmlTeam::Client.new(ENV['SODA_USERNAME'], ENV['SODA_PASSWORD'])
+    self.soda_client = SodaXmlTeam::Client.new(
+      ENV['SODA_USERNAME'], ENV['SODA_PASSWORD']
+    )
     self.messages = []
     self.events_list = []
   end
 
-  def run(options={})
+  def run(options = {})
     entity = Entity.find_by_import_key(options[:team_id])
     if entity.blank?
-      self.messages << "Could not find an entity that matched #{options[:team_id]}"
+      messages << "Could not find an entity that matched #{options[:team_id]}"
       return
     end
 
     # Get listing for desired league
     begin
-      documents = self.soda_client.content_finder({
+      documents = soda_client.content_finder(
         sandbox: ENV['SODA_ENVIRONMENT'] != 'production',
-        league_id: options[:team_id].split("-")[0],
+        league_id: options[:team_id].split('-')[0],
         team_id: options[:team_id],
         type: 'schedule-single-team',
-        start_datetime: options[:start_datetime].is_a?(String) ? DateTime.parse(options[:start_datetime]) : options[:start_datetime],
-        end_datetime: options[:end_datetime].is_a?(String) ? DateTime.parse(options[:end_datetime]) : options[:start_datetime]
-      })
+        start_datetime: options[:start_datetime],
+        end_datetime: options[:start_datetime]
+      )
     rescue
       documents = []
     end
 
     # See if there were any documents at all
-    if documents.length === 0 || !documents[0][:document_id]
-      self.messages << "No events were available for #{entity.entity_name}."
+    if documents.length == 0 || !documents[0][:document_id]
+      messages << "No events were available for #{entity.entity_name}."
       return
     end
 
@@ -40,18 +41,20 @@ class SodaScheduleImport
 
     # Check to see if you already have this document ID in S3
     s3 = AWS::S3.new
-    if s3.buckets[ENV['SEATSHARE_S3_BUCKET']].objects["soda/#{document_id}"].exists?
-      if !options[:force_update]
-        self.messages << "The latest schedule for #{entity.entity_name} (#{document_id}) has already been processed."
+    objects = s3.buckets[ENV['SEATSHARE_S3_BUCKET']].objects
+    if objects["soda/#{document_id}"].exists?
+      unless options[:force_update]
+        messages << "The latest schedule for #{entity.entity_name}"\
+          "(#{document_id}) has already been processed."
         return
       end
     end
 
     # Retrieve the document (this counts as using an API credit)
-    schedule_document = self.soda_client.get_document({
+    schedule_document = soda_client.get_document(
       sandbox: ENV['SODA_ENVIRONMENT'] != 'production',
       document_id: document_id
-    })
+    )
 
     # Cache the document to prevent re-downloads
     File.open File.join(Rails.root, 'tmp', 'soda', document_id), 'w' do |file|
@@ -61,28 +64,26 @@ class SodaScheduleImport
     # Store this file in S3
     File.open File.join(Rails.root, 'tmp', 'soda', document_id), 'rb' do |file|
       s3 = AWS::S3.new
-      object = s3.buckets[ENV['SEATSHARE_S3_BUCKET']].objects["soda/#{document_id}"]
+      object = s3.buckets[ENV['SEATSHARE_S3_BUCKET']]
+               .objects["soda/#{document_id}"]
       object.write(open(file))
     end
 
     # Parse the schedule and create the events
     schedule = SodaXmlTeam::Schedule.parse_schedule(schedule_document)
-    for row in schedule
+    schedule.each do |row|
 
       # Map in entity_id for import
       row[:entity_id] = entity.id
 
       # Skip the away games
-      if row[:home_team_id] != options[:team_id]
-        next
-      end
+      next unless row[:home_team_id] == options[:team_id]
 
       # Create or update the row
-      self.events_list << Event.import(row)
+      events_list << Event.import(row)
     end
 
     # Done with that team
-    self.messages << "#{entity.entity_name} schedule imported!"
+    messages << "#{entity.entity_name} schedule imported!"
   end
-
 end

--- a/lib/twilio_sms.rb
+++ b/lib/twilio_sms.rb
@@ -1,59 +1,51 @@
-require "twilio-ruby"
+require 'twilio-ruby'
 
 class TwilioSMS
-
   attr_accessor :twilio_client
 
   def initialize
-    self.twilio_client = Twilio::REST::Client.new(ENV['TWILIO_ACCOUNT_SID'], ENV['TWILIO_AUTH_TOKEN'])
+    self.twilio_client = Twilio::REST::Client.new(
+      ENV['TWILIO_ACCOUNT_SID'], ENV['TWILIO_AUTH_TOKEN']
+    )
   end
 
   def assign_ticket(ticket, acting_user)
-    if ticket.assigned.profile.mobile.blank? || ticket.assigned.profile.sms_notify != true
-      return false
-    end
-    begin
-      send = self.twilio_client.messages.create(
-        from: ENV['TWILIO_OUTBOUND_NUMBER'],
-        to: ticket.assigned.profile.mobile_e164,
-        body: "#{acting_user.first_name} has assigned you #{ticket.display_name} for #{ticket.event.display_name}. Log in to https://myseatshare.com to view."
-      )
-    rescue Exception => e
-      send = e.message
-    end
-    return send
+    profile = ticket.assigned.profile
+    return false unless !profile.mobile.blank? && profile.sms_notify
+    twilio_client.messages.create(
+      from: ENV['TWILIO_OUTBOUND_NUMBER'], to: profile.mobile_e164,
+      body: "#{acting_user.first_name} has assigned you"\
+        "#{ticket.display_name} for #{ticket.event.display_name}. Log in to"\
+        'https://myseatshare.com to view.'
+    )
+  rescue StandardError => e
+    e.message
   end
 
   def request_ticket(ticket, acting_user)
-    if ticket.owner.profile.mobile.blank? || ticket.owner.profile.sms_notify != true
-      return false
-    end
-    begin
-      send = self.twilio_client.messages.create(
-        from: ENV['TWILIO_OUTBOUND_NUMBER'],
-        to: ticket.owner.profile.mobile_e164,
-        body: "#{acting_user.first_name} has requested #{ticket.display_name} for #{ticket.event.display_name}. Log in to https://myseatshare.com to assign."
-      )
-    rescue
-      send = e.message
-    end
-    return send
+    profile = ticket.owner.profile
+    return false unless !profile.mobile.blank? && profile.sms_notify
+    twilio_client.messages.create(
+      from: ENV['TWILIO_OUTBOUND_NUMBER'], to: profile.mobile_e164,
+      body: "#{acting_user.first_name} has requested #{ticket.display_name}"\
+        "for #{ticket.event.display_name}. Log in to"\
+        'https://myseatshare.com to assign.'
+    )
+  rescue StandardError => e
+    e.message
   end
 
   def recent_messages
-    begin
-      self.twilio_client.account.messages.list || []
-    rescue Exception => e  
-      e.message
-    end
+    twilio_client.account.messages.list || []
+  rescue StandardError => e
+    e.message
   end
 
-  def get_sms_usage
-    begin
-      self.twilio_client.account.usage.records.last_month.list({:category => 'sms'}) || []
-    rescue Exception => e  
-      e.message
-    end
+  def sms_usage
+    twilio_client.account.usage.records.last_month.list(
+      category: 'sms'
+    ) || []
+  rescue StandardError => e
+    e.message
   end
-
 end

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -1,44 +1,43 @@
 require 'test_helper'
 
 class EventsControllerTest < ActionController::TestCase
-  test "should be redirected" do
-    get :show, :id => 1, :group_id => 2
+  test 'should be redirected' do
+    get :show, id: 1, group_id: 2
 
     assert_response :redirect
     assert_redirected_to '/login'
   end
 
-  test "should get show" do
+  test 'should get show' do
     @user = User.find(1)
     sign_in :user, @user
 
-    get :show, :id => 1, :group_id => 2
+    get :show, id: 1, group_id: 2
 
     assert_response :success, 'received a 200 status'
     assert_select 'title', 'Belmont Bruins vs. Brescia', 'event title matches'
     assert_select 'table', 1, 'there is a table for tickets'
   end
 
-  test "should see localized timezone" do
+  test 'should see localized timezone' do
     @user = User.find(2)
     sign_in :user, @user
 
-    get :show, :id => 4, :group_id => 1
+    get :show, id: 4, group_id: 1
 
     assert_response :success, 'received a 200 status'
     assert_select 'div.panel-heading', 'Saturday, October 26, 2013 - 3:00 pm EDT'
   end
 
-  test "should get the correct ticket counts" do
+  test 'should get the correct ticket counts' do
     @user = User.find(1)
     sign_in :user, @user
 
-    get :show, :id => 4, :group_id => 1
+    get :show, id: 4, group_id: 1
 
     assert_response :success, 'received a 200 status'
-    assert_select "li.available-ticket-count", '1 available in the group'
-    assert_select "li.total-ticket-count", '4 total in the group'
-    assert_select "li.held-ticket-count", '1 held by you'
+    assert_select 'li.available-ticket-count', '1 available in the group'
+    assert_select 'li.total-ticket-count', '4 total in the group'
+    assert_select 'li.held-ticket-count', '1 held by you'
   end
-
 end

--- a/test/controllers/groups_controller_test.rb
+++ b/test/controllers/groups_controller_test.rb
@@ -1,14 +1,14 @@
 require 'test_helper'
 
 class GroupsControllerTest < ActionController::TestCase
-  test "should be redirected" do
+  test 'should be redirected' do
     get :index
 
     assert_response :redirect
     assert_redirected_to '/login'
   end
 
-  test "should get index" do
+  test 'should get index' do
     @user = User.find(2)
     sign_in :user, @user
 
@@ -18,7 +18,7 @@ class GroupsControllerTest < ActionController::TestCase
     assert_select '.group_name', 2, 'page shows correct count of joined groups'
   end
 
-  test "should see group creation page" do
+  test 'should see group creation page' do
     @user = User.find(1)
     sign_in :user, @user
 
@@ -29,7 +29,7 @@ class GroupsControllerTest < ActionController::TestCase
     assert_select "form select[name='group[entity_id]'] option", 6, 'select on page has six items'
   end
 
-  test "should see join page" do
+  test 'should see join page' do
     @user = User.find(1)
     sign_in :user, @user
 
@@ -38,126 +38,125 @@ class GroupsControllerTest < ActionController::TestCase
     assert_select 'title', 'Join a Group', 'page title matches'
   end
 
-  test "should see join page with pre-populated code" do
+  test 'should see join page with pre-populated code' do
     @user = User.find(1)
     sign_in :user, @user
 
-    get :join, :invite_code => 'ABC123'
+    get :join, invite_code: 'ABC123'
     assert_response :success, 'got a 200 status'
     assert_select 'title', 'Join a Group', 'page title matches'
-    assert_tag :tag => "input", :attributes => { :id => "group_invitation_code", :value => "ABC123" }
+    assert_tag tag: 'input', attributes: { id: 'group_invitation_code', value: 'ABC123' }
   end
 
-  test "should see invite page" do
+  test 'should see invite page' do
     @user = User.find(1)
     sign_in :user, @user
 
-    get :invite, {:id => 2}
+    get :invite, id: 2
     assert_response :success, 'got a 200 status'
     assert_select 'title', 'Invite Member to Nashville Fans of Ballsports'
   end
 
-  test "should see leave page" do
+  test 'should see leave page' do
     @user = User.find(1)
     sign_in :user, @user
 
-    get :leave, {:id => 2}
+    get :leave, id: 2
     assert_response :success, 'got a 200 status'
     assert_select 'title', 'Leave Nashville Fans of Ballsports'
   end
 
-  test "should get group page" do
+  test 'should get group page' do
     @user = User.find(1)
     sign_in :user, @user
 
-    get :show, {:id => 1}
+    get :show, id: 1
     assert_response :success, 'got a 200 status'
     assert_select 'title', 'Geeks Watching Hockey', 'page title matches'
   end
 
-  test "non-member should get redirected to groups index" do
+  test 'non-member should get redirected to groups index' do
     @user = User.find(1)
     sign_in :user, @user
 
-    get :show, {:id => 2}
+    get :show, id: 2
     assert_response :redirect, 'was redirected to groups listing'
-    assert_redirected_to :controller => 'groups', :action => 'index'
+    assert_redirected_to controller: 'groups', action: 'index'
   end
 
-  test "should see remove user option" do
+  test 'should see remove user option' do
     @user = User.find(1)
     sign_in :user, @user
 
-    get :edit, {:id => 1}
+    get :edit, id: 1
     assert_response :success, 'got a 200 status'
     remove_user_column = css_select('.remove-user')
     assert remove_user_column, 'Remove User'
   end
 
-  test "should not see remove user option" do
+  test 'should not see remove user option' do
     @user = User.find(2)
     sign_in :user, @user
 
-    get :edit, {:id => 1}
+    get :edit, id: 1
     remove_user_column = css_select('.remove-user')
     !assert remove_user_column, 'Remove User'
     assert remove_user_column.length, 0
   end
 
-  test "should remove user - admin" do
+  test 'should remove user - admin' do
     @user = User.find(1)
     @removed = User.find(2)
     @group = Group.find(1)
     sign_in :user, @user
 
-    post :do_leave, {:user_id => @removed, :id => @group.id}
+    post :do_leave, user_id: @removed, id: @group.id
     assert_response :redirect, 'got a 304 status'
     assert_equal flash[:notice], 'Jill Smith has been removed'
   end
 
-  test "should remove user - not admin" do
+  test 'should remove user - not admin' do
     @user = User.find(3)
     @removed = User.find(3)
     @group = Group.find(1)
     sign_in :user, @user
 
-    post :do_leave, {:user_id => @removed, :id => @group.id}
+    post :do_leave, user_id: @removed, id: @group.id
     assert_response :redirect, 'got a 304 status'
     assert_equal flash[:notice], 'You have left Geeks Watching Hockey'
   end
 
-  test "should not remove user - administrator" do
+  test 'should not remove user - administrator' do
     assert_raise RuntimeError do
       @user = User.find(1)
       @removed = User.find(1)
       @group = Group.find(1)
       sign_in :user, @user
 
-      post :do_leave, {:user_id => @removed, :id => @group.id}
+      post :do_leave, user_id: @removed, id: @group.id
     end
   end
 
-  test "should not remove user - insufficient permission" do
+  test 'should not remove user - insufficient permission' do
     @user = User.find(3)
     @removed = User.find(2)
     @group = Group.find(1)
     sign_in :user, @user
 
-    post :do_leave, {:user_id => @removed, :id => @group.id}
+    post :do_leave, user_id: @removed, id: @group.id
     assert_response :redirect, 'got a 304 status'
     assert_equal flash[:error], 'You do not have permission to remove other users.'
   end
 
-  test "should see group message window" do
+  test 'should see group message window' do
     @user = User.find(1)
     @group = Group.find(1)
 
     sign_in :user, @user
 
-    get :message, { :id => @group.id }
+    get :message,  id: @group.id
 
     assert_response :success, 'got a 200 status'
     assert_select 'title', 'Send a Group Message to Geeks Watching Hockey'
   end
-
 end

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -1,18 +1,18 @@
 require 'test_helper'
 
 class ProfilesControllerTest < ActionController::TestCase
-  test "should be redirected" do
-    get :show, :id => 3
+  test 'should be redirected' do
+    get :show, id: 3
 
     assert_response :redirect
     assert_redirected_to '/login'
   end
 
-  test "should get profile of another user" do
+  test 'should get profile of another user' do
     @user = User.find(1)
     sign_in :user, @user
 
-    get :show, :id => 3
+    get :show, id: 3
 
     assert_response :success, 'received 200 status'
     assert_select 'title', 'Rick Taylor', 'page title matches'
@@ -20,11 +20,11 @@ class ProfilesControllerTest < ActionController::TestCase
     assert_select '.btn.btn-default', 0, 'does not have edit button'
   end
 
-  test "should get own profile with edit" do
+  test 'should get own profile with edit' do
     @user = User.find(1)
     sign_in :user, @user
 
-    get :show, :id => 1
+    get :show, id: 1
 
     assert_response :success, 'received 200 status'
     assert_select 'title', 'Jim Stone', 'page title matches'
@@ -32,7 +32,7 @@ class ProfilesControllerTest < ActionController::TestCase
     assert_select '.btn.btn-default', 1
   end
 
-  test "should get edit" do
+  test 'should get edit' do
     @user = User.find(1)
     sign_in :user, @user
 
@@ -41,5 +41,4 @@ class ProfilesControllerTest < ActionController::TestCase
     assert_response :success, 'received 200 status'
     assert_select 'title', 'Edit Profile', 'page title matches'
   end
-
 end

--- a/test/controllers/public_controller_test.rb
+++ b/test/controllers/public_controller_test.rb
@@ -1,58 +1,56 @@
 require 'test_helper'
 
 class PublicControllerTest < ActionController::TestCase
-  test "gets home page when not logged in" do
+  test 'gets home page when not logged in' do
     get :index
     assert_response :success, 'got home page'
     assert_select 'title', 'Welcome to SeatShare', 'title matches expected'
     assert_select 'h1', 'What is SeatShare?', 'page heading matches'
   end
 
-  test "gets redirected when logged in and has no groups" do 
+  test 'gets redirected when logged in and has no groups' do
     @user = User.find(6)
     sign_in :user, @user
 
     get :index
     assert_response :redirect, 'redirected to another page'
-    assert_redirected_to :controller => 'groups', :action => 'index'
+    assert_redirected_to controller: 'groups', action: 'index'
   end
 
-  test "gets redirected when logged in and is a group member" do 
+  test 'gets redirected when logged in and is a group member' do
     @user = User.find(1)
     sign_in :user, @user
 
     get :index
     assert_response :redirect, 'redirected to another page'
-    assert_redirected_to :controller => 'groups', :action => 'show', :id => 1
+    assert_redirected_to controller: 'groups', action: 'show', id: 1
   end
 
-  test "gets terms of service page" do
+  test 'gets terms of service page' do
     get :tos
     assert_response :success, 'loaded page with a 200'
     assert_select 'title', 'Terms of Service - SeatShare', 'title matches expected'
     assert_select 'h1', 'Terms of Service', 'page heading matches'
   end
 
-  test "gets privacy policy page" do
+  test 'gets privacy policy page' do
     get :privacy
     assert_response :success, 'loaded page with a 200'
     assert_select 'title', 'Privacy Policy - SeatShare', 'title matches expected'
     assert_select 'h1', 'Privacy Policy', 'page heading matches'
   end
 
-  test "gets contact page" do
+  test 'gets contact page' do
     get :contact
     assert_response :success, 'loaded page with a 200'
     assert_select 'title', 'Contact - SeatShare', 'title matches expected'
     assert_select 'h1', 'Let\'s talk!', 'page heading matches'
   end
 
-
-  test "gets teams page" do
+  test 'gets teams page' do
     get :teams
     assert_response :success, 'loaded page with a 200'
     assert_select 'title', 'Manage Season Tickets for Your Favorite Team - SeatShare', 'title matches expected'
     assert_select 'h1', 'Take home field advantage', 'page heading matches'
   end
-
 end

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -1,36 +1,34 @@
 require 'test_helper'
 
 class RegistrationsControllerTest < ActionController::TestCase
-
-  test "get register route" do
-    @request.env["devise.mapping"] = Devise.mappings[:user]
+  test 'get register route' do
+    @request.env['devise.mapping'] = Devise.mappings[:user]
 
     get :new
 
     assert_response :success
-    assert_select "title", "Create Your SeatShare Account"
-    assert_select "h4", "Joining a group?", 'invitation code block is empty'
+    assert_select 'title', 'Create Your SeatShare Account'
+    assert_select 'h4', 'Joining a group?', 'invitation code block is empty'
   end
 
-  test "get register route with invitation code" do
-    @request.env["devise.mapping"] = Devise.mappings[:user]
+  test 'get register route with invitation code' do
+    @request.env['devise.mapping'] = Devise.mappings[:user]
 
-    get :new, :invite_code => 'ABCDEFG123'
+    get :new, invite_code: 'ABCDEFG123'
 
     assert_response :success
-    assert_select "title", "Create Your SeatShare Account"
-    assert_select "h4", "You've been invited join a group!", 'invitation code block appears'
-    assert_select "strong.invite_code", "ABCDEFG123", 'invitation code appears'
+    assert_select 'title', 'Create Your SeatShare Account'
+    assert_select 'h4', "You've been invited join a group!", 'invitation code block appears'
+    assert_select 'strong.invite_code', 'ABCDEFG123', 'invitation code appears'
   end
 
-  test "get register route with team id" do
-    @request.env["devise.mapping"] = Devise.mappings[:user]
+  test 'get register route with team id' do
+    @request.env['devise.mapping'] = Devise.mappings[:user]
 
-    get :new, :entity_id => '1', :entity_slug => 'nashville-predators-nhl'
+    get :new, entity_id: '1', entity_slug: 'nashville-predators-nhl'
 
     assert_response :success
-    assert_select "title", "Create Your SeatShare Account - Nashville Predators (NHL)"
-    assert_select "h4", "Create a Nashville Predators group"
+    assert_select 'title', 'Create Your SeatShare Account - Nashville Predators (NHL)'
+    assert_select 'h4', 'Create a Nashville Predators group'
   end
-
 end

--- a/test/controllers/tickets_controller_test.rb
+++ b/test/controllers/tickets_controller_test.rb
@@ -1,63 +1,63 @@
 require 'test_helper'
 
 class TicketsControllerTest < ActionController::TestCase
-  test "should be redirected" do
-    get :edit, :group_id => 1, :event_id => 1, :id => 2
+  test 'should be redirected' do
+    get :edit, group_id: 1, event_id: 1, id: 2
 
     assert_response :redirect
     assert_redirected_to '/login'
   end
 
-  test "should get edit" do
+  test 'should get edit' do
     @user = User.find(1)
     sign_in :user, @user
 
-    get :edit, :group_id => 1, :event_id => 1, :id => 2
+    get :edit, group_id: 1, event_id: 1, id: 2
 
     assert_response :success, 'received 200 status'
     assert_select 'title', 'Belmont Bruins vs. Brescia - 326 K 10', 'ticket edit title matches'
   end
 
-  test "should unassign ticket" do
+  test 'should unassign ticket' do
     @user = User.find(1)
     sign_in :user, @user
 
-    get :unassign, :group_id => 1, :event_id => 1, :id => 2
+    get :unassign, group_id: 1, event_id: 1, id: 2
 
     assert_response :redirect, 'received a redirect'
     assert_redirected_to '/groups/1/event-1'
   end
 
-  test "should delete ticket" do
+  test 'should delete ticket' do
     @user = User.find(1)
     sign_in :user, @user
 
-    get :delete, :group_id => 1, :event_id => 1, :id => 2
+    get :delete, group_id: 1, event_id: 1, id: 2
 
     assert_response :redirect, 'received a redirect'
     assert_redirected_to '/groups/1/event-1'
   end
 
-  test "should be redirected to request" do
+  test 'should be redirected to request' do
     @user = User.find(2)
     sign_in :user, @user
 
-    get :edit, :group_id => 1, :event_id => 1, :id => 2
+    get :edit, group_id: 1, event_id: 1, id: 2
 
     assert_redirected_to '/groups/1/event-1/ticket-2/request'
   end
 
-  test "should get request" do
+  test 'should get request' do
     @user = User.find(2)
     sign_in :user, @user
 
-    get :request_ticket, :group_id => 1, :event_id => 1, :id => 2
+    get :request_ticket, group_id: 1, event_id: 1, id: 2
 
     assert_response :success, 'received 200 status'
     assert_select 'title', 'Belmont Bruins vs. Brescia - 326 K 10', 'ticket request title matches'
-  end 
+  end
 
-  test "should get future tickets" do
+  test 'should get future tickets' do
     @user = User.find(2)
     sign_in :user, @user
 
@@ -67,14 +67,13 @@ class TicketsControllerTest < ActionController::TestCase
     assert_select 'title', 'My Tickets', 'ticket request title matches'
   end
 
-  test "should get past tickets" do
+  test 'should get past tickets' do
     @user = User.find(2)
     sign_in :user, @user
 
-    get :index, :filter => 'past'
+    get :index, filter: 'past'
 
     assert_response :success, 'received 200 status'
     assert_select 'title', 'My Past Tickets', 'ticket request title matches'
   end
-
 end

--- a/test/controllers/user_aliases_controller_test.rb
+++ b/test/controllers/user_aliases_controller_test.rb
@@ -1,25 +1,24 @@
 require 'test_helper'
 
 class UserAliasesControllerTest < ActionController::TestCase
-
-  test "should get redirected" do
+  test 'should get redirected' do
     get :new
 
     assert_response :redirect
     assert_redirected_to '/login'
   end
 
-  test "should get redirected if not owned by user" do
+  test 'should get redirected if not owned by user' do
     @user = User.find(1)
     sign_in :user, @user
 
-    get :edit, :id => 1
+    get :edit, id: 1
 
     assert_response :redirect
     assert_redirected_to '/profile'
   end
 
-  test "should get add" do
+  test 'should get add' do
     @user = User.find(1)
     sign_in :user, @user
 
@@ -29,24 +28,23 @@ class UserAliasesControllerTest < ActionController::TestCase
     assert_select 'title', 'Add User Alias'
   end
 
-  test "should get edit" do
+  test 'should get edit' do
     @user = User.find(4)
     sign_in :user, @user
 
-    get :edit, :id => 1
+    get :edit, id: 1
 
     assert_response :success
     assert_select 'title', 'Edit User Alias'
   end
 
-  test "should get delete" do
+  test 'should get delete' do
     @user = User.find(1)
     sign_in :user, @user
 
-    get :delete, :id => 1
+    get :delete, id: 1
 
     assert_response :redirect
     assert_redirected_to '/profile'
   end
-
 end

--- a/test/integration/group_flow_test.rb
+++ b/test/integration/group_flow_test.rb
@@ -3,44 +3,44 @@ require 'test_helper'
 class GroupFlowTest < ActionDispatch::IntegrationTest
   fixtures :users
 
-  test "create a group" do
-    post_via_redirect "/login", {:user => { :email => users(:jim).email, :password => "testing123" }}
+  test 'create a group' do
+    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
 
     get '/groups/new'
     assert_response :success
 
-    post_via_redirect '/groups/new', {:group => { :group_name => 'A Test Group', :entity_id => '5'}}
+    post_via_redirect '/groups/new', group: { group_name: 'A Test Group', entity_id: '5' }
     assert_response :success
     assert_select 'title', 'A Test Group'
     assert_equal 'Group created!', flash[:notice]
   end
 
-  test "edit a group" do
-    post_via_redirect "/login", {:user => { :email => users(:jim).email, :password => "testing123" }}
+  test 'edit a group' do
+    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
 
     get '/groups/1/edit'
     assert_response :success
 
-    patch_via_redirect '/groups/1/edit', {:group => { :group_name => 'Group Name Changed'}}
+    patch_via_redirect '/groups/1/edit', group: { group_name: 'Group Name Changed' }
     assert_response :success
     assert_select 'title', 'Group Name Changed'
     assert_equal 'Group updated!', flash[:notice]
   end
 
-  test "join a group" do
-    post_via_redirect "/login", {:user => { :email => users(:jane).email, :password => "testing123" }}
+  test 'join a group' do
+    post_via_redirect '/login', user: { email: users(:jane).email, password: 'testing123' }
 
     get '/groups/join'
     assert_response :success
 
-    post_via_redirect '/groups/join', {:group => { :invitation_code => 'ABCDEFG123'}}
+    post_via_redirect '/groups/join', group: { invitation_code: 'ABCDEFG123' }
     assert_response :success
     assert_equal '/groups/1', path
     assert_equal 'Group joined!', flash[:notice]
   end
 
-  test "leave a group" do
-    post_via_redirect "/login", {:user => { :email => users(:jill).email, :password => "testing123" }}
+  test 'leave a group' do
+    post_via_redirect '/login', user: { email: users(:jill).email, password: 'testing123' }
 
     get '/groups/1/leave'
     assert_response :success
@@ -51,29 +51,28 @@ class GroupFlowTest < ActionDispatch::IntegrationTest
     assert_equal 'You have left Geeks Watching Hockey', flash[:notice]
   end
 
-  test "invite a user" do
-    post_via_redirect "/login", {:user => { :email => users(:jim).email, :password => "testing123" }}
+  test 'invite a user' do
+    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
 
     get '/groups/1/invite'
     assert_response :success
 
-    post_via_redirect '/groups/1/invite', {:group_invitation => { :email => 'rick@example.net', :message => 'Join us!'}}
+    post_via_redirect '/groups/1/invite', group_invitation: { email: 'rick@example.net', message: 'Join us!' }
     assert_response :success
     assert_equal '/groups/1', path
     assert_equal 'Group invitation sent!', flash[:notice]
 
   end
 
-  test "remove a user from a group" do
-    post_via_redirect "/login", {:user => { :email => users(:jim).email, :password => "testing123" }}
+  test 'remove a user from a group' do
+    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
 
     get '/groups/1/edit'
     assert_response :success
 
-    patch_via_redirect '/groups/1/leave', {:user_id => 2, :id => 1}
+    patch_via_redirect '/groups/1/leave', user_id: 2, id: 1
     assert_response :success
     assert_equal '/groups/1/edit', path
     assert_equal 'Jill Smith has been removed', flash[:notice]
   end
-
 end

--- a/test/integration/profile_flow_test.rb
+++ b/test/integration/profile_flow_test.rb
@@ -3,13 +3,13 @@ require 'test_helper'
 class ProfileFlowTest < ActionDispatch::IntegrationTest
   fixtures :users, :profiles
 
-  test "edit user profile" do
-    post_via_redirect "/login", {:user => { :email => users(:jim).email, :password => "testing123" }}
+  test 'edit user profile' do
+    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
 
     get '/profile'
     assert_response :success
 
-    patch_via_redirect '/profile', {:user => { :first_name => 'Jim', :last_name => 'Stone', :profile_attributes => { :bio => 'Something else entirely.', :location => 'Somewhere Else', :mobile => '(555) 555-4567', :notify_sms => 1 } } }
+    patch_via_redirect '/profile', user: { first_name: 'Jim', last_name: 'Stone', profile_attributes: { bio: 'Something else entirely.', location: 'Somewhere Else', mobile: '(555) 555-4567', notify_sms: 1 } }
     assert_response :success
     assert_select 'title', 'Jim Stone'
     assert_equal 'Profile updated!', flash[:notice]
@@ -17,8 +17,8 @@ class ProfileFlowTest < ActionDispatch::IntegrationTest
     assert_select '.profile-mobile', '(555) 555-4567'
   end
 
-  test "view edit user without profile" do
-    post_via_redirect "/login", {:user => { :email => users(:rick).email, :password => "testing123" }}
+  test 'view edit user without profile' do
+    post_via_redirect '/login', user: { email: users(:rick).email, password: 'testing123' }
 
     get '/profile'
     assert_response :success
@@ -26,11 +26,10 @@ class ProfileFlowTest < ActionDispatch::IntegrationTest
     assert_equal users(:rick).profile.nil?, false
   end
 
-  test "view user without profile" do
-    post_via_redirect "/login", {:user => { :email => users(:jim).email, :password => "testing123" }}
+  test 'view user without profile' do
+    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
 
     get '/profiles/3'
     assert_response :success
   end
-
 end

--- a/test/integration/ticket_flow_test.rb
+++ b/test/integration/ticket_flow_test.rb
@@ -3,120 +3,120 @@ require 'test_helper'
 class TicketFlowTest < ActionDispatch::IntegrationTest
   fixtures :users
 
-  test "add a single ticket" do
-    post_via_redirect "/login", {:user => { :email => users(:jim).email, :password => "testing123" }}
+  test 'add a single ticket' do
+    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
 
     get '/groups/1/event-4'
     assert_response :success
     assert_select 'title', 'Nashville Predators vs. St. Louis Blues'
 
-    post_via_redirect '/groups/1/event-4/add-ticket', {:ticket => { :section => '325', :row => 'L', :seat => '9', :event_id => 4, :cost => '40.00', :note => 'added a note'}}
+    post_via_redirect '/groups/1/event-4/add-ticket', ticket: { section: '325', row: 'L', seat: '9', event_id: 4, cost: '40.00', note: 'added a note' }
 
     assert_response :success
     assert_equal '/groups/1/event-4', path
     assert_equal 'Ticket added!', flash[:notice]
   end
 
-  test "add a single ticket - no section" do
-    post_via_redirect "/login", {:user => { :email => users(:jim).email, :password => "testing123" }}
+  test 'add a single ticket - no section' do
+    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
 
     get '/groups/1/event-4'
     assert_response :success
     assert_select 'title', 'Nashville Predators vs. St. Louis Blues'
 
-    post_via_redirect '/groups/1/event-4/add-ticket', {:ticket => { :event_id => 4, :cost => '40.00', :note => 'added a note'}}
+    post_via_redirect '/groups/1/event-4/add-ticket', ticket: { event_id: 4, cost: '40.00', note: 'added a note' }
 
     assert_response :success
     assert_equal '/groups/1/event-4/add-ticket', path
     assert_equal 'Could not create ticket.', flash[:error]
   end
 
-  test "add season tickets" do
-    post_via_redirect "/login", {:user => { :email => users(:jim).email, :password => "testing123" }}
+  test 'add season tickets' do
+    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
 
     get '/groups/1/event-4'
     assert_response :success
     assert_select 'title', 'Nashville Predators vs. St. Louis Blues'
 
-    post_via_redirect '/groups/1/add-tickets', {:ticket => { :event_id => [3,4], :section => '100', :row => 'R', :seat => 2, :cost => '40.00', :note => 'added a note'}}
+    post_via_redirect '/groups/1/add-tickets', ticket: { event_id: [3, 4], section: '100', row: 'R', seat: 2, cost: '40.00', note: 'added a note' }
 
     assert_response :success
     assert_equal '/groups/1', path
     assert_equal 'Tickets added!', flash[:notice]
   end
 
-  test "add season tickets - no section" do
-    post_via_redirect "/login", {:user => { :email => users(:jim).email, :password => "testing123" }}
+  test 'add season tickets - no section' do
+    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
 
     get '/groups/1/event-4'
     assert_response :success
     assert_select 'title', 'Nashville Predators vs. St. Louis Blues'
 
-    post_via_redirect '/groups/1/add-tickets', {:ticket => { :event_id => [3,4], :cost => '40.00', :note => 'added a note'}}
+    post_via_redirect '/groups/1/add-tickets', ticket: { event_id: [3, 4], cost: '40.00', note: 'added a note' }
 
     assert_response :success
     assert_equal '/groups/1/add-tickets', path
     assert_equal 'Could not create tickets.', flash[:error]
   end
 
-  test "add season tickets - no events" do
-    post_via_redirect "/login", {:user => { :email => users(:jim).email, :password => "testing123" }}
+  test 'add season tickets - no events' do
+    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
 
     get '/groups/1/event-4'
     assert_response :success
     assert_select 'title', 'Nashville Predators vs. St. Louis Blues'
 
-    post_via_redirect '/groups/1/add-tickets', {:ticket => { :section => '325', :row => 'J', :seat => 5, :cost => '40.00', :note => 'added a note'}}
+    post_via_redirect '/groups/1/add-tickets', ticket: { section: '325', row: 'J', seat: 5, cost: '40.00', note: 'added a note' }
 
     assert_response :success
     assert_equal '/groups/1/add-tickets', path
     assert_equal 'No events selected.', flash[:error]
   end
 
-  test "edit a ticket" do
-    post_via_redirect "/login", {:user => { :email => users(:jim).email, :password => "testing123" }}
+  test 'edit a ticket' do
+    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
 
     get '/groups/1/event-4/ticket-1'
     assert_response :success
     assert_select 'title', 'Nashville Predators vs. St. Louis Blues - 326 K 9'
 
-    post_via_redirect '/groups/1/event-4/ticket-1', {:ticket => { :cost => '40.00', :note => 'added a note'}}
+    post_via_redirect '/groups/1/event-4/ticket-1', ticket: { cost: '40.00', note: 'added a note' }
 
     assert_response :success
     assert_equal '/groups/1/event-4', path
     assert_equal 'Ticket updated!', flash[:notice]
   end
 
-  test "request a ticket" do
-    post_via_redirect "/login", {:user => { :email => users(:jill).email, :password => "testing123" }}
+  test 'request a ticket' do
+    post_via_redirect '/login', user: { email: users(:jill).email, password: 'testing123' }
 
     get '/groups/1/event-4/ticket-1/request'
     assert_response :success
     assert_select 'title', 'Nashville Predators vs. St. Louis Blues - 326 K 9'
 
-    patch_via_redirect '/groups/1/event-4/ticket-1/request', {:message => { :personalization => 'requesting a ticket'}}
+    patch_via_redirect '/groups/1/event-4/ticket-1/request', message: { personalization: 'requesting a ticket' }
 
     assert_response :success
     assert_equal '/groups/1/event-4', path
     assert_equal 'Ticket request sent!', flash[:notice]
   end
 
-  test "assign a ticket" do
-    post_via_redirect "/login", {:user => { :email => users(:jim).email, :password => "testing123" }}
+  test 'assign a ticket' do
+    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
 
     get '/groups/1/event-4/ticket-1'
     assert_response :success
     assert_select 'title', 'Nashville Predators vs. St. Louis Blues - 326 K 9'
 
-    post_via_redirect '/groups/1/event-4/ticket-1', {:ticket => { :user_id => 2, :cost => '40.00', :note => 'added a note'}}
+    post_via_redirect '/groups/1/event-4/ticket-1', ticket: { user_id: 2, cost: '40.00', note: 'added a note' }
 
     assert_response :success
     assert_equal '/groups/1/event-4', path
     assert_equal 'Ticket updated!', flash[:notice]
   end
 
-  test "unassign a ticket" do
-    post_via_redirect "/login", {:user => { :email => users(:jim).email, :password => "testing123" }}
+  test 'unassign a ticket' do
+    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
 
     get '/groups/1/event-4/ticket-1/unassign'
 
@@ -124,8 +124,8 @@ class TicketFlowTest < ActionDispatch::IntegrationTest
     assert_equal 'Ticket unassigned!', flash[:notice]
   end
 
-  test "delete a ticket" do
-    post_via_redirect "/login", {:user => { :email => users(:jim).email, :password => "testing123" }}
+  test 'delete a ticket' do
+    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
 
     get '/groups/1/event-4/ticket-1/delete'
 
@@ -133,31 +133,30 @@ class TicketFlowTest < ActionDispatch::IntegrationTest
     assert_equal 'Ticket deleted!', flash[:notice]
   end
 
-  test "bulk edit tickets - future" do
-    post_via_redirect "/login", {:user => { :email => users(:jim).email, :password => "testing123" }}
+  test 'bulk edit tickets - future' do
+    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
 
-    post_via_redirect '/tickets', {:ticket_cost => { "1" => "10.00", "2" => "15.00" }, :tickets => {:filter => nil}}
-
-    assert_response :success
-    assert_equal 'Tickets updated!', flash[:notice]
-  end
-
-  test "bulk edit tickets - past" do
-    post_via_redirect "/login", {:user => { :email => users(:jim).email, :password => "testing123" }}
-
-    post_via_redirect '/tickets', {:ticket_cost => { "2" => "15.00" }, :tickets => {:filter => 'past'}}
+    post_via_redirect '/tickets', ticket_cost: { '1' => '10.00', '2' => '15.00' }, tickets: { filter: nil }
 
     assert_response :success
     assert_equal 'Tickets updated!', flash[:notice]
   end
 
-  test "bulk edit tickets - not owner" do
-    post_via_redirect "/login", {:user => { :email => users(:jim).email, :password => "testing123" }}
+  test 'bulk edit tickets - past' do
+    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
 
-    post_via_redirect '/tickets', {:ticket_cost => { "4" => "15.00" }, :tickets => {:filter => nil}}
+    post_via_redirect '/tickets', ticket_cost: { '2' => '15.00' }, tickets: { filter: 'past' }
+
+    assert_response :success
+    assert_equal 'Tickets updated!', flash[:notice]
+  end
+
+  test 'bulk edit tickets - not owner' do
+    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
+
+    post_via_redirect '/tickets', ticket_cost: { '4' => '15.00' }, tickets: { filter: nil }
 
     assert_response :success
     assert_equal 'Ticket cost could not be updated.', flash[:error]
   end
-
 end

--- a/test/integration/user_login_test.rb
+++ b/test/integration/user_login_test.rb
@@ -3,50 +3,49 @@ require 'test_helper'
 class UserLoginTest < ActionDispatch::IntegrationTest
   fixtures :users
 
-  test "login and view default group" do
-    get "/login"
+  test 'login and view default group' do
+    get '/login'
     assert_response :success
 
-    post_via_redirect "/login", {:user => { :email => users(:jim).email, :password => "testing123" }}
+    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
     assert_equal nil, flash[:alert]
     assert_equal 'Signed in successfully.', flash[:notice]
     assert_equal '/groups/1', path
   end
 
-  test "login and view group landing page" do
-    get "/login"
+  test 'login and view group landing page' do
+    get '/login'
     assert_response :success
 
-    post_via_redirect "/login", {:user => { :email => users(:sarah).email, :password => "testing123" }}
+    post_via_redirect '/login', user: { email: users(:sarah).email, password: 'testing123' }
     assert_equal nil, flash[:alert]
     assert_equal 'Signed in successfully.', flash[:notice]
     assert_equal '/groups', path
   end
 
-  test "login and be denied entry" do
-    get "/login"
+  test 'login and be denied entry' do
+    get '/login'
     assert_response :success
 
-    post_via_redirect "/login", {:user => { :email => users(:peter).email, :password => "testing123" }}
+    post_via_redirect '/login', user: { email: users(:peter).email, password: 'testing123' }
     assert_equal 'Your account is not activated yet.', flash[:alert]
     assert_equal '/login', path
   end
 
-  test "login and then logout" do
-    get "/login"
+  test 'login and then logout' do
+    get '/login'
     assert_response :success
 
-    post_via_redirect "/login", {:user => { :email => users(:jim).email, :password => "testing123" }}
+    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
     assert_equal nil, flash[:alert]
     assert_equal 'Signed in successfully.', flash[:notice]
     assert_equal '/groups/1', path
 
-    delete "/logout"
+    delete '/logout'
     assert_equal 'Signed out successfully.', flash[:notice]
     assert_equal '/logout', path
 
-    get "/groups/1"
+    get '/groups/1'
     assert_equal '/unauthenticated', path
   end
-
 end

--- a/test/integration/user_signup_test.rb
+++ b/test/integration/user_signup_test.rb
@@ -1,12 +1,11 @@
 require 'test_helper'
 
 class UserSignupTest < ActionDispatch::IntegrationTest
-
-  test "signup for an account - success" do
-    get "/register"
+  test 'signup for an account - success' do
+    get '/register'
     assert_response :success
 
-    post_via_redirect "/", {:user => { :first_name => 'New', :last_name => 'User', :email => 'newuser@example.com', :password => 'testing123', :password_confirm => 'testing123' }}
+    post_via_redirect '/', user: { first_name: 'New', last_name: 'User', email: 'newuser@example.com', password: 'testing123', password_confirm: 'testing123' }
 
     assert_response :success
     assert_equal nil, flash[:alert]
@@ -14,23 +13,23 @@ class UserSignupTest < ActionDispatch::IntegrationTest
     assert_equal '/groups', path
   end
 
-  test "signup for an account with an existing email" do
-    get "/register"
+  test 'signup for an account with an existing email' do
+    get '/register'
     assert_response :success
 
-    post_via_redirect "/", {:user => { :first_name => 'New', :last_name => 'User', :email => 'stonej@example.net', :password => 'testing123', :password_confirm => 'testing123' }}
+    post_via_redirect '/', user: { first_name: 'New', last_name: 'User', email: 'stonej@example.net', password: 'testing123', password_confirm: 'testing123' }
 
     assert_response :success
     assert_equal 'There were errors with your registration.', flash[:alert]
     assert_equal '/', path
   end
 
-  test "signup for an account with an invite code" do
-    get "/register/invite/ABCDEFG123"
+  test 'signup for an account with an invite code' do
+    get '/register/invite/ABCDEFG123'
     assert_response :success
-    assert_select "h4", "You've been invited join a group!"
+    assert_select 'h4', "You've been invited join a group!"
 
-    post_via_redirect "/", {:user => { :first_name => 'New', :last_name => 'User', :email => 'newuser@example.com', :password => 'testing123', :password_confirm => 'testing123', :invite_code => 'ABCDEFG123' }}
+    post_via_redirect '/', user: { first_name: 'New', last_name: 'User', email: 'newuser@example.com', password: 'testing123', password_confirm: 'testing123', invite_code: 'ABCDEFG123' }
 
     assert_response :success
     assert_equal nil, flash[:alert]
@@ -38,12 +37,12 @@ class UserSignupTest < ActionDispatch::IntegrationTest
     assert_equal '/groups/join', path
   end
 
-  test "signup for an account with an team ID" do
-    get "/register/nashville-predators-nhl/1"
+  test 'signup for an account with an team ID' do
+    get '/register/nashville-predators-nhl/1'
     assert_response :success
-    assert_select "h4", "Create a Nashville Predators group"
+    assert_select 'h4', 'Create a Nashville Predators group'
 
-    post_via_redirect "/", {:user => { :first_name => 'New', :last_name => 'User', :email => 'newuser@example.com', :password => 'testing123', :password_confirm => 'testing123', :entity_id => 1 }}
+    post_via_redirect '/', user: { first_name: 'New', last_name: 'User', email: 'newuser@example.com', password: 'testing123', password_confirm: 'testing123', entity_id: 1 }
 
     assert_response :success
     assert_equal nil, flash[:alert]
@@ -51,32 +50,31 @@ class UserSignupTest < ActionDispatch::IntegrationTest
     assert_equal '/groups/new', path
   end
 
-  test "add user alias" do
-    post_via_redirect "/login", {:user => { :email => users(:jim).email, :password => "testing123" }}
+  test 'add user alias' do
+    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
 
-    get "/profile/aliases/new"
+    get '/profile/aliases/new'
     assert_response :success
 
-    post_via_redirect "/profile/aliases/new", {:user_alias => {:first_name => "New", :last_name => 'Alias'}}
-
-    assert_response :success
-    assert_equal nil, flash[:alert]
-    assert_equal "User alias created!", flash[:notice]
-    assert_equal "/profile", path
-  end
-
-  test "delete user alias" do
-    post_via_redirect "/login", {:user => { :email => users(:jill).email, :password => "testing123" }}
-
-    get "/profile"
-    assert_response :success
-
-    get_via_redirect "/profile/aliases/2/delete"
+    post_via_redirect '/profile/aliases/new', user_alias: { first_name: 'New', last_name: 'Alias' }
 
     assert_response :success
     assert_equal nil, flash[:alert]
-    assert_equal "User Alias deleted.", flash[:notice]
-    assert_equal "/profile", path
+    assert_equal 'User alias created!', flash[:notice]
+    assert_equal '/profile', path
   end
 
+  test 'delete user alias' do
+    post_via_redirect '/login', user: { email: users(:jill).email, password: 'testing123' }
+
+    get '/profile'
+    assert_response :success
+
+    get_via_redirect '/profile/aliases/2/delete'
+
+    assert_response :success
+    assert_equal nil, flash[:alert]
+    assert_equal 'User Alias deleted.', flash[:notice]
+    assert_equal '/profile', path
+  end
 end

--- a/test/mailers/custom_devise_mailer_test.rb
+++ b/test/mailers/custom_devise_mailer_test.rb
@@ -43,10 +43,9 @@ class CustomDeviseMailerTest < ActionMailer::TestCase
 
   test 'body should have link to confirm the account' do
     if mail.body.encoded =~ %r{<a href=\"http://localhost:3000/password/edit\?reset_password_token=([^"]+)">}
-      assert_equal Devise.token_generator.digest(user.class, :reset_password_token, $1), user.reset_password_token
+      assert_equal Devise.token_generator.digest(user.class, :reset_password_token, Regexp.last_match[1]), user.reset_password_token
     else
-      flunk "expected reset password url regex to match"
+      flunk 'expected reset password url regex to match'
     end
   end
-
 end

--- a/test/mailers/group_notifier_test.rb
+++ b/test/mailers/group_notifier_test.rb
@@ -1,22 +1,22 @@
 require 'test_helper'
 
 class GroupNotifierTest < ActionMailer::TestCase
-  test "send group invitation" do
+  test 'send group invitation' do
     invite = GroupInvitation.find(1)
 
     email = GroupNotifier.create_invite(invite).deliver
 
     assert_not ActionMailer::Base.deliveries.empty?
-    assert_equal ["no-reply@myseatshare.com"], email.from
-    assert_equal ["sarahb@example.org"], email.reply_to
-    assert_equal ["bob@example.com"], email.to
-    assert_equal "You have been invited to join Geeks Watching Hockey", email.subject
-    assert_includes email.body.to_s, "<title>You have been invited to join Geeks Watching Hockey</title>"
+    assert_equal ['no-reply@myseatshare.com'], email.from
+    assert_equal ['sarahb@example.org'], email.reply_to
+    assert_equal ['bob@example.com'], email.to
+    assert_equal 'You have been invited to join Geeks Watching Hockey', email.subject
+    assert_includes email.body.to_s, '<title>You have been invited to join Geeks Watching Hockey</title>'
     assert_includes email.body.to_s, "<a href=\"http://localhost:3000/register/invite/ABCDEFG123\">Use Invitation ABCDEFG123</a>"
     assert_includes email.body.to_s, "Sarah Becker has invited you to join our <strong>Nashville Predators</strong> group on <a href=\"http://localhost:3000/\">SeatShare</a>, a service that helps manage our season tickets."
   end
 
-  test "send group message" do
+  test 'send group message' do
     sending_user = User.find(1)
     group = Group.find(1)
     recipient_users = group.users
@@ -24,13 +24,12 @@ class GroupNotifierTest < ActionMailer::TestCase
     email = GroupNotifier.send_group_message(group, sending_user, recipient_users, 'Anyone want to go to the game on Friday?', "I'll have an extra ticket to spare.\n\nFree to a good home.").deliver
 
     assert_not ActionMailer::Base.deliveries.empty?
-    assert_equal ["no-reply@myseatshare.com"], email.from
-    assert_equal ["stonej@example.net"], email.reply_to
-    assert_equal ["stonej@example.net", "jillsmith83@us.example.org", "rick.taylor@example.net"], email.to
-    assert_equal "[Geeks Watching Hockey] Anyone want to go to the game on Friday?", email.subject
-    assert_includes email.body.to_s, "<title>[Geeks Watching Hockey] Anyone want to go to the game on Friday?</title>"
+    assert_equal ['no-reply@myseatshare.com'], email.from
+    assert_equal ['stonej@example.net'], email.reply_to
+    assert_equal ['stonej@example.net', 'jillsmith83@us.example.org', 'rick.taylor@example.net'], email.to
+    assert_equal '[Geeks Watching Hockey] Anyone want to go to the game on Friday?', email.subject
+    assert_includes email.body.to_s, '<title>[Geeks Watching Hockey] Anyone want to go to the game on Friday?</title>'
     assert_includes email.body.to_s, "<p>I'll have an extra ticket to spare.</p>"
-    assert_includes email.body.to_s, "<p>Free to a good home.</p>"
+    assert_includes email.body.to_s, '<p>Free to a good home.</p>'
   end
-
 end

--- a/test/mailers/schedule_notifier_test.rb
+++ b/test/mailers/schedule_notifier_test.rb
@@ -1,8 +1,7 @@
 require 'test_helper'
 
 class ScheduleNotifierTest < ActionMailer::TestCase
-
-  test "send daily schedule" do
+  test 'send daily schedule' do
     events = Event.where('DATE(start_time) = \'2013-10-15\'').order_by_date
     group = Group.find(1)
     user = User.find(1)
@@ -17,7 +16,7 @@ class ScheduleNotifierTest < ActionMailer::TestCase
     assert_includes email.body.to_s, '<td><a href="http://localhost:3000/groups/1/event-7">Nashville Predators vs. Florida Panthers</a></td>'
   end
 
-  test "send weekly schedule" do
+  test 'send weekly schedule' do
     events = Event.where('start_time >= \'2013-10-13\' AND start_time <= \'2013-10-20\'').order_by_date
     group = Group.find(1)
     user = User.find(1)
@@ -31,5 +30,4 @@ class ScheduleNotifierTest < ActionMailer::TestCase
     assert_includes email.body.to_s, '<title>The week ahead for Geeks Watching Hockey</title>'
     assert_includes email.body.to_s, '<td><a href="http://localhost:3000/groups/1/event-6">Nashville Predators vs. Los Angeles Kings</a></td>'
   end
-
 end

--- a/test/mailers/ticket_notifier_test.rb
+++ b/test/mailers/ticket_notifier_test.rb
@@ -1,8 +1,7 @@
 require 'test_helper'
 
 class TicketNotifierTest < ActionMailer::TestCase
-
-  test "ticket assigned to user" do
+  test 'ticket assigned to user' do
     ticket = Ticket.find(7)
     user = User.find(3)
 
@@ -15,13 +14,13 @@ class TicketNotifierTest < ActionMailer::TestCase
     assert_includes email.body.to_s, '<p>Jill,</p>'
     assert_includes email.body.to_s, '<p>Rick Taylor (<a href="mailto:rick.taylor@example.net">rick.taylor@example.net</a>) has assigned a ticket to you for the following event in your group Geeks Watching Hockey.</p>'
     fails_intermittently('https://github.com/seatshare/seatshare-rails/issues/109',
-      'Rails.configuration.time_zone' => Rails.configuration.time_zone, 'Time.zone.name' => Time.zone.name, 'user.timezone' => user.timezone) do
+                         'Rails.configuration.time_zone' => Rails.configuration.time_zone, 'Time.zone.name' => Time.zone.name, 'user.timezone' => user.timezone) do
       assert_includes email.body.to_s, '<td>Nashville Predators vs. St. Louis Blues : Saturday, October 26, 2013 - 2:00 pm CDT</td>'
     end
     assert_includes email.body.to_s, '<td><a href="http://localhost:3000/groups/1/event-4/ticket-7">326 K 13</a></td>'
   end
 
-  test "ticket requested from user" do
+  test 'ticket requested from user' do
     ticket = Ticket.find(2)
     user = User.find(2)
 
@@ -34,7 +33,7 @@ class TicketNotifierTest < ActionMailer::TestCase
     assert_includes email.body.to_s, '<p>Jim,</p>'
     assert_includes email.body.to_s, '<p>Jill Smith (<a href="mailto:jillsmith83@us.example.org">jillsmith83@us.example.org</a>) has requested your ticket for the following event in your group Geeks Watching Hockey.</p>'
     fails_intermittently('https://github.com/seatshare/seatshare-rails/issues/109',
-      'Rails.configuration.time_zone' => Rails.configuration.time_zone, 'Time.zone.name' => Time.zone.name, 'user.timezone' => user.timezone) do
+                         'Rails.configuration.time_zone' => Rails.configuration.time_zone, 'Time.zone.name' => Time.zone.name, 'user.timezone' => user.timezone) do
       assert_includes email.body.to_s, '<td>Nashville Predators vs. St. Louis Blues : Saturday, October 26, 2013 - 2:00 pm CDT</td>'
     end
     assert_includes email.body.to_s, '<td><a href="http://localhost:3000/groups/1/event-4/ticket-2">326 K 10</a></td>'

--- a/test/mailers/welcome_email_test.rb
+++ b/test/mailers/welcome_email_test.rb
@@ -1,8 +1,7 @@
 require 'test_helper'
 
 class WelcomeEmailTest < ActionMailer::TestCase
-
-  test "send welcome email" do
+  test 'send welcome email' do
     user = User.find(1)
 
     email = WelcomeEmail.welcome(user).deliver
@@ -12,5 +11,4 @@ class WelcomeEmailTest < ActionMailer::TestCase
     assert_equal ['stonej@example.net'], email.to
     assert_equal 'Welcome to SeatShare, Jim!', email.subject
   end
-
 end

--- a/test/models/entity_test.rb
+++ b/test/models/entity_test.rb
@@ -1,24 +1,24 @@
 require 'test_helper'
 
 class EntityTest < ActiveSupport::TestCase
-  test "new entity has attributes" do
-    entity = Entity.new({
-      entity_name: 'Nashville Sportsball (Inactive)',
-    })
+  test 'new entity has attributes' do
+    entity = Entity.new(
+      entity_name: 'Nashville Sportsball (Inactive)'
+    )
     entity.save!
 
     assert entity.entity_name?, 'Name for entity is set'
     assert entity.status == 0, 'Status for entity is inactive'
   end
 
-  test "fixture entity has attributes" do
+  test 'fixture entity has attributes' do
     entity = Entity.find(1)
 
     assert entity.entity_name === 'Nashville Predators', 'Name for entity is set'
     assert entity.status === 1, 'Status for entity is inactive'
   end
 
-  test "gets entity by group ID" do
+  test 'gets entity by group ID' do
     entity = Group.find(2).entity
 
     assert entity.id === 6, 'fixture entity ID matches'
@@ -26,12 +26,11 @@ class EntityTest < ActiveSupport::TestCase
     assert entity.status === 1, 'fixture entity is active'
   end
 
-  test "get all active entities" do
+  test 'get all active entities' do
     entities = Entity.active
 
-    assert entities.count() === 5, 'count of fixture entities matches'
+    assert entities.count === 5, 'count of fixture entities matches'
     assert entities[0].class.to_s === 'Entity', 'class of fixture entity matches'
     assert entities[0].entity_name?, 'fixture entity name is set'
   end
-
 end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -1,13 +1,13 @@
 require 'test_helper'
 
 class EventTest < ActiveSupport::TestCase
-  test "new event has attributes" do
-    event = Event.new({
+  test 'new event has attributes' do
+    event = Event.new(
       event_name: 'A New Event',
       description: 'This describes the event',
       entity_id: 1,
       start_time: '2013-01-01 18:00:00 CST'
-    })
+    )
     event.save!
 
     assert event.id > 0, 'new event ID is set'
@@ -18,12 +18,12 @@ class EventTest < ActiveSupport::TestCase
     assert event.date_tba? === false, 'new event date is not TBA'
     assert event.time_tba? === false, 'new event time is not TBA'
     fails_intermittently('https://github.com/seatshare/seatshare-rails/issues/109',
-      'Rails.configuration.time_zone' => Rails.configuration.time_zone, 'Time.zone.name' => Time.zone.name) do
+                         'Rails.configuration.time_zone' => Rails.configuration.time_zone, 'Time.zone.name' => Time.zone.name) do
       assert event.date_time === 'Tuesday, January 1, 2013 - 6:00 pm CST', 'new event date/time string matches'
     end
   end
 
-  test "fixture event has attributes" do
+  test 'fixture event has attributes' do
     event = Event.find(1)
 
     assert event.event_name === 'Belmont Bruins vs. Brescia', 'fixture event name matches'
@@ -35,15 +35,15 @@ class EventTest < ActiveSupport::TestCase
     assert event.date_time === 'Tuesday, November 26, 2013', 'new event date/time string matches'
   end
 
-  test "get events by group ID" do
+  test 'get events by group ID' do
     events = Group.find(1).events.order('start_time ASC')
 
     assert events[0].class.to_s === 'Event', 'returned item is an event'
-    assert events[0].event_name === "Nashville Predators vs. Minnesota Wild", 'event title matches'
+    assert events[0].event_name === 'Nashville Predators vs. Minnesota Wild', 'event title matches'
     assert events.count === 7, 'event count equals seven'
   end
 
-  test "get event by ticket ID" do
+  test 'get event by ticket ID' do
     event = Ticket.find(2).event
 
     assert event.id === 4, 'event ID matches'
@@ -51,7 +51,7 @@ class EventTest < ActiveSupport::TestCase
     assert event.event_name === 'Nashville Predators vs. St. Louis Blues', 'event name matches'
   end
 
-  test "get ticket status counts" do
+  test 'get ticket status counts' do
     event = Event.find(4)
     user = User.find(1)
     group = Group.find(1)
@@ -65,26 +65,26 @@ class EventTest < ActiveSupport::TestCase
     assert stats[:percent_full] === 75
   end
 
-  test "two created events do not share an import key" do
-    event1 = Event.create({
+  test 'two created events do not share an import key' do
+    event1 = Event.create(
         event_name: 'Event 1',
         entity_id: 1,
         start_time: '2014-01-01 12:00',
         import_key: ''
-    })
-    event2 = Event.create({
+    )
+    event2 = Event.create(
         event_name: 'Event 2',
         entity_id: 1,
         start_time: '2014-01-01 12:00',
         import_key: ''
-    })
+    )
 
     assert event1[:event_name] === 'Event 1'
     assert event2[:event_name] === 'Event 2'
 
   end
 
-  test "imported row matches output" do
+  test 'imported row matches output' do
     row1 = {
       entity_id: 1,
       home_team: 'Nashville Predators',

--- a/test/models/group_invitation_test.rb
+++ b/test/models/group_invitation_test.rb
@@ -1,12 +1,12 @@
 require 'test_helper'
 
 class GroupInvitationTest < ActiveSupport::TestCase
-  test "new group invitation has attributes" do
-    invitation = GroupInvitation.new({
+  test 'new group invitation has attributes' do
+    invitation = GroupInvitation.new(
       user_id: 1,
       email: 'someguy@example.com',
       group_id: 1
-    })
+    )
     invitation.save!
 
     assert invitation.invitation_code != ''
@@ -15,17 +15,16 @@ class GroupInvitationTest < ActiveSupport::TestCase
     assert invitation.user_id === 1
   end
 
-  test "use invitation" do
+  test 'use invitation' do
     invitation = GroupInvitation.get_by_invitation_code('ABCDEFG123')
 
     assert invitation.status === 1, 'is a valid invitation code'
     assert invitation.email === 'bob@example.com', 'invitation has an email address'
     assert invitation.user_id === 4, 'invitation attached to an ID'
 
-    invitation.use_invitation()
+    invitation.use_invitation
     invitation = GroupInvitation.get_by_invitation_code('ABCDEFG123')
 
     assert invitation.status === 0, 'invitation was marked as used'
   end
-
 end

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -1,13 +1,12 @@
 require 'test_helper'
 
 class GroupTest < ActiveSupport::TestCase
-
-  test "new group has attributes" do
-    group = Group.new({
-      :group_name => 'Another Sportsball Group',
-      :creator_id => 5,
-      :entity_id => 6
-    })
+  test 'new group has attributes' do
+    group = Group.new(
+      group_name: 'Another Sportsball Group',
+      creator_id: 5,
+      entity_id: 6
+    )
     group.save!
 
     assert group.group_name === 'Another Sportsball Group', 'new group name matches'
@@ -15,7 +14,7 @@ class GroupTest < ActiveSupport::TestCase
     assert group.invitation_code.length === 10, 'new group has valid invitation code'
   end
 
-  test "fixture group has attributes" do
+  test 'fixture group has attributes' do
     group = Group.find(1)
 
     assert group.group_name === 'Geeks Watching Hockey', 'group name matches fixture'
@@ -24,41 +23,41 @@ class GroupTest < ActiveSupport::TestCase
     assert group.users.count === 3, 'group member count matches'
   end
 
-  test "get group by ticket ID" do
+  test 'get group by ticket ID' do
     group = Ticket.find(1).group
 
     assert group.id === 1, 'fixture group ID matches'
     assert group.group_name === 'Geeks Watching Hockey', 'fixture group name matches'
   end
 
-  test "gets groups by user ID" do
+  test 'gets groups by user ID' do
     groups = User.find(2).groups
 
     assert groups.count === 2, 'fixture group count matches'
   end
 
-  test "check if member" do
+  test 'check if member' do
     user = User.find(1)
     group = Group.find(3)
 
-    assert group.is_member(user) === false, "fixture user is not a member"
-    assert group.is_admin(user) === false, "fixture user is not an admin"
+    assert group.member?(user) === false, 'fixture user is not a member'
+    assert group.admin?(user) === false, 'fixture user is not an admin'
   end
 
-  test "check if admin" do
+  test 'check if admin' do
     user = User.find(1)
     group = Group.find(1)
 
-    assert group.is_member(user) === true, "fixture user is a member"
-    assert group.is_admin(user) === true, "fixture user is an admin"
+    assert group.member?(user) === true, 'fixture user is a member'
+    assert group.admin?(user) === true, 'fixture user is an admin'
   end
 
-  test "join a group" do
+  test 'join a group' do
     user = User.find(4)
     group = Group.find(2)
 
-    assert group.is_member(user) === false, 'user is not yet a member'
-    assert group.is_admin(user) === false, 'user is not an admin'
+    assert group.member?(user) === false, 'user is not yet a member'
+    assert group.admin?(user) === false, 'user is not an admin'
 
     group_user = group.join_group(user)
 
@@ -66,16 +65,16 @@ class GroupTest < ActiveSupport::TestCase
     assert group_user.group_id === 2, 'group ID matches'
     assert group_user.role === 'member', 'role matches'
 
-    assert group.is_member(user) === true, 'user is a member'
-    assert group.is_admin(user) === false, 'user is not an admin'
+    assert group.member?(user) === true, 'user is a member'
+    assert group.admin?(user) === false, 'user is not an admin'
   end
 
-  test "join a group as an admin" do
+  test 'join a group as an admin' do
     user = User.find(4)
     group = Group.find(2)
 
-    assert group.is_member(user) === false, 'user is not yet a member'
-    assert group.is_admin(user) === false, 'user is not yet an admin'
+    assert group.member?(user) === false, 'user is not yet a member'
+    assert group.admin?(user) === false, 'user is not yet an admin'
 
     group_user = group.join_group(user, 'admin')
 
@@ -83,11 +82,11 @@ class GroupTest < ActiveSupport::TestCase
     assert group_user.group_id === 2, 'group ID matches'
     assert group_user.role === 'admin', 'role matches'
 
-    assert group.is_member(user) === true, 'user is a member'
-    assert group.is_admin(user) === true, 'user is an admin'
+    assert group.member?(user) === true, 'user is a member'
+    assert group.admin?(user) === true, 'user is an admin'
   end
 
-  test "gets correct list of administrators" do
+  test 'gets correct list of administrators' do
     group = Group.find(2)
 
     assert group.administrators.count === 1
@@ -95,32 +94,31 @@ class GroupTest < ActiveSupport::TestCase
     assert group.administrators.first.last_name === 'Taylor'
   end
 
-  test "leave a group" do
+  test 'leave a group' do
     user = User.find(2)
     group = Group.find(1)
 
-    assert group.is_member(user) === true, 'user is a member'
-    assert group.is_admin(user) === false, 'user is not an admin'
+    assert group.member?(user) === true, 'user is a member'
+    assert group.admin?(user) === false, 'user is not an admin'
 
     group.leave_group(user)
 
-    assert group.is_member(user) === false, 'user is not a member'
-    assert group.is_admin(user) === false, 'user is not an admin'
+    assert group.member?(user) === false, 'user is not a member'
+    assert group.admin?(user) === false, 'user is not an admin'
   end
 
-  test "leave a group as an admin" do
+  test 'leave a group as an admin' do
     user = User.find(1)
     group = Group.find(1)
 
-    assert group.is_member(user) === true, 'user is a member'
-    assert group.is_admin(user) === true, 'user is an admin'
+    assert group.member?(user) === true, 'user is a member'
+    assert group.admin?(user) === true, 'user is an admin'
 
     assert_raises RuntimeError do
       group.leave_group(user)
     end
 
-    assert group.is_member(user) === true, 'user is still a member'
-    assert group.is_admin(user) === true, 'user is still an admin'
+    assert group.member?(user) === true, 'user is still a member'
+    assert group.admin?(user) === true, 'user is still an admin'
   end
-
 end

--- a/test/models/group_user_test.rb
+++ b/test/models/group_user_test.rb
@@ -1,18 +1,18 @@
 require 'test_helper'
 
 class GroupUserTest < ActiveSupport::TestCase
-  test "add user to group" do
-    group_users = GroupUser.new({
-      :user_id => 5,
-      :group_id => 6
-    })
+  test 'add user to group' do
+    group_users = GroupUser.new(
+      user_id: 5,
+      group_id: 6
+    )
     group_users.save!
 
     assert group_users.user_id === 5, 'new user ID match'
     assert group_users.group_id === 6, 'new group ID match'
   end
 
-  test "group users match group ID" do
+  test 'group users match group ID' do
     users = Group.find(1).users
 
     assert users.count === 3, 'fixture user count matches'
@@ -20,11 +20,10 @@ class GroupUserTest < ActiveSupport::TestCase
     assert users[0].last_name?, 'fixture last name is set'
   end
 
-  test "groups match user match user ID" do
+  test 'groups match user match user ID' do
     groups = User.find(2).groups
 
     assert groups.count === 2, 'fixture group count matches'
     assert groups[0].group_name?, 'fixture group name is set'
   end
-
 end

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -1,10 +1,8 @@
 require 'test_helper'
 
 class ProfileTest < ActiveSupport::TestCase
-  
-  test "convert phone number to E.164 format" do
+  test 'convert phone number to E.164 format' do
     user = User.find(1)
-    assert_equal "+14108675309", user.profile.mobile_e164
+    assert_equal '+14108675309', user.profile.mobile_e164
   end
-
 end

--- a/test/models/ticket_history_test.rb
+++ b/test/models/ticket_history_test.rb
@@ -1,15 +1,14 @@
 require 'test_helper'
 
 class TicketHistoryTest < ActiveSupport::TestCase
-
-  test "new ticket history" do
-    ticket_history = TicketHistory.new({
-      :ticket_id => 1,
-      :event_id => 4,
-      :group_id => 1,
-      :user_id => 1,
-      :entry => '{"text":"assigned","user":{"id":"1","username":"jstone","first_name":"Jim","last_name":"Stone","email":"stonej@example.net","status":"1"},"ticket":{"id":"1","section":"326","row":"K","seat":"9","cost":"32.00","user_id":"1","ticket_id":1}}'
-    })
+  test 'new ticket history' do
+    ticket_history = TicketHistory.new(
+      ticket_id: 1,
+      event_id: 4,
+      group_id: 1,
+      user_id: 1,
+      entry: '{"text":"assigned","user":{"id":"1","username":"jstone","first_name":"Jim","last_name":"Stone","email":"stonej@example.net","status":"1"},"ticket":{"id":"1","section":"326","row":"K","seat":"9","cost":"32.00","user_id":"1","ticket_id":1}}'
+    )
     ticket_history.save!
 
     assert ticket_history.ticket_id === 1
@@ -19,28 +18,27 @@ class TicketHistoryTest < ActiveSupport::TestCase
     assert JSON.parse(ticket_history.entry)['text'] === 'assigned'
   end
 
-  test "ticket property is set" do
+  test 'ticket property is set' do
     ticket_history = TicketHistory.find(1)
 
     assert ticket_history.ticket.display_name === '326 K 9'
   end
 
-  test "event property is set" do
+  test 'event property is set' do
     ticket_history = TicketHistory.find(1)
 
     assert ticket_history.event.event_name === 'Nashville Predators vs. St. Louis Blues'
   end
 
-  test "group property is set" do
+  test 'group property is set' do
     ticket_history = TicketHistory.find(1)
 
     assert ticket_history.group.group_name === 'Geeks Watching Hockey'
   end
 
-  test "user property is set" do
+  test 'user property is set' do
     ticket_history = TicketHistory.find(1)
 
     assert ticket_history.user.display_name === 'Jim Stone'
   end
-
 end

--- a/test/models/ticket_test.rb
+++ b/test/models/ticket_test.rb
@@ -1,18 +1,17 @@
 require 'test_helper'
 
 class TicketTest < ActiveSupport::TestCase
-
-  test "new ticket has attributes" do
-    ticket = Ticket.new({
-      :group_id => 1,
-      :event_id => 4,
-      :section => '301',
-      :row => 'Q',
-      :seat => '3',
-      :cost => 45.00,
-      :owner_id => 1,
-      :user_id => 2
-    })
+  test 'new ticket has attributes' do
+    ticket = Ticket.new(
+      group_id: 1,
+      event_id: 4,
+      section: '301',
+      row: 'Q',
+      seat: '3',
+      cost: 45.00,
+      owner_id: 1,
+      user_id: 2
+    )
     ticket.save!
 
     assert ticket.cost === 45.00
@@ -23,13 +22,13 @@ class TicketTest < ActiveSupport::TestCase
     assert ticket.event.event_name === 'Nashville Predators vs. St. Louis Blues'
   end
 
-  test "owner property is set" do
+  test 'owner property is set' do
     ticket = Ticket.find(1)
 
     assert ticket.owner.display_name === 'Jim Stone'
   end
 
-  test "assigned property is set" do
+  test 'assigned property is set' do
     ticket = Ticket.find(1)
 
     assert ticket.assigned.display_name === 'Jim Stone'
@@ -39,7 +38,7 @@ class TicketTest < ActiveSupport::TestCase
     assert ticket.assigned.nil? === true
   end
 
-  test "alias property is set" do
+  test 'alias property is set' do
     ticket = Ticket.find(4)
 
     assert ticket.alias.display_name === 'Jennifer Newton'
@@ -49,13 +48,13 @@ class TicketTest < ActiveSupport::TestCase
     assert ticket.alias.nil? === true
   end
 
-  test "group property is set" do
+  test 'group property is set' do
     ticket = Ticket.find(1)
 
     assert ticket.group.group_name === 'Geeks Watching Hockey'
   end
 
-  test "display_name property is set" do
+  test 'display_name property is set' do
     ticket = Ticket.find(1)
 
     assert ticket.display_name === '326 K 9'
@@ -65,24 +64,23 @@ class TicketTest < ActiveSupport::TestCase
     assert ticket.display_name === 'VIP'
   end
 
-  test "is_available? check" do
+  test 'available? check' do
     ticket = Ticket.find(1)
 
-    assert ticket.is_available? === false
+    assert ticket.available? === false
 
     ticket = Ticket.find(2)
 
-    assert ticket.is_available? === true
+    assert ticket.available? === true
   end
 
-  test "is_assigned? check" do
+  test 'assigned? check' do
     ticket = Ticket.find(1)
 
-    assert ticket.is_assigned? === true
+    assert ticket.assigned? === true
 
     ticket = Ticket.find(2)
 
-    assert ticket.is_assigned? === false
+    assert ticket.assigned? === false
   end
-
 end

--- a/test/models/user_alias_test.rb
+++ b/test/models/user_alias_test.rb
@@ -1,12 +1,12 @@
 require 'test_helper'
 
 class UserAliasTest < ActiveSupport::TestCase
-  test "new user alias has attributes" do
-    user_alias = UserAlias.new({
+  test 'new user alias has attributes' do
+    user_alias = UserAlias.new(
       user_id: 1,
       first_name: 'Amanda',
       last_name: 'Goodlaw'
-    })
+    )
 
     assert user_alias.first_name === 'Amanda', 'new user alias first name matches'
     assert user_alias.last_name === 'Goodlaw', 'new user alias last name matches'
@@ -14,7 +14,7 @@ class UserAliasTest < ActiveSupport::TestCase
     assert user_alias.user_id === 1, 'new user alias user ID matches'
   end
 
-  test "fixture user alias has attributes" do
+  test 'fixture user alias has attributes' do
     user_alias = UserAlias.find(1)
 
     assert user_alias.first_name === 'Kevin', 'fixture user alias first name matches'
@@ -23,16 +23,15 @@ class UserAliasTest < ActiveSupport::TestCase
     assert user_alias.user_id === 4, 'fixture user alias user ID matches'
   end
 
-  test "user alias unset from matching tickets when deleted" do
+  test 'user alias unset from matching tickets when deleted' do
     user_alias = UserAlias.find(2)
-    ticket = Ticket.find(4);
+    ticket = Ticket.find(4)
 
     assert user_alias.id === ticket.alias_id, 'ticket is assigned to user'
 
     user_alias.destroy
 
-    ticket = Ticket.find(4);
+    ticket = Ticket.find(4)
     assert ticket.alias_id === 0, 'ticket was assigned back to 0'
   end
-
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,13 +1,13 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
-  test "create new user" do
-    user = User.new({
-      :first_name => 'Randy',
-      :last_name => 'Phillips',
-      :email => 'randy23@example.net',
-      :password => 'somethingpasswordy'
-    })
+  test 'create new user' do
+    user = User.new(
+      first_name: 'Randy',
+      last_name: 'Phillips',
+      email: 'randy23@example.net',
+      password: 'somethingpasswordy'
+    )
     user.save!
 
     assert user.first_name === 'Randy', 'new user first name matches'
@@ -15,7 +15,7 @@ class UserTest < ActiveSupport::TestCase
     assert user.email === 'randy23@example.net', 'new user email matches'
   end
 
-  test "get user from fixture" do
+  test 'get user from fixture' do
     user = User.find(1)
 
     assert user.first_name === 'Jim', 'fixture first name matches'
@@ -23,18 +23,17 @@ class UserTest < ActiveSupport::TestCase
     assert user.email === 'stonej@example.net', 'fixture email matches'
   end
 
-  test "get full name of user" do
+  test 'get full name of user' do
     user = User.find(2)
 
     assert user.display_name === 'Jill Smith'
   end
 
-  test "group users match group ID" do
+  test 'group users match group ID' do
     users = Group.find(2).users
 
     assert users.count === 2, 'fixture user count matches'
     assert users[0].first_name?, 'fixture first name is set'
     assert users[0].last_name?, 'fixture last name is set'
   end
-
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,14 +1,14 @@
 $LOAD_PATH << 'test'
 require 'rubygems'
 require 'spork'
-#uncomment the following line to use spork with the debugger
-#require 'spork/ext/ruby-debug'
+# uncomment the following line to use spork with the debugger
+# require 'spork/ext/ruby-debug'
 
 Spork.prefork do
   # Loading more in this block will cause your tests to run faster. However,
   # if you change any configuration or code from libraries loaded here, you'll
   # need to restart spork for it take effect.
-  ENV["RAILS_ENV"] ||= "test"
+  ENV['RAILS_ENV'] ||= 'test'
 
   require 'rails/application'
   Spork.trap_method(Rails::Application::RoutesReloader, :reload!)
@@ -89,15 +89,15 @@ end
 # Re-raises any MiniTest::Assertion from a failing test assertion in the block.
 #
 # Returns the value of the yielded block when no test assertion fails.
-def fails_intermittently(issue_link, args = {}, &block)
-  raise ArgumentError, "provide a GitHub issue link" unless issue_link
-  raise ArgumentError, "a block is required" unless block_given?
+def fails_intermittently(issue_link, args = {}, &_block)
+  fail ArgumentError, 'provide a GitHub issue link' unless issue_link
+  fail ArgumentError, 'a block is required' unless block_given?
   yield
 rescue MiniTest::Assertion, StandardError => boom # we have a test failure!
   STDERR.puts "\n\nIntermittent test failure! See: #{issue_link}"
 
   if args.empty?
-    STDERR.puts "No further debugging information available."
+    STDERR.puts 'No further debugging information available.'
   else
     STDERR.puts "Debugging information:\n"
     args.keys.sort.each do |key|


### PR DESCRIPTION
Side effect of installing Rubocop is that it gripes about a whole lot of stuff. So, I first ran the automatic code cleanup option `rubocop <target> -a` and then followed it up with plowing through each flagged line manually. The test suite remains in tact, so I'm relatively confident in how this turned out. Still, I'm not in a rush to merge this until I've had a better chance to do some UAT on the app locally to make sure the critical paths are working properly.

I stopped working on it when it had 99 problems detected, mostly because those are going to be harder to solve ... and because I enjoy a cheap laugh.

Details of remaining issues after this PR: https://gist.github.com/stephenyeargin/136403f7c0f4d50cfb42
