### PR TITLE
Last bit of Rubocop complaints

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,8 +11,32 @@ AllCops:
     - 'db/**/*'
     - 'log/**/*'
     - 'public/**/*'
-    - 'test/**/*'
     - 'vendor/**/*'
 
+## These should be reduced to their defaults,
+## but we'll start at these to make sure it
+## doesn't get any worse
+
+Metrics/AbcSize:
+  # Max: 15
+  Max: 110
+
+Metrics/CyclomaticComplexity:
+  # Max: 6
+  Max: 15
+
+Metrics/PerceivedComplexity:
+  # Max: 7
+  Max: 20
+
+Metrics/MethodLength:
+  # Max: 10
+  Max: 65
+
+Metrics/ClassLength:
+  # Max: 100
+  Max: 300
+
 Documentation:
+  # Enabled: true
   Enabled: false

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -8,11 +8,13 @@ class GroupsController < ApplicationController
   end
 
   def new
+    active_entities = Entity.order_by_name.active
     @entity = Entity.find_by_id(params[:entity_id])
-    @entities = Entity.order_by_name.active.inject({}) do |options, entity|
+    options = {}
+    active_entities.each_with_object({}) do |entity|
       (options[entity.entity_type] ||= []) << [entity.entity_name, entity.id]
-      options
     end
+    @entities = options
     @group = Group.new
   end
 
@@ -139,10 +141,9 @@ class GroupsController < ApplicationController
 
   def leave
     @group = Group.find_by_id(params[:id]) || not_found
-    if @group.admin?(current_user)
-      flash[:error] = 'Administrator cannot leave group.'
-      redirect_to(action: 'show', id: @group.id) && return
-    end
+    redirect_to(
+      action: 'show', id: @group.id
+    ) && return if @group.admin?(current_user)
   end
 
   def do_leave

--- a/app/controllers/public_controller.rb
+++ b/app/controllers/public_controller.rb
@@ -3,25 +3,14 @@ class PublicController < ApplicationController
   before_action :authenticate_user!, only: :token
 
   def index
-    if user_signed_in?
-      if session[:current_group_id].is_a? Numeric
-        redirect_to(
-          controller: 'groups', action: 'show',
-          id: session[:current_group_id], status: 302
-        ) && return
-      else
-        groups = current_user.groups.active
-        if groups.count == 0
-          redirect_to(
-            controller: 'groups', action: 'index', status: 302
-          ) && return
-        else
-          redirect_to(
-            controller: 'groups', action: 'show', id: groups.first.id,
-            status: 302
-          ) && return
-        end
-      end
+    render 'index' && return unless user_signed_in?
+    if session[:current_group_id].is_a? Numeric
+      redirect_to(
+        controller: 'groups', action: 'show',
+        id: session[:current_group_id], status: 302
+      ) && return
+    else
+      redirect_to_default_group
     end
   end
 
@@ -49,10 +38,24 @@ class PublicController < ApplicationController
   private
 
   def layout_by_resource
-    if params[:action] === 'index'
+    if params[:action] == 'index'
       'home'
     else
       'two-column'
+    end
+  end
+
+  def redirect_to_default_group
+    groups = current_user.groups.active
+    if groups.count == 0
+      redirect_to(
+        controller: 'groups', action: 'index', status: 302
+      ) && return
+    else
+      redirect_to(
+        controller: 'groups', action: 'show', id: groups.first.id,
+        status: 302
+      ) && return
     end
   end
 end

--- a/app/controllers/user_aliases_controller.rb
+++ b/app/controllers/user_aliases_controller.rb
@@ -20,9 +20,9 @@ class UserAliasesController < ApplicationController
 
   def edit
     @user_alias = UserAlias.find_by_id(params[:id]) || not_found
-    if @user_alias.user_id != current_user.id
-      redirect_to(controller: 'profiles', action: 'edit') && return
-    end
+    redirect_to(
+      controller: 'profiles', action: 'edit'
+    ) && return if @user_alias.user_id != current_user.id
   end
 
   def update

--- a/app/mailers/schedule_notifier.rb
+++ b/app/mailers/schedule_notifier.rb
@@ -58,7 +58,7 @@ class ScheduleNotifier < ActionMailer::Base
 
   def events_day_of_week(events)
     events_day_of_week = []
-    for day_of_week, index in Date::DAYNAMES.each_with_index.to_a.rotate(1)
+    Date::DAYNAMES.each_with_index.to_a.rotate(1).each do |_, index|
       events_day_of_week[index] = []
       events.each do |event|
         next if event.start_time.wday != index

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -26,7 +26,10 @@ class EventsControllerTest < ActionController::TestCase
     get :show, id: 4, group_id: 1
 
     assert_response :success, 'received a 200 status'
-    assert_select 'div.panel-heading', 'Saturday, October 26, 2013 - 3:00 pm EDT'
+    assert_select(
+      'div.panel-heading',
+      'Saturday, October 26, 2013 - 3:00 pm EDT'
+    )
   end
 
   test 'should get the correct ticket counts' do

--- a/test/controllers/groups_controller_test.rb
+++ b/test/controllers/groups_controller_test.rb
@@ -25,8 +25,16 @@ class GroupsControllerTest < ActionController::TestCase
     get :new
     assert_response :success, 'got a 200 status'
     assert_select 'title', 'Create a Group', 'page title matches'
-    assert_select "form input[name='group[group_name]']", 1, 'group name field exists'
-    assert_select "form select[name='group[entity_id]'] option", 6, 'select on page has six items'
+    assert_select(
+      "form input[name='group[group_name]']",
+      1,
+      'group name field exists'
+    )
+    assert_select(
+      "form select[name='group[entity_id]'] option",
+      6,
+      'select on page has six items'
+    )
   end
 
   test 'should see join page' do
@@ -45,7 +53,10 @@ class GroupsControllerTest < ActionController::TestCase
     get :join, invite_code: 'ABC123'
     assert_response :success, 'got a 200 status'
     assert_select 'title', 'Join a Group', 'page title matches'
-    assert_tag tag: 'input', attributes: { id: 'group_invitation_code', value: 'ABC123' }
+    assert_tag(
+      tag: 'input',
+      attributes: { id: 'group_invitation_code', value: 'ABC123' }
+    )
   end
 
   test 'should see invite page' do
@@ -145,7 +156,10 @@ class GroupsControllerTest < ActionController::TestCase
 
     post :do_leave, user_id: @removed, id: @group.id
     assert_response :redirect, 'got a 304 status'
-    assert_equal flash[:error], 'You do not have permission to remove other users.'
+    assert_equal(
+      flash[:error],
+      'You do not have permission to remove other users.'
+    )
   end
 
   test 'should see group message window' do

--- a/test/controllers/public_controller_test.rb
+++ b/test/controllers/public_controller_test.rb
@@ -29,14 +29,22 @@ class PublicControllerTest < ActionController::TestCase
   test 'gets terms of service page' do
     get :tos
     assert_response :success, 'loaded page with a 200'
-    assert_select 'title', 'Terms of Service - SeatShare', 'title matches expected'
+    assert_select(
+      'title',
+      'Terms of Service - SeatShare',
+      'title matches expected'
+    )
     assert_select 'h1', 'Terms of Service', 'page heading matches'
   end
 
   test 'gets privacy policy page' do
     get :privacy
     assert_response :success, 'loaded page with a 200'
-    assert_select 'title', 'Privacy Policy - SeatShare', 'title matches expected'
+    assert_select(
+      'title',
+      'Privacy Policy - SeatShare',
+      'title matches expected'
+    )
     assert_select 'h1', 'Privacy Policy', 'page heading matches'
   end
 
@@ -50,7 +58,11 @@ class PublicControllerTest < ActionController::TestCase
   test 'gets teams page' do
     get :teams
     assert_response :success, 'loaded page with a 200'
-    assert_select 'title', 'Manage Season Tickets for Your Favorite Team - SeatShare', 'title matches expected'
+    assert_select(
+      'title',
+      'Manage Season Tickets for Your Favorite Team - SeatShare',
+      'title matches expected'
+    )
     assert_select 'h1', 'Take home field advantage', 'page heading matches'
   end
 end

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -18,7 +18,11 @@ class RegistrationsControllerTest < ActionController::TestCase
 
     assert_response :success
     assert_select 'title', 'Create Your SeatShare Account'
-    assert_select 'h4', "You've been invited join a group!", 'invitation code block appears'
+    assert_select(
+      'h4',
+      "You've been invited join a group!",
+      'invitation code block appears'
+    )
     assert_select 'strong.invite_code', 'ABCDEFG123', 'invitation code appears'
   end
 
@@ -28,7 +32,10 @@ class RegistrationsControllerTest < ActionController::TestCase
     get :new, entity_id: '1', entity_slug: 'nashville-predators-nhl'
 
     assert_response :success
