### PR TITLE
Fix for Timezone tests

### DIFF
--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -38,6 +38,7 @@ ActiveAdmin.register User do
           pf.input :bio
           pf.input :location
           pf.input :mobile
+          pf.input :sms_notify, :label => 'Notify SMS'
         end
       end
     end

--- a/test/integration/ticket_flow_test.rb
+++ b/test/integration/ticket_flow_test.rb
@@ -3,6 +3,10 @@ require 'test_helper'
 class TicketFlowTest < ActionDispatch::IntegrationTest
   fixtures :users
 
+  def setup
+    Time.zone = 'Central Time (US & Canada)'
+  end
+
   test 'add a single ticket' do
     post_via_redirect(
       '/login',

--- a/test/mailers/schedule_notifier_test.rb
+++ b/test/mailers/schedule_notifier_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class ScheduleNotifierTest < ActionMailer::TestCase
+  def setup
+    Time.zone = 'Central Time (US & Canada)'
+  end
+
   test 'send daily schedule' do
     events = Event.where('DATE(start_time) = \'2013-10-15\'').order_by_date
     group = Group.find(1)

--- a/test/mailers/ticket_notifier_test.rb
+++ b/test/mailers/ticket_notifier_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class TicketNotifierTest < ActionMailer::TestCase
+  def setup
+    Time.zone = 'Central Time (US & Canada)'
+  end
+
   test 'ticket assigned to user' do
     ticket = Ticket.find(7)
     user = User.find(3)

--- a/test/models/ticket_test.rb
+++ b/test/models/ticket_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class TicketTest < ActiveSupport::TestCase
+  def setup
+    Time.zone = 'Central Time (US & Canada)'
+  end
+
   test 'new ticket has attributes' do
     ticket = Ticket.new(
       group_id: 1,


### PR DESCRIPTION
Fixes #109

In talking to @kamarcum tonight he suggested using the `setup` or `teardown` method to resolve the intermittent test failures related to time zones. Seemed legit to me, and through 20 runs of the suite I cannot make it fail again.
