### PR TITLE
Clean up META tags for social sharing

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,13 +1,13 @@
 <% if @entity.nil? %>
 <% content_for :page_title do %>Create a SeatShare Account<% end %>
+<% content_for :page_description do %>Register for an account with SeatShare to start managing your season tickets.<% end %>
 <% content_for :html_head do %>
-<meta name="description" content="Register for an account with SeatShare to start managing your season tickets." />
 <link rel="canonical" href="https://myseatshare.com/register" />
 <% end %>
 <% else %>
 <% content_for :page_title do %><%= "Create a SeatShare Account - #{@entity.display_name}".truncate(70, omission: '...') %><% end %>
+<% content_for :page_description do %><%= "Register for an account with SeatShare to start managing your season tickets for your #{@entity.display_name} group." %><% end %>
 <% content_for :html_head do %>
-<meta name="description" content="<%= "Register for an account with SeatShare to start managing your season tickets for your #{@entity.display_name} group." %>" />
 <link rel="canonical" href="https://myseatshare.com/register" />
 <% end %>
 <% end %>

--- a/app/views/layouts/_meta_tags.html.erb
+++ b/app/views/layouts/_meta_tags.html.erb
@@ -1,0 +1,18 @@
+<meta name="description" content="<%= yield :page_description || 'SeatShare is the easiest way to manage your group season tickets.' %>" />
+
+<!-- Twitter Card data -->
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:site" content="@mySeatShare" />
+<meta name="twitter:title" content="<%= yield :page_title || 'SeatShare' %>" />
+<meta name="twitter:description" content="<%= yield :page_description || 'SeatShare is the easiest way to manage your group season tickets.' %>" />
+<meta name="twitter:creator" content="@mySeatShare" />
+<meta name="twitter:image" content="<%= image_url('screenshot-laptop.png') %>" />
+
+<!-- Open Graph data -->
+<meta property="og:title" content="<%= yield :page_description || 'SeatShare is the easiest way to manage your group season tickets.' %>" />
+<meta property="og:type" content="article" />
+<meta property="og:url" content="<%= request.original_url %>" />
+<meta property="og:image" content="<%= image_url('screenshot-laptop.png') %>" />
+<meta property="og:description" content="<%= yield :page_description || 'SeatShare is the easiest way to manage your group season tickets.' %>" />
+<meta property="og:site_name" content="SeatShare" />
+<meta property="fb:admins" content="689513964463043" /> 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,8 @@
 
 <%= favicon_link_tag 'favicon.png', rel: 'shortcut icon', type: 'image/png' %>
 
+<%= render 'layouts/meta_tags' %>
+
 <%= render 'layouts/ios' %>
 
 <%= render 'layouts/mixpanel' %>

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -13,6 +13,8 @@
 
 <%= favicon_link_tag 'favicon.png', rel: 'shortcut icon', type: 'image/png' %>
 
+<%= render 'layouts/meta_tags' %>
+
 <%= render 'layouts/ios' %>
 
 <%= render 'layouts/mixpanel' %>

--- a/app/views/layouts/login.html.erb
+++ b/app/views/layouts/login.html.erb
@@ -13,6 +13,8 @@
 
 <%= favicon_link_tag 'favicon.png', rel: 'shortcut icon', type: 'image/png' %>
 
+<%= render 'layouts/meta_tags' %>
+
 <%= render 'layouts/ios' %>
 
 <%= render 'layouts/mixpanel' %>

--- a/app/views/layouts/single-column.html.erb
+++ b/app/views/layouts/single-column.html.erb
@@ -13,6 +13,8 @@
 
 <%= favicon_link_tag 'favicon.png', rel: 'shortcut icon', type: 'image/png' %>
 
+<%= render 'layouts/meta_tags' %>
+
 <%= render 'layouts/ios' %>
 
 <%= render 'layouts/mixpanel' %>

--- a/app/views/layouts/two-column.html.erb
+++ b/app/views/layouts/two-column.html.erb
@@ -13,6 +13,8 @@
 
 <%= favicon_link_tag 'favicon.png', rel: 'shortcut icon', type: 'image/png' %>
 
+<%= render 'layouts/meta_tags' %>
+
 <%= render 'layouts/ios' %>
 
 <%= render 'layouts/mixpanel' %>

--- a/app/views/public/contact.html.erb
+++ b/app/views/public/contact.html.erb
@@ -1,7 +1,5 @@
 <% content_for :page_title do %>Contact - SeatShare<% end %>
-<% content_for :html_head do %>
-<meta name="description" content="Have questions or comments about SeatShare? We are here to help." />
-<% end %>
+<% content_for :page_description do %>Have questions or comments about SeatShare? We are here to help.<% end %>
 
 <h1>Let's talk!</h1>
 

--- a/app/views/public/index.html.erb
+++ b/app/views/public/index.html.erb
@@ -1,7 +1,5 @@
 <% content_for :page_title do %>Welcome to SeatShare<% end %>
-<% content_for :html_head do %>
-<meta name="description" content="SeatShare helps you manage your group's season tickets for sports or performing arts events. Sign up for free." />
-<% end %>
+<% content_for :page_description do %>SeatShare helps you manage your group's season tickets for sports or performing arts events. Sign up for free.<% end %>
 
 <h1>What is SeatShare?</h1>
 <p class="lead">SeatShare is the easiest way to manage your shared pool of tickets for a sports team or performing arts venue.</p>

--- a/app/views/public/privacy.html.erb
+++ b/app/views/public/privacy.html.erb
@@ -1,7 +1,5 @@
 <% content_for :page_title do %>Privacy Policy - SeatShare<% end %>
-<% content_for :html_head do %>
-<meta name="description" content="SeatShare values your privacy and will not sell or share your information." />
-<% end %>
+<% content_for :page_description do %>SeatShare values your privacy and will not sell or share your information.<% end %>
 
 <h1>Privacy Policy</h1>
 

--- a/app/views/public/teams.html.erb
+++ b/app/views/public/teams.html.erb
@@ -1,7 +1,5 @@
 <% content_for :page_title do %>Manage Season Tickets for Your Favorite Team - SeatShare<% end %>
-<% content_for :html_head do %>
-<meta name="description" content="We import schedules for all of the most popular teams, including NHL, NFL, NBA, MLB and college sports." />
-<% end %>
+<% content_for :page_description do %>We import schedules for all of the most popular teams, including NHL, NFL, NBA, MLB and college sports.<% end %>
 
 <% content_for :page_header do %>
 <div class="jumbotron teams-header">

--- a/app/views/public/tos.html.erb
+++ b/app/views/public/tos.html.erb
@@ -1,7 +1,5 @@
 <% content_for :page_title do %>Terms of Service - SeatShare<% end %>
-<% content_for :html_head do %>
-<meta name="description" content="The Terms of Service for SeatShare are the rules that govern access and use of the website." />
-<% end %>
+<% content_for :page_description do %>The Terms of Service for SeatShare are the rules that govern access and use of the website.<% end %>
 
 <h1>Terms of Service</h1>
 


### PR DESCRIPTION
Reference: http://moz.com/blog/meta-data-templates-123

I want to make it behave better when somebody shares a link on Facebook/Twitter/etc. The only way to do this is by providing additional meta tags for OpenGraph and the like.