-    assert_select 'title', 'Create Your SeatShare Account - Nashville Predators (NHL)'
+    assert_select(
+      'title',
+      'Create Your SeatShare Account - Nashville Predators (NHL)'
+    )
     assert_select 'h4', 'Create a Nashville Predators group'
   end
 end

--- a/test/controllers/tickets_controller_test.rb
+++ b/test/controllers/tickets_controller_test.rb
@@ -15,7 +15,10 @@ class TicketsControllerTest < ActionController::TestCase
     get :edit, group_id: 1, event_id: 1, id: 2
 
     assert_response :success, 'received 200 status'
-    assert_select 'title', 'Belmont Bruins vs. Brescia - 326 K 10', 'ticket edit title matches'
+    assert_select(
+      'title',
+      'Belmont Bruins vs. Brescia - 326 K 10', 'ticket edit title matches'
+    )
   end
 
   test 'should unassign ticket' do
@@ -54,7 +57,10 @@ class TicketsControllerTest < ActionController::TestCase
     get :request_ticket, group_id: 1, event_id: 1, id: 2
 
     assert_response :success, 'received 200 status'
-    assert_select 'title', 'Belmont Bruins vs. Brescia - 326 K 10', 'ticket request title matches'
+    assert_select(
+      'title',
+      'Belmont Bruins vs. Brescia - 326 K 10', 'ticket request title matches'
+    )
   end
 
   test 'should get future tickets' do

--- a/test/integration/group_flow_test.rb
+++ b/test/integration/group_flow_test.rb
@@ -4,31 +4,46 @@ class GroupFlowTest < ActionDispatch::IntegrationTest
   fixtures :users
 
   test 'create a group' do
-    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
+    post_via_redirect(
+      '/login',
+      user: { email: users(:jim).email, password: 'testing123' }
+    )
 
     get '/groups/new'
     assert_response :success
 
-    post_via_redirect '/groups/new', group: { group_name: 'A Test Group', entity_id: '5' }
+    post_via_redirect(
+      '/groups/new',
+      group: { group_name: 'A Test Group', entity_id: '5' }
+    )
     assert_response :success
     assert_select 'title', 'A Test Group'
     assert_equal 'Group created!', flash[:notice]
   end
 
   test 'edit a group' do
-    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
+    post_via_redirect(
+      '/login',
+      user: { email: users(:jim).email, password: 'testing123' }
+    )
 
     get '/groups/1/edit'
     assert_response :success
 
-    patch_via_redirect '/groups/1/edit', group: { group_name: 'Group Name Changed' }
+    patch_via_redirect(
+      '/groups/1/edit',
+      group: { group_name: 'Group Name Changed' }
+    )
     assert_response :success
     assert_select 'title', 'Group Name Changed'
     assert_equal 'Group updated!', flash[:notice]
   end
 
   test 'join a group' do
-    post_via_redirect '/login', user: { email: users(:jane).email, password: 'testing123' }
+    post_via_redirect(
+      '/login',
+      user: { email: users(:jane).email, password: 'testing123' }
+    )
 
     get '/groups/join'
     assert_response :success
@@ -40,7 +55,10 @@ class GroupFlowTest < ActionDispatch::IntegrationTest
   end
 
   test 'leave a group' do
-    post_via_redirect '/login', user: { email: users(:jill).email, password: 'testing123' }
+    post_via_redirect(
+      '/login',
+      user: { email: users(:jill).email, password: 'testing123' }
+    )
 
     get '/groups/1/leave'
     assert_response :success
@@ -52,12 +70,18 @@ class GroupFlowTest < ActionDispatch::IntegrationTest
   end
 
   test 'invite a user' do
-    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
+    post_via_redirect(
+      '/login',
+      user: { email: users(:jim).email, password: 'testing123' }
+    )
 
     get '/groups/1/invite'
     assert_response :success
 
-    post_via_redirect '/groups/1/invite', group_invitation: { email: 'rick@example.net', message: 'Join us!' }
+    post_via_redirect(
+      '/groups/1/invite',
+      group_invitation: { email: 'rick@example.net', message: 'Join us!' }
+    )
     assert_response :success
     assert_equal '/groups/1', path
     assert_equal 'Group invitation sent!', flash[:notice]
@@ -65,7 +89,10 @@ class GroupFlowTest < ActionDispatch::IntegrationTest
   end
 
   test 'remove a user from a group' do
-    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
+    post_via_redirect(
+      '/login',
+      user: { email: users(:jim).email, password: 'testing123' }
+    )
 
     get '/groups/1/edit'
     assert_response :success

--- a/test/integration/profile_flow_test.rb
+++ b/test/integration/profile_flow_test.rb
@@ -4,12 +4,27 @@ class ProfileFlowTest < ActionDispatch::IntegrationTest
   fixtures :users, :profiles
 
   test 'edit user profile' do
-    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
+    post_via_redirect(
+      '/login',
+      user: { email: users(:jim).email, password: 'testing123' }
+    )
 
     get '/profile'
     assert_response :success
 
-    patch_via_redirect '/profile', user: { first_name: 'Jim', last_name: 'Stone', profile_attributes: { bio: 'Something else entirely.', location: 'Somewhere Else', mobile: '(555) 555-4567', notify_sms: 1 } }
+    patch_via_redirect(
+      '/profile',
+      user: {
+        first_name: 'Jim',
+        last_name: 'Stone',
+        profile_attributes: {
+          bio: 'Something else entirely.',
+          location: 'Somewhere Else',
+          mobile: '(555) 555-4567',
+          notify_sms: 1
+        }
+      }
+    )
     assert_response :success
     assert_select 'title', 'Jim Stone'
     assert_equal 'Profile updated!', flash[:notice]
@@ -18,7 +33,10 @@ class ProfileFlowTest < ActionDispatch::IntegrationTest
   end
 
   test 'view edit user without profile' do
-    post_via_redirect '/login', user: { email: users(:rick).email, password: 'testing123' }
+    post_via_redirect(
+      '/login',
+      user: { email: users(:rick).email, password: 'testing123' }
+    )
 
     get '/profile'
     assert_response :success
@@ -27,7 +45,10 @@ class ProfileFlowTest < ActionDispatch::IntegrationTest
   end
 
   test 'view user without profile' do
-    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
+    post_via_redirect(
+      '/login',
+      user: { email: users(:jim).email, password: 'testing123' }
+    )
 
     get '/profiles/3'
     assert_response :success

--- a/test/integration/ticket_flow_test.rb
+++ b/test/integration/ticket_flow_test.rb
@@ -4,13 +4,26 @@ class TicketFlowTest < ActionDispatch::IntegrationTest
   fixtures :users
 
   test 'add a single ticket' do
-    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
+    post_via_redirect(
+      '/login',
+      user: { email: users(:jim).email, password: 'testing123' }
+    )
 
     get '/groups/1/event-4'
     assert_response :success
     assert_select 'title', 'Nashville Predators vs. St. Louis Blues'
 
-    post_via_redirect '/groups/1/event-4/add-ticket', ticket: { section: '325', row: 'L', seat: '9', event_id: 4, cost: '40.00', note: 'added a note' }
+    post_via_redirect(
+      '/groups/1/event-4/add-ticket',
+      ticket: {
+        section: '325',
+        row: 'L',
+        seat: '9',
+        event_id: 4,
+        cost: '40.00',
+        note: 'added a note'
+      }
+    )
 
     assert_response :success
     assert_equal '/groups/1/event-4', path
@@ -18,13 +31,19 @@ class TicketFlowTest < ActionDispatch::IntegrationTest
   end
 
   test 'add a single ticket - no section' do
-    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
+    post_via_redirect(
+      '/login',
+      user: { email: users(:jim).email, password: 'testing123' }
+    )
 
     get '/groups/1/event-4'
     assert_response :success
     assert_select 'title', 'Nashville Predators vs. St. Louis Blues'
 
-    post_via_redirect '/groups/1/event-4/add-ticket', ticket: { event_id: 4, cost: '40.00', note: 'added a note' }
+    post_via_redirect(
+      '/groups/1/event-4/add-ticket',
+      ticket: { event_id: 4, cost: '40.00', note: 'added a note' }
+    )
 
     assert_response :success
     assert_equal '/groups/1/event-4/add-ticket', path
@@ -32,13 +51,26 @@ class TicketFlowTest < ActionDispatch::IntegrationTest
   end
 
   test 'add season tickets' do
-    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
+    post_via_redirect(
+      '/login',
+      user: { email: users(:jim).email, password: 'testing123' }
+    )
 
     get '/groups/1/event-4'
     assert_response :success
     assert_select 'title', 'Nashville Predators vs. St. Louis Blues'
 
