### PR TITLE
Fix workflow for registering with a group code

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -15,6 +15,11 @@ class RegistrationsController < Devise::RegistrationsController
     else
       @entity = nil
     end
+    if params[:group_code]
+      @group = Group.find_by_invitation_code(params[:group_code])
+    else
+      @group = nil
+    end
     super
   end
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -82,6 +82,8 @@
     <div class="col-md-12">
         <% if @invite %>
         <%= f.hidden_field :invite_code, :value => @invite.invitation_code %>
+        <% elsif @group %>
+        <%= f.hidden_field :invite_code, :value => @group.invitation_code %>
         <% elsif @entity %>
         <%= f.hidden_field :entity_id, :value => @entity.id %>
         <% end %>
@@ -111,9 +113,16 @@
 <% if @invite %>
 <div class="alert alert-success">
   <h4>You've been invited join a group!</h4>
-  <p><%= @invite.user.display_name %> invited you to join <%= @invite.group.group_name %>, so you will be ready to go here in just a bit!</p>
+  <p><strong><%= @invite.user.display_name %></strong> invited you to join <strong><%= @invite.group.group_name %></strong>, so you will be ready to go here in just a bit!</p>
   <br />
   <p class="text-lg">Invitation code: <strong class="invite_code"><%= @invite.invitation_code %></strong></p>
+</div>
+<% elsif @group %>
+<div class="alert alert-success">
+  <h4>You've been invited join a group!</h4>
+  <p>You have been invited to join <strong><%= @group.group_name %></strong>, so you will be ready to go here in just a bit!</p>
+  <br />
+  <p class="text-lg">Invitation code: <strong class="invite_code"><%= @group.invitation_code %></strong></p>
 </div>
 <% elsif @entity %>
 <div class="alert alert-success">

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -15,10 +15,10 @@
   </div>
 
   <div class="form-group">
-    <%= f.label :invitation_code, :class => 'col-md-3 control-label' %>
+    <%= f.label :invitation_code, 'Share Link', class: 'col-md-3 control-label' %>
     <div class="col-md-9">
       <p class="form-control-static">
-        <%= @group.invitation_code %><br />
+        <span class="text-muted"><%= "#{request.protocol}#{request.host_with_port}#{new_user_registration_path}" %>/group/</span><%= @group.invitation_code %><br />
         <small><%= link_to 'Reset invitation code', { :controller => 'groups', :action => 'do_reset_invite', :id => @group.id }, :class => 'text-muted confirm', :method => 'post' %></small>
       </p>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ SeatShare::Application.routes.draw do
   get 'contact' => 'public#contact'
 
   devise_scope :user do
+    get "register/group/:group_code", to: "registrations#new", as: 'register_with_group_code'
     get "register/invite/:invite_code", to: "registrations#new", as: 'register_with_invite_code'
     get "register/:entity_slug/:entity_id", to: "registrations#new", as: 'register_with_entity_id'
   end

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -28,6 +28,21 @@ class RegistrationsControllerTest < ActionController::TestCase
     assert_select 'strong.invite_code', 'ABCDEFG123', 'invitation code appears'
   end
 
+  test 'get register route with group code' do
+    @request.env['devise.mapping'] = Devise.mappings[:user]
+
+    get :new, group_code: 'QWERTY1234'
+
+    assert_response :success
+    assert_select 'title', 'Create a SeatShare Account'
+    assert_select(
+      'h4',
+      "You've been invited join a group!",
+      'invitation code block appears'
+    )
+    assert_select 'strong.invite_code', 'QWERTY1234', 'invitation code appears'
+  end
+
   test 'get register route with team id' do
     @request.env['devise.mapping'] = Devise.mappings[:user]
 


### PR DESCRIPTION
Arafat registered recently using the link. Only trouble is that the link doesn't actually do anything special there, just makes a note of the invitation code. This fixes that by wiring in a URL that will properly handle the invitation code.

Four kinds of ways to register now:
- Generic home page registration - Takes you to the landing page to create or join a group
- Register with a team (entity) selected - Prefills the create group page
- Register with an individual group invitation - Prefills your unique invitation code
- Register with the group code - Prefills with the group's invitation code

This has room for cleanup in general, but those are the four major workflows.
