### PR TITLE
Bump bower to 1.3.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 # Ignore rvm configuration files
 .ruby-version
 .ruby-gemset
+
+# Ignore node modules
+/node_modules/

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "seatshare-rails",
   "version": "1.0.0",
   "dependencies": {
-    "bower": "~1.2"
+    "bower": "~1.3"
   },
   "engine": {
     "node": "0.10.x",


### PR DESCRIPTION
bower relies on the node-tmp library which sucks and doesn't follow
semver and thus keeps breaking bower. in the 1.3 series bower finally
pinned to specific node-tmp versions rather than fuzzy matching.
also let's gitignore the node_modules dir for good measure.