-    post_via_redirect '/groups/1/add-tickets', ticket: { event_id: [3, 4], section: '100', row: 'R', seat: 2, cost: '40.00', note: 'added a note' }
+    post_via_redirect(
+      '/groups/1/add-tickets',
+      ticket: {
+        event_id: [3, 4],
+        section: '100',
+        row: 'R',
+        seat: 2,
+        cost: '40.00',
+        note: 'added a note'
+      }
+    )
 
     assert_response :success
     assert_equal '/groups/1', path
@@ -46,13 +78,19 @@ class TicketFlowTest < ActionDispatch::IntegrationTest
   end
 
   test 'add season tickets - no section' do
-    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
+    post_via_redirect(
+      '/login',
+      user: { email: users(:jim).email, password: 'testing123' }
+    )
 
     get '/groups/1/event-4'
     assert_response :success
     assert_select 'title', 'Nashville Predators vs. St. Louis Blues'
 
-    post_via_redirect '/groups/1/add-tickets', ticket: { event_id: [3, 4], cost: '40.00', note: 'added a note' }
+    post_via_redirect(
+      '/groups/1/add-tickets',
+      ticket: { event_id: [3, 4], cost: '40.00', note: 'added a note' }
+    )
 
     assert_response :success
     assert_equal '/groups/1/add-tickets', path
@@ -60,13 +98,25 @@ class TicketFlowTest < ActionDispatch::IntegrationTest
   end
 
   test 'add season tickets - no events' do
-    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
+    post_via_redirect(
+      '/login',
+      user: { email: users(:jim).email, password: 'testing123' }
+    )
 
     get '/groups/1/event-4'
     assert_response :success
     assert_select 'title', 'Nashville Predators vs. St. Louis Blues'
 
-    post_via_redirect '/groups/1/add-tickets', ticket: { section: '325', row: 'J', seat: 5, cost: '40.00', note: 'added a note' }
+    post_via_redirect(
+      '/groups/1/add-tickets',
+      ticket: {
+        section: '325',
+        row: 'J',
+        seat: 5,
+        cost: '40.00',
+        note: 'added a note'
+      }
+    )
 
     assert_response :success
     assert_equal '/groups/1/add-tickets', path
@@ -74,13 +124,19 @@ class TicketFlowTest < ActionDispatch::IntegrationTest
   end
 
   test 'edit a ticket' do
-    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
+    post_via_redirect(
+      '/login',
+      user: { email: users(:jim).email, password: 'testing123' }
+    )
 
     get '/groups/1/event-4/ticket-1'
     assert_response :success
     assert_select 'title', 'Nashville Predators vs. St. Louis Blues - 326 K 9'
 
-    post_via_redirect '/groups/1/event-4/ticket-1', ticket: { cost: '40.00', note: 'added a note' }
+    post_via_redirect(
+      '/groups/1/event-4/ticket-1',
+      ticket: { cost: '40.00', note: 'added a note' }
+    )
 
     assert_response :success
     assert_equal '/groups/1/event-4', path
@@ -88,27 +144,37 @@ class TicketFlowTest < ActionDispatch::IntegrationTest
   end
 
   test 'request a ticket' do
-    post_via_redirect '/login', user: { email: users(:jill).email, password: 'testing123' }
+    post_via_redirect(
+      '/login',
+      user: { email: users(:jill).email, password: 'testing123' }
+    )
 
     get '/groups/1/event-4/ticket-1/request'
     assert_response :success
     assert_select 'title', 'Nashville Predators vs. St. Louis Blues - 326 K 9'
 
-    patch_via_redirect '/groups/1/event-4/ticket-1/request', message: { personalization: 'requesting a ticket' }
-
+    patch_via_redirect(
+      '/groups/1/event-4/ticket-1/request',
+      message: { personalization: 'requesting a ticket' }
+    )
     assert_response :success
     assert_equal '/groups/1/event-4', path
     assert_equal 'Ticket request sent!', flash[:notice]
   end
 
   test 'assign a ticket' do
-    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
+    post_via_redirect(
+      '/login', user: { email: users(:jim).email, password: 'testing123' }
+    )
 
     get '/groups/1/event-4/ticket-1'
     assert_response :success
     assert_select 'title', 'Nashville Predators vs. St. Louis Blues - 326 K 9'
 
-    post_via_redirect '/groups/1/event-4/ticket-1', ticket: { user_id: 2, cost: '40.00', note: 'added a note' }
+    post_via_redirect(
+      '/groups/1/event-4/ticket-1',
+      ticket: { user_id: 2, cost: '40.00', note: 'added a note' }
+    )
 
     assert_response :success
     assert_equal '/groups/1/event-4', path
@@ -116,7 +182,9 @@ class TicketFlowTest < ActionDispatch::IntegrationTest
   end
 
   test 'unassign a ticket' do
-    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
+    post_via_redirect(
+      '/login', user: { email: users(:jim).email, password: 'testing123' }
+    )
 
     get '/groups/1/event-4/ticket-1/unassign'
 
@@ -125,7 +193,10 @@ class TicketFlowTest < ActionDispatch::IntegrationTest
   end
 
   test 'delete a ticket' do
-    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
+    post_via_redirect(
+      '/login',
+      user: { email: users(:jim).email, password: 'testing123' }
+    )
 
     get '/groups/1/event-4/ticket-1/delete'
 
@@ -134,27 +205,45 @@ class TicketFlowTest < ActionDispatch::IntegrationTest
   end
 
   test 'bulk edit tickets - future' do
-    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
+    post_via_redirect(
+      '/login',
+      user: { email: users(:jim).email, password: 'testing123' }
+    )
 
-    post_via_redirect '/tickets', ticket_cost: { '1' => '10.00', '2' => '15.00' }, tickets: { filter: nil }
+    post_via_redirect(
+      '/tickets',
+      ticket_cost: { '1' => '10.00', '2' => '15.00' }, tickets: { filter: nil }
+    )
 
     assert_response :success
     assert_equal 'Tickets updated!', flash[:notice]
   end
 
   test 'bulk edit tickets - past' do
-    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
+    post_via_redirect(
+      '/login',
+      user: { email: users(:jim).email, password: 'testing123' }
+    )
 
-    post_via_redirect '/tickets', ticket_cost: { '2' => '15.00' }, tickets: { filter: 'past' }
+    post_via_redirect(
+      '/tickets',
+      ticket_cost: { '2' => '15.00' }, tickets: { filter: 'past' }
+    )
 
     assert_response :success
     assert_equal 'Tickets updated!', flash[:notice]
   end
 
   test 'bulk edit tickets - not owner' do
-    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
+    post_via_redirect(
+      '/login',
+      user: { email: users(:jim).email, password: 'testing123' }
+    )
 
-    post_via_redirect '/tickets', ticket_cost: { '4' => '15.00' }, tickets: { filter: nil }
+    post_via_redirect(
+      '/tickets',
+      ticket_cost: { '4' => '15.00' }, tickets: { filter: nil }
+    )
 
     assert_response :success
     assert_equal 'Ticket cost could not be updated.', flash[:error]

--- a/test/integration/user_login_test.rb
+++ b/test/integration/user_login_test.rb
@@ -7,7 +7,10 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     get '/login'
     assert_response :success
 
-    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
+    post_via_redirect(
+      '/login',
+      user: { email: users(:jim).email, password: 'testing123' }
+    )
     assert_equal nil, flash[:alert]
     assert_equal 'Signed in successfully.', flash[:notice]
     assert_equal '/groups/1', path
@@ -17,7 +20,10 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     get '/login'
     assert_response :success
 
-    post_via_redirect '/login', user: { email: users(:sarah).email, password: 'testing123' }
+    post_via_redirect(
+      '/login',
+      user: { email: users(:sarah).email, password: 'testing123' }
+    )
     assert_equal nil, flash[:alert]
     assert_equal 'Signed in successfully.', flash[:notice]
     assert_equal '/groups', path
@@ -27,7 +33,10 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     get '/login'
     assert_response :success
 
-    post_via_redirect '/login', user: { email: users(:peter).email, password: 'testing123' }
+    post_via_redirect(
+      '/login',
+      user: { email: users(:peter).email, password: 'testing123' }
+    )
     assert_equal 'Your account is not activated yet.', flash[:alert]
     assert_equal '/login', path
   end
@@ -36,7 +45,10 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     get '/login'
     assert_response :success
 
-    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
+    post_via_redirect(
+      '/login',
+      user: { email: users(:jim).email, password: 'testing123' }
+    )
     assert_equal nil, flash[:alert]
     assert_equal 'Signed in successfully.', flash[:notice]
     assert_equal '/groups/1', path

