### PR TITLE
Only email 'Active' groups

### DIFF
--- a/lib/tasks/send_reminders.rake
+++ b/lib/tasks/send_reminders.rake
@@ -5,7 +5,7 @@ namespace :send_reminders do
     Time.zone = ActiveSupport::TimeZone["Central Time (US & Canada)"]
 
     puts "[START] #{DateTime.now}"
-    groups = Group.all
+    groups = Group.active
     puts "Sending Daily Reminders for events for today"
     for group in groups
       events = group.events.today.order_by_date
@@ -35,7 +35,7 @@ namespace :send_reminders do
     Time.zone = ActiveSupport::TimeZone["Central Time (US & Canada)"]
 
     puts "[START] #{DateTime.now}"
-    groups = Group.all
+    groups = Group.active
     puts "Sending Weekly Reminders for events for next seven days"
     for group in groups
     events = group.events.next_seven_days.order_by_date


### PR DESCRIPTION
A user seems to have accidentally created two groups of the same name, so I want to disable one of them. Trouble is, emails will still go out anyway. This fixes alerts so that it uses the `active` scope.
