### PR TITLE
Protect user profiles from non-group members

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -8,6 +8,7 @@ class ProfilesController < ApplicationController
   # Show a user profile
   def show
     @user = User.find_by_id(params[:id]) || not_found
+    not_found unless current_user.user_can_view? @user
     @user.profile = Profile.new if @user.profile.nil?
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,6 +56,21 @@ class User < ActiveRecord::Base
   end
 
   ##
+  # User Can View?
+  # - user: instance of user to see if they have a common group
+  def user_can_view?(user)
+    return false if user.nil?
+    shared_users = []
+    groups.collect do |group|
+      group.users.collect do |u|
+        shared_users << u.id
+      end
+    end
+    return true if shared_users.include? user.id
+    false
+  end
+
+  ##
   # Order user records by name
   def self.order_by_name
     order('LOWER(last_name) ASC, LOWER(first_name) ASC')

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -38,4 +38,16 @@ class UserTest < ActiveSupport::TestCase
     assert users[0].first_name?, 'fixture first name is set'
     assert users[0].last_name?, 'fixture last name is set'
   end
+
+  test 'user can view?' do
+    user1 = User.find(1)
+    user2 = User.find(2)
+    user3 = User.find(3)
+    user4 = User.find(4)
+
+    assert user1.user_can_view?(user2) == true
+    assert user2.user_can_view?(user3) == true
+    assert user3.user_can_view?(user4) == false
+    assert user4.user_can_view?(user2) == false
+  end
 end


### PR DESCRIPTION
Enforces a rule that says you have to share at least one group with an authenticated user before being allowed to see their profile page. Otherwise a user could simply increment the `/profiles/:id` route to read other user profiles.