--- a/test/integration/user_signup_test.rb
+++ b/test/integration/user_signup_test.rb
@@ -5,7 +5,16 @@ class UserSignupTest < ActionDispatch::IntegrationTest
     get '/register'
     assert_response :success
 
-    post_via_redirect '/', user: { first_name: 'New', last_name: 'User', email: 'newuser@example.com', password: 'testing123', password_confirm: 'testing123' }
+    post_via_redirect(
+      '/',
+      user: {
+        first_name: 'New',
+        last_name: 'User',
+        email: 'newuser@example.com',
+        password: 'testing123',
+        password_confirm: 'testing123'
+      }
+    )
 
     assert_response :success
     assert_equal nil, flash[:alert]
@@ -17,7 +26,16 @@ class UserSignupTest < ActionDispatch::IntegrationTest
     get '/register'
     assert_response :success
 
-    post_via_redirect '/', user: { first_name: 'New', last_name: 'User', email: 'stonej@example.net', password: 'testing123', password_confirm: 'testing123' }
+    post_via_redirect(
+      '/',
+      user: {
+        first_name: 'New',
+        last_name: 'User',
+        email: 'stonej@example.net',
+        password: 'testing123',
+        password_confirm: 'testing123'
+      }
+    )
 
     assert_response :success
     assert_equal 'There were errors with your registration.', flash[:alert]
@@ -29,7 +47,17 @@ class UserSignupTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select 'h4', "You've been invited join a group!"
 
-    post_via_redirect '/', user: { first_name: 'New', last_name: 'User', email: 'newuser@example.com', password: 'testing123', password_confirm: 'testing123', invite_code: 'ABCDEFG123' }
+    post_via_redirect(
+      '/',
+      user: {
+        first_name: 'New',
+        last_name: 'User',
+        email: 'newuser@example.com',
+        password: 'testing123',
+        password_confirm: 'testing123',
+        invite_code: 'ABCDEFG123'
+      }
+    )
 
     assert_response :success
     assert_equal nil, flash[:alert]
@@ -42,7 +70,17 @@ class UserSignupTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select 'h4', 'Create a Nashville Predators group'
 
-    post_via_redirect '/', user: { first_name: 'New', last_name: 'User', email: 'newuser@example.com', password: 'testing123', password_confirm: 'testing123', entity_id: 1 }
+    post_via_redirect(
+      '/',
+      user: {
+        first_name: 'New',
+        last_name: 'User',
+        email: 'newuser@example.com',
+        password: 'testing123',
+        password_confirm: 'testing123',
+        entity_id: 1
+      }
+    )
 
     assert_response :success
     assert_equal nil, flash[:alert]
@@ -51,12 +89,18 @@ class UserSignupTest < ActionDispatch::IntegrationTest
   end
 
   test 'add user alias' do
-    post_via_redirect '/login', user: { email: users(:jim).email, password: 'testing123' }
+    post_via_redirect(
+      '/login',
+      user: { email: users(:jim).email, password: 'testing123' }
+    )
 
     get '/profile/aliases/new'
     assert_response :success
 
-    post_via_redirect '/profile/aliases/new', user_alias: { first_name: 'New', last_name: 'Alias' }
+    post_via_redirect(
+      '/profile/aliases/new',
+      user_alias: { first_name: 'New', last_name: 'Alias' }
+    )
 
     assert_response :success
     assert_equal nil, flash[:alert]
@@ -65,7 +109,10 @@ class UserSignupTest < ActionDispatch::IntegrationTest
   end
 
   test 'delete user alias' do
-    post_via_redirect '/login', user: { email: users(:jill).email, password: 'testing123' }
+    post_via_redirect(
+      '/login',
+      user: { email: users(:jill).email, password: 'testing123' }
+    )
 
     get '/profile'
     assert_response :success

--- a/test/mailers/custom_devise_mailer_test.rb
+++ b/test/mailers/custom_devise_mailer_test.rb
@@ -42,8 +42,15 @@ class CustomDeviseMailerTest < ActionMailer::TestCase
   end
 
   test 'body should have link to confirm the account' do
