### PR TITLE
Display share-able group invitation code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,6 +97,9 @@ gem "global_phone", "~> 1.0.1"
 # Sitemaps
 gem "dynamic_sitemaps"
 
+# Zeroclipboard
+gem 'zeroclipboard-rails'
+
 # testing
 group :testing do
   gem 'guard-minitest'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,6 +336,8 @@ GEM
       rack (>= 1.0)
     whenever (0.9.4)
       chronic (>= 0.6.3)
+    zeroclipboard-rails (0.1.0)
+      railties (>= 3.1)
 
 PLATFORMS
   ruby
@@ -384,3 +386,4 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   underscore-rails
   whenever
+  zeroclipboard-rails

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,4 +18,5 @@
 //= require underscore
 //= require clndr
 //= require select2
+//= require zeroclipboard
 //= require_directory .

--- a/app/assets/javascripts/seatshare.js.coffee
+++ b/app/assets/javascripts/seatshare.js.coffee
@@ -10,7 +10,10 @@ seatshareReady = ->
   	return window.confirm 'Are you sure?'
 
   # Tooltips
-  $('a[data-toggle="tooltip"], span[data-toggle="tooltip"], div[data-toggle="tooltip"]').tooltip()
+  $('a[data-toggle="tooltip"], span[data-toggle="tooltip"], div[data-toggle="tooltip"], button[data-toggle="tooltip"]').tooltip()
+
+  # Zeroclipboard
+  clip = new ZeroClipboard($("button.zeroclipboard"))
 
 $(document).ready(seatshareReady)
 $(document).on('page:load', seatshareReady)

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -165,7 +165,7 @@ class GroupsController < ApplicationController
       group.join_group(current_user, 'member')
       flash[:notice] = 'Group joined!'
       redirect_to(action: 'show', id: group.id) && return
-    rescue InvitationAlreadyUsed
+    rescue
       flash[:error] = 'The provided invitation code has already been used.'
       redirect_to(action: 'join') && return
     end
@@ -212,6 +212,8 @@ class GroupsController < ApplicationController
   def invite
     @group = Group.find(params[:id]) || not_found
     @group_invitation = GroupInvitation.new
+    @invite_link = "#{request.protocol}#{request.host_with_port}"\
+      "#{new_user_registration_path}/group/#{@group.invitation_code}"
   end
 
   ##

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -85,6 +85,7 @@ class Group < ActiveRecord::Base
   def join_group(user = nil, role = nil)
     role = 'member' if role != 'admin'
     fail 'NotValidGroup' if id.nil?
+    fail 'AlreadyMember' if member?(user)
     user_group = GroupUser.new(
       user_id: user.id,
       group_id: id,

--- a/app/views/groups/invite.html.erb
+++ b/app/views/groups/invite.html.erb
@@ -1,11 +1,19 @@
 <% content_for :page_title do %><%= "Invite Member to #{@group.group_name}" %><% end %>
 
+<div class="jumbotron">
+  <p>Anyone with this link can join your ticket group.</p>
+  <p><%= link_to @invite_link, @invite_link %></p>
+  <p>
+    <button class="btn btn-default zeroclipboard" data-clipboard-text="<%= @invite_link %>" data-toggle="tooltip" title="Copy link to clipboard."><span class="fa fa-clipboard"></span> Copy to Clipboard</button>
+  </p>
+</div>
+
 <%= form_for @group_invitation, html: {class: "form-horizontal", role: "form"}, url: { :controller => 'groups', :action => 'invite', :id => @group.id } do |f| %>
 
 <div class="row">
   <div class="col-md-12">
     <fieldset>
-      <legend>Invite a New Member</legend>
+      <legend>Invite a New Member via Email</legend>
       <div class="form-group">
         <%= f.label :email, :class => 'col-md-3 control-label' %>
         <div class="col-md-9">


### PR DESCRIPTION
Fixes #165 for @bval
- Adds link to the Invitation form
- Adds `zeroclipboard-rails` gem for usability++
- Fixes an issue where a user could potentially join a group as an admin and member (discovered in testing)

![](http://cl.ly/image/0Y472M0F422D/Image%202015-03-01%20at%208.37.50%20PM.png)

After working with the sign-up process, this made more sense to simply share as an alternative way to inviting a user. The email-based invites are not getting noticed (because email sucks). It makes more sense to do it this way. If we go another route with subscription limits, we would allow a Group Administrator to turn off invitations entirely (or when their subscription reached a particular limit). That's a problem for later.

The user-based invitation code creation remains on the table, but this removes the barrier for now.
