### PR TITLE
Updates to registration workflow

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -111,6 +111,30 @@ class Group < ActiveRecord::Base
     )
   end
 
+  ##
+  # Join by invitation code
+  # - invitation_code: String
+  def self.join_with_invitation_code(invitation_code = nil, user = nil)
+    return false if invitation_code.nil? || user.nil?
+
+    # Start by attempting to using a GroupInvite
+    invitation = GroupInvitation.get_by_invitation_code(invitation_code)
+    unless invitation.blank?
+      invitation.group.join_group(user, 'member')
+      invitation.use_invitation
+      return invitation.group
+    end
+
+    # If that didn't work, use a group.invitation_code
+    group = find_by_invitation_code(invitation_code)
+    unless group.nil?
+      group.join(user, 'member')
+      return group
+    end
+
+    false
+  end
+
   private
 
   ##

--- a/app/models/group_invitation.rb
+++ b/app/models/group_invitation.rb
@@ -29,11 +29,9 @@ class GroupInvitation < ActiveRecord::Base
   ##
   # Retrieve invitation by invitation code
   def self.get_by_invitation_code(invitation_code = nil)
-    fail 'InvalidInvitation' if invitation_code.length != 10
     invitation = GroupInvitation.where(
       "invitation_code = '#{invitation_code}'"
     ).first
-    fail 'InvalidInvitation' if invitation.nil?
     invitation
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ SeatShare::Application.routes.draw do
   post 'groups/new' => 'groups#create'
   get 'groups/join' => 'groups#join', as: 'join_group'
   post 'groups/join' => 'groups#do_join'
+  get 'groups/join/:invite_code' => 'groups#join'
   get 'groups/:id' => 'groups#show', as: 'group'
   get 'groups/:id/edit' => 'groups#edit', as: 'edit_group'
   patch 'groups/:id/edit' => 'groups#update'

--- a/test/integration/user_signup_test.rb
+++ b/test/integration/user_signup_test.rb
@@ -45,7 +45,7 @@ class UserSignupTest < ActionDispatch::IntegrationTest
     assert_equal '/', path
   end
 
-  test 'signup for an account with an invite code' do
+  test 'signup for an account with a valid invite code' do
     get '/register/invite/ABCDEFG123'
     assert_response :success
     assert_select 'h4', "You've been invited join a group!"
@@ -65,7 +65,26 @@ class UserSignupTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_equal nil, flash[:alert]
     assert_equal 'Welcome! You have signed up successfully.', flash[:notice]
-    assert_equal '/groups/join', path
+    assert_equal '/groups/1', path
+  end
+
+  test 'signup for an account with a bad invite code' do
+    post_via_redirect(
+      '/',
+      user: {
+        first_name: 'New',
+        last_name: 'User',
+        email: 'newuser@example.com',
+        password: 'testing123',
+        password_confirm: 'testing123',
+        invite_code: 'XYZ890'
+      }
+    )
+
+    assert_response :success
+    assert_equal nil, flash[:alert]
+    assert_equal 'Welcome! You have signed up successfully.', flash[:notice]
+    assert_equal '/groups', path
   end
 
   test 'signup for an account with an team ID' do


### PR DESCRIPTION
Fixes #156
- Auto-join for new registrations that include an invitation code
- Redirect existing users to `/groups/join` route if a registration link with invitation is clicked
- Update the tests