-    if mail.body.encoded =~ %r{<a href=\"http://localhost:3000/password/edit\?reset_password_token=([^"]+)">}
-      assert_equal Devise.token_generator.digest(user.class, :reset_password_token, Regexp.last_match[1]), user.reset_password_token
+    if mail.body.encoded =~ %r{/password/edit\?reset_password_token=([^"]+)">}
+      assert_equal(
+        Devise.token_generator.digest(
+          user.class,
+          :reset_password_token,
+          Regexp.last_match[1]
+        ),
+        user.reset_password_token
+      )
     else
       flunk 'expected reset password url regex to match'
     end

--- a/test/mailers/group_notifier_test.rb
+++ b/test/mailers/group_notifier_test.rb
@@ -10,10 +10,25 @@ class GroupNotifierTest < ActionMailer::TestCase
     assert_equal ['no-reply@myseatshare.com'], email.from
     assert_equal ['sarahb@example.org'], email.reply_to
     assert_equal ['bob@example.com'], email.to
-    assert_equal 'You have been invited to join Geeks Watching Hockey', email.subject
-    assert_includes email.body.to_s, '<title>You have been invited to join Geeks Watching Hockey</title>'
-    assert_includes email.body.to_s, "<a href=\"http://localhost:3000/register/invite/ABCDEFG123\">Use Invitation ABCDEFG123</a>"
-    assert_includes email.body.to_s, "Sarah Becker has invited you to join our <strong>Nashville Predators</strong> group on <a href=\"http://localhost:3000/\">SeatShare</a>, a service that helps manage our season tickets."
+    assert_equal(
+      'You have been invited to join Geeks Watching Hockey',
+      email.subject
+    )
+    assert_includes(
+      email.body.to_s,
+      '<title>You have been invited to join Geeks Watching Hockey</title>'
+    )
+    assert_includes(
+      email.body.to_s,
+      "<a href=\"http://localhost:3000/register/invite/ABCDEFG123\">"\
+        'Use Invitation ABCDEFG123</a>'
+    )
+    assert_includes(
+      email.body.to_s,
+      'Sarah Becker has invited you to join our <strong>Nashville '\
+        "Predators</strong> group on <a href=\"http://localhost:3000/\">"\
+        'SeatShare</a>, a service that helps manage our season tickets.'
+    )
   end
 
   test 'send group message' do
@@ -21,15 +36,38 @@ class GroupNotifierTest < ActionMailer::TestCase
     group = Group.find(1)
     recipient_users = group.users
 
-    email = GroupNotifier.send_group_message(group, sending_user, recipient_users, 'Anyone want to go to the game on Friday?', "I'll have an extra ticket to spare.\n\nFree to a good home.").deliver
+    email = GroupNotifier.send_group_message(
+        group,
+        sending_user,
+        recipient_users,
+        'Anyone want to go to the game on Friday?',
+        "I'll have an extra ticket to spare.\n\nFree to a good home."
+        ).deliver
 
     assert_not ActionMailer::Base.deliveries.empty?
     assert_equal ['no-reply@myseatshare.com'], email.from
     assert_equal ['stonej@example.net'], email.reply_to
-    assert_equal ['stonej@example.net', 'jillsmith83@us.example.org', 'rick.taylor@example.net'], email.to
-    assert_equal '[Geeks Watching Hockey] Anyone want to go to the game on Friday?', email.subject
-    assert_includes email.body.to_s, '<title>[Geeks Watching Hockey] Anyone want to go to the game on Friday?</title>'
-    assert_includes email.body.to_s, "<p>I'll have an extra ticket to spare.</p>"
+    assert_equal(
+      [
+        'stonej@example.net',
+        'jillsmith83@us.example.org',
+        'rick.taylor@example.net'
+      ],
+      email.to
+    )
+    assert_equal(
+      '[Geeks Watching Hockey] Anyone want to go to the game on Friday?',
+      email.subject
+    )
+    assert_includes(
+      email.body.to_s,
+      '<title>[Geeks Watching Hockey] Anyone want to go to the game '\
+        'on Friday?</title>'
+    )
+    assert_includes(
+      email.body.to_s,
+      "<p>I'll have an extra ticket to spare.</p>"
+    )
     assert_includes email.body.to_s, '<p>Free to a good home.</p>'
   end
 end

--- a/test/mailers/schedule_notifier_test.rb
+++ b/test/mailers/schedule_notifier_test.rb
@@ -12,12 +12,21 @@ class ScheduleNotifierTest < ActionMailer::TestCase
     assert_equal ['no-reply@myseatshare.com'], email.from
     assert_equal ['stonej@example.net'], email.to
     assert_equal 'Today\'s events for Geeks Watching Hockey', email.subject
-    assert_includes email.body.to_s, '<title>Today&#39;s events for Geeks Watching Hockey</title>'
-    assert_includes email.body.to_s, '<td><a href="http://localhost:3000/groups/1/event-7">Nashville Predators vs. Florida Panthers</a></td>'
+    assert_includes(
+      email.body.to_s,
+      '<title>Today&#39;s events for Geeks Watching Hockey</title>'
+    )
+    assert_includes(
+      email.body.to_s,
+      '<td><a href="http://localhost:3000/groups/1/event-7">Nashville '\
+        'Predators vs. Florida Panthers</a></td>'
+    )
   end
 
   test 'send weekly schedule' do
-    events = Event.where('start_time >= \'2013-10-13\' AND start_time <= \'2013-10-20\'').order_by_date
+    events = Event.where(
+      'start_time >= \'2013-10-13\' AND start_time <= \'2013-10-20\''
+    ).order_by_date
     group = Group.find(1)
     user = User.find(1)
 
@@ -27,7 +36,14 @@ class ScheduleNotifierTest < ActionMailer::TestCase
     assert_equal ['no-reply@myseatshare.com'], email.from
     assert_equal ['stonej@example.net'], email.to
     assert_equal 'The week ahead for Geeks Watching Hockey', email.subject
-    assert_includes email.body.to_s, '<title>The week ahead for Geeks Watching Hockey</title>'
-    assert_includes email.body.to_s, '<td><a href="http://localhost:3000/groups/1/event-6">Nashville Predators vs. Los Angeles Kings</a></td>'
+    assert_includes(
+      email.body.to_s,
+      '<title>The week ahead for Geeks Watching Hockey</title>'
+    )
+    assert_includes(
+      email.body.to_s,
+      '<td><a href="http://localhost:3000/groups/1/event-6">Nashville '\
+        'Predators vs. Los Angeles Kings</a></td>'
+    )
   end
 end

--- a/test/mailers/ticket_notifier_test.rb
+++ b/test/mailers/ticket_notifier_test.rb
@@ -10,14 +10,33 @@ class TicketNotifierTest < ActionMailer::TestCase
     assert_not ActionMailer::Base.deliveries.empty?
     assert_equal email.from, ['no-reply@myseatshare.com']
     assert_equal email.to, ['jillsmith83@us.example.org']
-    assert_equal email.subject, 'Rick has assigned you a ticket via Geeks Watching Hockey'
+    assert_equal(
+      email.subject,
+      'Rick has assigned you a ticket via Geeks Watching Hockey'
+    )
     assert_includes email.body.to_s, '<p>Jill,</p>'
-    assert_includes email.body.to_s, '<p>Rick Taylor (<a href="mailto:rick.taylor@example.net">rick.taylor@example.net</a>) has assigned a ticket to you for the following event in your group Geeks Watching Hockey.</p>'
-    fails_intermittently('https://github.com/seatshare/seatshare-rails/issues/109',
-                         'Rails.configuration.time_zone' => Rails.configuration.time_zone, 'Time.zone.name' => Time.zone.name, 'user.timezone' => user.timezone) do
-      assert_includes email.body.to_s, '<td>Nashville Predators vs. St. Louis Blues : Saturday, October 26, 2013 - 2:00 pm CDT</td>'
+    assert_includes(
+      email.body.to_s,
+      '<p>Rick Taylor (<a href="mailto:rick.taylor@example.net">'\
+        'rick.taylor@example.net</a>) has assigned a ticket to you for the '\
+        'following event in your group Geeks Watching Hockey.</p>'
+    )
+    fails_intermittently(
+      'https://github.com/seatshare/seatshare-rails/issues/109',
+      'Rails.configuration.time_zone' => Rails.configuration.time_zone,
+      'Time.zone.name' => Time.zone.name, 'user.timezone' => user.timezone
+    ) do
+      assert_includes(
+        email.body.to_s,
+        '<td>Nashville Predators vs. St. Louis Blues : Saturday, '\
+          'October 26, 2013 - 2:00 pm CDT</td>'
+      )
     end
-    assert_includes email.body.to_s, '<td><a href="http://localhost:3000/groups/1/event-4/ticket-7">326 K 13</a></td>'
+    assert_includes(
+      email.body.to_s,
+      '<td><a href="http://localhost:3000/groups/1/event-4/ticket-7">'\
+        '326 K 13</a></td>'
+    )
   end
 
   test 'ticket requested from user' do
@@ -29,13 +48,33 @@ class TicketNotifierTest < ActionMailer::TestCase
     assert_not ActionMailer::Base.deliveries.empty?
     assert_equal email.from, ['no-reply@myseatshare.com']
     assert_equal email.to, ['stonej@example.net']
-    assert_equal email.subject, 'Jill has requested your ticket via Geeks Watching Hockey'
+    assert_equal(
+      email.subject,
+      'Jill has requested your ticket via Geeks Watching Hockey'
+    )
     assert_includes email.body.to_s, '<p>Jim,</p>'
-    assert_includes email.body.to_s, '<p>Jill Smith (<a href="mailto:jillsmith83@us.example.org">jillsmith83@us.example.org</a>) has requested your ticket for the following event in your group Geeks Watching Hockey.</p>'
-    fails_intermittently('https://github.com/seatshare/seatshare-rails/issues/109',
-                         'Rails.configuration.time_zone' => Rails.configuration.time_zone, 'Time.zone.name' => Time.zone.name, 'user.timezone' => user.timezone) do
-      assert_includes email.body.to_s, '<td>Nashville Predators vs. St. Louis Blues : Saturday, October 26, 2013 - 2:00 pm CDT</td>'
+    assert_includes(
+      email.body.to_s,
+      '<p>Jill Smith (<a href="mailto:jillsmith83@us.example.org">'\
+        'jillsmith83@us.example.org</a>) has requested your ticket for the '\
+        'following event in your group Geeks Watching Hockey.</p>'
+    )
+    fails_intermittently(
+      'https://github.com/seatshare/seatshare-rails/issues/109',
+      'Rails.configuration.time_zone' => Rails.configuration.time_zone,
+      'Time.zone.name' => Time.zone.name,
+      'user.timezone' => user.timezone
+    ) do
+      assert_includes(
+        email.body.to_s,
+        '<td>Nashville Predators vs. St. Louis Blues : Saturday, October 26, '\
+          '2013 - 2:00 pm CDT</td>'
+      )
     end
-    assert_includes email.body.to_s, '<td><a href="http://localhost:3000/groups/1/event-4/ticket-2">326 K 10</a></td>'
+    assert_includes(
+      email.body.to_s,
+      '<td><a href="http://localhost:3000/groups/1/event-4/ticket-2">'\
+        '326 K 10</a></td>'
+    )
   end
 end

--- a/test/models/entity_test.rb
+++ b/test/models/entity_test.rb
@@ -14,23 +14,23 @@ class EntityTest < ActiveSupport::TestCase
   test 'fixture entity has attributes' do
     entity = Entity.find(1)
 
-    assert entity.entity_name === 'Nashville Predators', 'Name for entity is set'
-    assert entity.status === 1, 'Status for entity is inactive'
+    assert entity.entity_name == 'Nashville Predators', 'Name for entity is set'
+    assert entity.status == 1, 'Status for entity is inactive'
   end
 
   test 'gets entity by group ID' do
     entity = Group.find(2).entity
 
-    assert entity.id === 6, 'fixture entity ID matches'
-    assert entity.entity_name === 'Nashville Sportsball', 'fixture entity name matches'
-    assert entity.status === 1, 'fixture entity is active'
+    assert entity.id == 6, 'fixture entity ID matches'
+    assert entity.entity_name == 'Nashville Sportsball', 'fixture name matches'
+    assert entity.status == 1, 'fixture entity is active'
   end
 
   test 'get all active entities' do
     entities = Entity.active
 
-    assert entities.count === 5, 'count of fixture entities matches'
-    assert entities[0].class.to_s === 'Entity', 'class of fixture entity matches'
+    assert entities.count == 5, 'count of fixture entities matches'
+    assert entities[0].class.to_s == 'Entity', 'class of fixture entity matches'
     assert entities[0].entity_name?, 'fixture entity name is set'
   end
 end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -15,40 +15,58 @@ class EventTest < ActiveSupport::TestCase
     assert event.description?, 'new event has a description'
     assert event.start_time.acts_like_time?, 'new event start time is set'
     assert event.start_time.day == 1, 'new event day matches'
-    assert event.date_tba? === false, 'new event date is not TBA'
-    assert event.time_tba? === false, 'new event time is not TBA'
-    fails_intermittently('https://github.com/seatshare/seatshare-rails/issues/109',
-                         'Rails.configuration.time_zone' => Rails.configuration.time_zone, 'Time.zone.name' => Time.zone.name) do
-      assert event.date_time === 'Tuesday, January 1, 2013 - 6:00 pm CST', 'new event date/time string matches'
+    assert event.date_tba? == false, 'new event date is not TBA'
+    assert event.time_tba? == false, 'new event time is not TBA'
+    fails_intermittently(
+      'https://github.com/seatshare/seatshare-rails/issues/109',
+      'Rails.configuration.time_zone' => Rails.configuration.time_zone,
+      'Time.zone.name' => Time.zone.name
+    ) do
+      assert(
+        event.date_time == 'Tuesday, January 1, 2013 - 6:00 pm CST',
+        'new event date/time string matches'
+      )
     end
   end
 
   test 'fixture event has attributes' do
     event = Event.find(1)
 
-    assert event.event_name === 'Belmont Bruins vs. Brescia', 'fixture event name matches'
+    assert(
+      event.event_name == 'Belmont Bruins vs. Brescia',
+      'fixture event name matches'
+    )
     assert event.description.nil?, 'fixture event description is nil'
     assert event.start_time.acts_like_time?, 'fixture event start time is set'
-    assert event.start_time.day === 26, 'fixture event day matches'
-    assert event.date_tba? === false, 'event date is not TBA'
-    assert event.time_tba? === true, 'event time is TBA'
-    assert event.date_time === 'Tuesday, November 26, 2013', 'new event date/time string matches'
+    assert event.start_time.day == 26, 'fixture event day matches'
+    assert event.date_tba? == false, 'event date is not TBA'
+    assert event.time_tba? == true, 'event time is TBA'
+    assert(
+      event.date_time == 'Tuesday, November 26, 2013',
+      'new event date/time string matches'
+    )
   end
 
   test 'get events by group ID' do
     events = Group.find(1).events.order('start_time ASC')
 
-    assert events[0].class.to_s === 'Event', 'returned item is an event'
-    assert events[0].event_name === 'Nashville Predators vs. Minnesota Wild', 'event title matches'
-    assert events.count === 7, 'event count equals seven'
+    assert events[0].class.to_s == 'Event', 'returned item is an event'
+    assert(
+      events[0].event_name == 'Nashville Predators vs. Minnesota Wild',
+      'event title matches'
+    )
+    assert events.count == 7, 'event count equals seven'
   end
 
   test 'get event by ticket ID' do
     event = Ticket.find(2).event
 
-    assert event.id === 4, 'event ID matches'
-    assert event.entity_id === 1, 'entity ID matches'
-    assert event.event_name === 'Nashville Predators vs. St. Louis Blues', 'event name matches'
+    assert event.id == 4, 'event ID matches'
+    assert event.entity_id == 1, 'entity ID matches'
+    assert(
+      event.event_name == 'Nashville Predators vs. St. Louis Blues',
+      'event name matches'
+    )
   end
 
   test 'get ticket status counts' do
@@ -59,10 +77,10 @@ class EventTest < ActiveSupport::TestCase
     stats = event.ticket_stats(group, user)
 
     assert stats.is_a? Hash
-    assert stats[:available] === 1
-    assert stats[:total] === 4
-    assert stats[:held] === 1
-    assert stats[:percent_full] === 75
+    assert stats[:available] == 1
+    assert stats[:total] == 4
+    assert stats[:held] == 1
+    assert stats[:percent_full] == 75
   end
 
   test 'two created events do not share an import key' do
@@ -79,8 +97,8 @@ class EventTest < ActiveSupport::TestCase
         import_key: ''
     )
 
-    assert event1[:event_name] === 'Event 1'
-    assert event2[:event_name] === 'Event 2'
+    assert event1[:event_name] == 'Event 1'
+    assert event2[:event_name] == 'Event 2'
 
   end
 
@@ -93,10 +111,10 @@ class EventTest < ActiveSupport::TestCase
       time_certainty: 'not certain'
     }
     record = Event.import row1
-    assert record[:event_name] === 'Colorado Avalanche vs. Nashville Predators'
-    assert record[:start_time] === DateTime.parse('October 8, 2009 7:00 PM CDT')
-    assert record[:date_tba] === 0
-    assert record[:time_tba] === 1
+    assert record[:event_name] == 'Colorado Avalanche vs. Nashville Predators'
+    assert record[:start_time] == DateTime.parse('October 8, 2009 7:00 PM CDT')
+    assert record[:date_tba] == 0
+    assert record[:time_tba] == 1
 
     row2 = {
       entity_id: 1,
@@ -106,9 +124,9 @@ class EventTest < ActiveSupport::TestCase
       time_certainty: 'certain'
     }
     record = Event.import row2
-    assert record[:event_name] === 'San Jose Sharks vs. Nashville Predators'
-    assert record[:start_time] === DateTime.parse('October 22, 2009 7:00 PM CDT')
-    assert record[:date_tba] === 0
-    assert record[:time_tba] === 0
+    assert record[:event_name] == 'San Jose Sharks vs. Nashville Predators'
+    assert record[:start_time] == DateTime.parse('October 22, 2009 7:00 PM CDT')
+    assert record[:date_tba] == 0
+    assert record[:time_tba] == 0
   end
 end

--- a/test/models/group_invitation_test.rb
+++ b/test/models/group_invitation_test.rb
@@ -10,21 +10,24 @@ class GroupInvitationTest < ActiveSupport::TestCase
     invitation.save!
 
     assert invitation.invitation_code != ''
-    assert invitation.email === 'someguy@example.com'
-    assert invitation.group_id === 1
-    assert invitation.user_id === 1
+    assert invitation.email == 'someguy@example.com'
+    assert invitation.group_id == 1
+    assert invitation.user_id == 1
   end
 
   test 'use invitation' do
     invitation = GroupInvitation.get_by_invitation_code('ABCDEFG123')
 
-    assert invitation.status === 1, 'is a valid invitation code'
-    assert invitation.email === 'bob@example.com', 'invitation has an email address'
-    assert invitation.user_id === 4, 'invitation attached to an ID'
+    assert invitation.status == 1, 'is a valid invitation code'
+    assert(
+      invitation.email == 'bob@example.com',
+      'invitation has an email address'
+    )
+    assert invitation.user_id == 4, 'invitation attached to an ID'
 
     invitation.use_invitation
     invitation = GroupInvitation.get_by_invitation_code('ABCDEFG123')
 
-    assert invitation.status === 0, 'invitation was marked as used'
+    assert invitation.status == 0, 'invitation was marked as used'
   end
 end

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -9,116 +9,131 @@ class GroupTest < ActiveSupport::TestCase
     )
     group.save!
 
-    assert group.group_name === 'Another Sportsball Group', 'new group name matches'
-    assert group.creator_id === 5, 'new group creator ID matches'
-    assert group.invitation_code.length === 10, 'new group has valid invitation code'
+    assert(
+      group.group_name == 'Another Sportsball Group',
+      'new group name matches'
+    )
+    assert group.creator_id == 5, 'new group creator ID matches'
+    assert(
+      group.invitation_code.length == 10,
+      'new group has valid invitation code'
+    )
   end
 
   test 'fixture group has attributes' do
     group = Group.find(1)
 
-    assert group.group_name === 'Geeks Watching Hockey', 'group name matches fixture'
-    assert group.entity_id === 1, 'group entity ID matches fixture'
-    assert group.entity.entity_name === 'Nashville Predators', 'entity name matches fixture'
-    assert group.users.count === 3, 'group member count matches'
+    assert(
+      group.group_name == 'Geeks Watching Hockey',
+      'group name matches fixture'
+    )
+    assert group.entity_id == 1, 'group entity ID matches fixture'
+    assert(
+      group.entity.entity_name == 'Nashville Predators',
+      'entity name matches fixture'
+    )
+    assert group.users.count == 3, 'group member count matches'
   end
 
   test 'get group by ticket ID' do
     group = Ticket.find(1).group
 
-    assert group.id === 1, 'fixture group ID matches'
-    assert group.group_name === 'Geeks Watching Hockey', 'fixture group name matches'
+    assert group.id == 1, 'fixture group ID matches'
+    assert(
+      group.group_name == 'Geeks Watching Hockey',
+      'fixture group name matches'
+    )
   end
 
   test 'gets groups by user ID' do
     groups = User.find(2).groups
 
-    assert groups.count === 2, 'fixture group count matches'
+    assert groups.count == 2, 'fixture group count matches'
   end
 
   test 'check if member' do
     user = User.find(1)
     group = Group.find(3)
 
-    assert group.member?(user) === false, 'fixture user is not a member'
-    assert group.admin?(user) === false, 'fixture user is not an admin'
+    assert group.member?(user) == false, 'fixture user is not a member'
+    assert group.admin?(user) == false, 'fixture user is not an admin'
   end
 
   test 'check if admin' do
     user = User.find(1)
     group = Group.find(1)
 
-    assert group.member?(user) === true, 'fixture user is a member'
-    assert group.admin?(user) === true, 'fixture user is an admin'
+    assert group.member?(user) == true, 'fixture user is a member'
+    assert group.admin?(user) == true, 'fixture user is an admin'
   end
 
   test 'join a group' do
     user = User.find(4)
     group = Group.find(2)
 
-    assert group.member?(user) === false, 'user is not yet a member'
-    assert group.admin?(user) === false, 'user is not an admin'
+    assert group.member?(user) == false, 'user is not yet a member'
+    assert group.admin?(user) == false, 'user is not an admin'
 
     group_user = group.join_group(user)
 
-    assert group_user.user_id === 4, 'user ID matches'
-    assert group_user.group_id === 2, 'group ID matches'
-    assert group_user.role === 'member', 'role matches'
+    assert group_user.user_id == 4, 'user ID matches'
+    assert group_user.group_id == 2, 'group ID matches'
+    assert group_user.role == 'member', 'role matches'
 
-    assert group.member?(user) === true, 'user is a member'
-    assert group.admin?(user) === false, 'user is not an admin'
+    assert group.member?(user) == true, 'user is a member'
+    assert group.admin?(user) == false, 'user is not an admin'
   end
 
   test 'join a group as an admin' do
     user = User.find(4)
     group = Group.find(2)
 
-    assert group.member?(user) === false, 'user is not yet a member'
-    assert group.admin?(user) === false, 'user is not yet an admin'
+    assert group.member?(user) == false, 'user is not yet a member'
+    assert group.admin?(user) == false, 'user is not yet an admin'
 
     group_user = group.join_group(user, 'admin')
 
-    assert group_user.user_id === 4, 'user ID matches'
-    assert group_user.group_id === 2, 'group ID matches'
-    assert group_user.role === 'admin', 'role matches'
+    assert group_user.user_id == 4, 'user ID matches'
+    assert group_user.group_id == 2, 'group ID matches'
+    assert group_user.role == 'admin', 'role matches'
 
-    assert group.member?(user) === true, 'user is a member'
-    assert group.admin?(user) === true, 'user is an admin'
+    assert group.member?(user) == true, 'user is a member'
+    assert group.admin?(user) == true, 'user is an admin'
   end
 
   test 'gets correct list of administrators' do
     group = Group.find(2)
 
-    assert group.administrators.count === 1
-    assert group.administrators.first.first_name === 'Rick'
-    assert group.administrators.first.last_name === 'Taylor'
+    assert group.administrators.count == 1
+    assert group.administrators.first.first_name == 'Rick'
+    assert group.administrators.first.last_name == 'Taylor'
   end
 
   test 'leave a group' do
     user = User.find(2)
     group = Group.find(1)
 
-    assert group.member?(user) === true, 'user is a member'
-    assert group.admin?(user) === false, 'user is not an admin'
+    assert group.member?(user) == true, 'user is a member'
+    assert group.admin?(user) == false, 'user is not an admin'
 
     group.leave_group(user)
 
-    assert group.member?(user) === false, 'user is not a member'
-    assert group.admin?(user) === false, 'user is not an admin'
+    assert group.member?(user) == false, 'user is not a member'
+    assert group.admin?(user) == false, 'user is not an admin'
   end
 
   test 'leave a group as an admin' do
     user = User.find(1)
     group = Group.find(1)
 
-    assert group.member?(user) === true, 'user is a member'
-    assert group.admin?(user) === true, 'user is an admin'
+    assert group.member?(user) == true, 'user is a member'
+    assert group.admin?(user) == true, 'user is an admin'
 
     assert_raises RuntimeError do
       group.leave_group(user)
     end
 
-    assert group.member?(user) === true, 'user is still a member'
-    assert group.admin?(user) === true, 'user is still an admin'
+    assert group.member?(user) == true, 'user is still a member'
+    assert group.admin?(user) == true, 'user is still an admin'
   end
 end

--- a/test/models/group_user_test.rb
+++ b/test/models/group_user_test.rb
@@ -8,14 +8,14 @@ class GroupUserTest < ActiveSupport::TestCase
     )
     group_users.save!
 
-    assert group_users.user_id === 5, 'new user ID match'
-    assert group_users.group_id === 6, 'new group ID match'
+    assert group_users.user_id == 5, 'new user ID match'
+    assert group_users.group_id == 6, 'new group ID match'
   end
 
   test 'group users match group ID' do
     users = Group.find(1).users
 
-    assert users.count === 3, 'fixture user count matches'
+    assert users.count == 3, 'fixture user count matches'
     assert users[0].first_name?, 'fixture first name is set'
     assert users[0].last_name?, 'fixture last name is set'
   end
@@ -23,7 +23,7 @@ class GroupUserTest < ActiveSupport::TestCase
   test 'groups match user match user ID' do
     groups = User.find(2).groups
 
-    assert groups.count === 2, 'fixture group count matches'
+    assert groups.count == 2, 'fixture group count matches'
     assert groups[0].group_name?, 'fixture group name is set'
   end
 end

--- a/test/models/ticket_history_test.rb
+++ b/test/models/ticket_history_test.rb
@@ -7,38 +7,42 @@ class TicketHistoryTest < ActiveSupport::TestCase
       event_id: 4,
       group_id: 1,
       user_id: 1,
-      entry: '{"text":"assigned","user":{"id":"1","username":"jstone","first_name":"Jim","last_name":"Stone","email":"stonej@example.net","status":"1"},"ticket":{"id":"1","section":"326","row":"K","seat":"9","cost":"32.00","user_id":"1","ticket_id":1}}'
+      entry: '{"text":"assigned","user":{"id":"1","username":"jstone",'\
+        '"first_name":"Jim","last_name":"Stone","email":"stonej@example.net",'\
+        '"status":"1"},"ticket":{"id":"1","section":"326","row":"K",'\
+        '"seat":"9","cost":"32.00","user_id":"1","ticket_id":1}}'
     )
     ticket_history.save!
 
-    assert ticket_history.ticket_id === 1
-    assert ticket_history.event_id === 4
-    assert ticket_history.group_id === 1
-    assert ticket_history.user_id === 1
-    assert JSON.parse(ticket_history.entry)['text'] === 'assigned'
+    assert ticket_history.ticket_id == 1
+    assert ticket_history.event_id == 4
+    assert ticket_history.group_id == 1
+    assert ticket_history.user_id == 1
+    assert JSON.parse(ticket_history.entry)['text'] == 'assigned'
   end
 
   test 'ticket property is set' do
     ticket_history = TicketHistory.find(1)
 
-    assert ticket_history.ticket.display_name === '326 K 9'
+    assert ticket_history.ticket.display_name == '326 K 9'
   end
 
   test 'event property is set' do
     ticket_history = TicketHistory.find(1)
 
-    assert ticket_history.event.event_name === 'Nashville Predators vs. St. Louis Blues'
+    assert ticket_history.event.event_name ==
+      'Nashville Predators vs. St. Louis Blues'
   end
 
   test 'group property is set' do
     ticket_history = TicketHistory.find(1)
 
-    assert ticket_history.group.group_name === 'Geeks Watching Hockey'
+    assert ticket_history.group.group_name == 'Geeks Watching Hockey'
   end
 
   test 'user property is set' do
     ticket_history = TicketHistory.find(1)
 
-    assert ticket_history.user.display_name === 'Jim Stone'
+    assert ticket_history.user.display_name == 'Jim Stone'
   end
 end

--- a/test/models/ticket_test.rb
+++ b/test/models/ticket_test.rb
@@ -14,73 +14,73 @@ class TicketTest < ActiveSupport::TestCase
     )
     ticket.save!
 
-    assert ticket.cost === 45.00
-    assert ticket.display_name === '301 Q 3'
-    assert ticket.owner.display_name === 'Jim Stone'
-    assert ticket.assigned.display_name === 'Jill Smith'
-    assert ticket.group.group_name === 'Geeks Watching Hockey'
-    assert ticket.event.event_name === 'Nashville Predators vs. St. Louis Blues'
+    assert ticket.cost == 45.00
+    assert ticket.display_name == '301 Q 3'
+    assert ticket.owner.display_name == 'Jim Stone'
+    assert ticket.assigned.display_name == 'Jill Smith'
+    assert ticket.group.group_name == 'Geeks Watching Hockey'
+    assert ticket.event.event_name == 'Nashville Predators vs. St. Louis Blues'
   end
 
   test 'owner property is set' do
     ticket = Ticket.find(1)
 
-    assert ticket.owner.display_name === 'Jim Stone'
+    assert ticket.owner.display_name == 'Jim Stone'
   end
 
   test 'assigned property is set' do
     ticket = Ticket.find(1)
 
-    assert ticket.assigned.display_name === 'Jim Stone'
+    assert ticket.assigned.display_name == 'Jim Stone'
 
     ticket = Ticket.find(2)
 
-    assert ticket.assigned.nil? === true
+    assert ticket.assigned.nil? == true
   end
 
   test 'alias property is set' do
     ticket = Ticket.find(4)
 
-    assert ticket.alias.display_name === 'Jennifer Newton'
+    assert ticket.alias.display_name == 'Jennifer Newton'
 
     ticket = Ticket.find(1)
 
-    assert ticket.alias.nil? === true
+    assert ticket.alias.nil? == true
   end
 
   test 'group property is set' do
     ticket = Ticket.find(1)
 
-    assert ticket.group.group_name === 'Geeks Watching Hockey'
+    assert ticket.group.group_name == 'Geeks Watching Hockey'
   end
 
   test 'display_name property is set' do
     ticket = Ticket.find(1)
 
-    assert ticket.display_name === '326 K 9'
+    assert ticket.display_name == '326 K 9'
 
     ticket = Ticket.find(5)
 
-    assert ticket.display_name === 'VIP'
+    assert ticket.display_name == 'VIP'
   end
 
   test 'available? check' do
     ticket = Ticket.find(1)
 
-    assert ticket.available? === false
+    assert ticket.available? == false
 
     ticket = Ticket.find(2)
 
-    assert ticket.available? === true
+    assert ticket.available? == true
   end
 
   test 'assigned? check' do
     ticket = Ticket.find(1)
 
-    assert ticket.assigned? === true
+    assert ticket.assigned? == true
 
     ticket = Ticket.find(2)
 
-    assert ticket.assigned? === false
+    assert ticket.assigned? == false
   end
 end

--- a/test/models/user_alias_test.rb
+++ b/test/models/user_alias_test.rb
@@ -8,30 +8,30 @@ class UserAliasTest < ActiveSupport::TestCase
       last_name: 'Goodlaw'
     )
 
-    assert user_alias.first_name === 'Amanda', 'new user alias first name matches'
-    assert user_alias.last_name === 'Goodlaw', 'new user alias last name matches'
-    assert user_alias.display_name === 'Amanda Goodlaw', 'new user alias full name matches'
-    assert user_alias.user_id === 1, 'new user alias user ID matches'
+    assert user_alias.first_name == 'Amanda', 'user alias first name matches'
+    assert user_alias.last_name == 'Goodlaw', 'user alias last name matches'
+    assert user_alias.display_name == 'Amanda Goodlaw', 'alias name matches'
+    assert user_alias.user_id == 1, 'new user alias user ID matches'
   end
 
   test 'fixture user alias has attributes' do
     user_alias = UserAlias.find(1)
 
-    assert user_alias.first_name === 'Kevin', 'fixture user alias first name matches'
-    assert user_alias.last_name === 'Jones', 'fixture user alias last name matches'
-    assert user_alias.display_name === 'Kevin Jones', 'new user alias full name matches'
-    assert user_alias.user_id === 4, 'fixture user alias user ID matches'
+    assert user_alias.first_name == 'Kevin', 'fixture alias first name matches'
+    assert user_alias.last_name == 'Jones', 'fixture alias last name matches'
+    assert user_alias.display_name == 'Kevin Jones', 'new alias name matches'
+    assert user_alias.user_id == 4, 'fixture user alias user ID matches'
   end
 
   test 'user alias unset from matching tickets when deleted' do
     user_alias = UserAlias.find(2)
     ticket = Ticket.find(4)
 
-    assert user_alias.id === ticket.alias_id, 'ticket is assigned to user'
+    assert user_alias.id == ticket.alias_id, 'ticket is assigned to user'
 
     user_alias.destroy
 
     ticket = Ticket.find(4)
-    assert ticket.alias_id === 0, 'ticket was assigned back to 0'
+    assert ticket.alias_id == 0, 'ticket was assigned back to 0'
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -10,29 +10,29 @@ class UserTest < ActiveSupport::TestCase
     )
     user.save!
 
-    assert user.first_name === 'Randy', 'new user first name matches'
-    assert user.last_name === 'Phillips', 'new user last name matches'
-    assert user.email === 'randy23@example.net', 'new user email matches'
+    assert user.first_name == 'Randy', 'new user first name matches'
+    assert user.last_name == 'Phillips', 'new user last name matches'
+    assert user.email == 'randy23@example.net', 'new user email matches'
   end
 
   test 'get user from fixture' do
     user = User.find(1)
 
-    assert user.first_name === 'Jim', 'fixture first name matches'
-    assert user.last_name === 'Stone', 'fixture last name matches'
-    assert user.email === 'stonej@example.net', 'fixture email matches'
+    assert user.first_name == 'Jim', 'fixture first name matches'
+    assert user.last_name == 'Stone', 'fixture last name matches'
+    assert user.email == 'stonej@example.net', 'fixture email matches'
   end
 
   test 'get full name of user' do
     user = User.find(2)
 
-    assert user.display_name === 'Jill Smith'
+    assert user.display_name == 'Jill Smith'
   end
 
   test 'group users match group ID' do
     users = Group.find(2).users
 
-    assert users.count === 2, 'fixture user count matches'
+    assert users.count == 2, 'fixture user count matches'
     assert users[0].first_name?, 'fixture first name is set'
     assert users[0].last_name?, 'fixture last name is set'
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,20 +16,26 @@ Spork.prefork do
   require File.expand_path('../../config/environment', __FILE__)
   require 'rails/test_help'
 
-  class ActiveSupport::TestCase
-    ActiveRecord::Migration.check_pending!
+  module ActiveSupport
+    class TestCase
+      ActiveRecord::Migration.check_pending!
 
-    # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
-    #
-    # Note: You'll currently still have to declare fixtures explicitly in integration tests
-    # -- they do not yet inherit this setting
-    fixtures :all
+      # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical
+      # order.
+      #
+      # Note: You'll currently still have to declare fixtures explicitly in
+      # integration tests
+      # -- they do not yet inherit this setting
+      fixtures :all
 
-    # Add more helper methods to be used by all tests here...
+      # Add more helper methods to be used by all tests here...
+    end
   end
 
-  class ActionController::TestCase
-    include Devise::TestHelpers
+  module ActionController
+    class TestCase
+      include Devise::TestHelpers
+    end
   end
 
   class DeviseController
@@ -44,39 +50,12 @@ Spork.each_run do
   # This code will be run each time you run your specs.
 end
 
-# --- Instructions ---
-# Sort the contents of this file into a Spork.prefork and a Spork.each_run
-# block.
-#
-# The Spork.prefork block is run only once when the spork server is started.
-# You typically want to place most of your (slow) initializer code in here, in
-# particular, require'ing any 3rd-party gems that you don't normally modify
-# during development.
-#
-# The Spork.each_run block is run each time you run your specs.  In case you
-# need to load files that tend to change during development, require them here.
-# With Rails, your application modules are loaded automatically, so sometimes
-# this block can remain empty.
-#
-# Note: You can modify files loaded *from* the Spork.each_run block without
-# restarting the spork server.  However, this file itself will not be reloaded,
-# so if you change any of the code inside the each_run block, you still need to
-# restart the server.  In general, if you have non-trivial code in this file,
-# it's advisable to move it into a separate file so you can easily edit it
-# without restarting spork.  (For example, with RSpec, you could move
-# non-trivial code into a file spec/support/my_helper.rb, making sure that the
-# spec/support/* files are require'd from inside the each_run block.)
-#
-# Any code that is left outside the two blocks will be run during preforking
-# *and* during each_run -- that's probably not what you want.
-#
-# These instructions should self-destruct in 10 seconds.  If they don't, feel
-# free to delete them.
-
-# Public: provide debugging information for tests which are known to fail intermittently
+# Public: provide debugging information for tests which are known to fail
+# intermittently
 #
 # issue_link - url of GitHub issue documenting this intermittent test failure
-# args       - Hash of debugging information (names => values) to output on a failure
+# args       - Hash of debugging information (names => values) to output on a
+#              failure
 # block      - block which intermittently fails
 #
 # Example


### PR DESCRIPTION
Little bit of shame here, but these code edits plus these YML configuration tweaks turns Rubocop all green. I'd rather tackle each of them separately in different PRs as we go along, but these should keep new code from causing trouble. Eventually, the goal would be to return the configuration back to their defaults.

```
Metrics/AbcSize:
  # Max: 15
  Max: 110

Metrics/CyclomaticComplexity:
  # Max: 6
  Max: 15

Metrics/PerceivedComplexity:
  # Max: 7
  Max: 20

Metrics/MethodLength:
  # Max: 10
  Max: 65

Metrics/ClassLength:
  # Max: 100
  Max: 300
```
