### PR TITLE
Add manual schedule upload from SODA

### DIFF
--- a/app/admin/event.rb
+++ b/app/admin/event.rb
@@ -25,6 +25,10 @@ ActiveAdmin.register Event do
     link_to 'Import from SODA', action: 'import_soda'
   end
 
+  action_item 'import', only: :index do
+    link_to 'Import from File', action: 'import_file'
+  end
+
   show do
     attributes_table do
       row :id
@@ -95,4 +99,28 @@ ActiveAdmin.register Event do
       end
     end
   end
+
+  collection_action :import_file, method: :get
+  collection_action :import_file, method: :post do
+    @page_title = 'Import from File'
+
+    unless params[:file].nil?
+
+      # Used to display the list back upon completion
+      @events_list = []
+
+      # Used to flash messages describing error or success
+      @messages = []
+
+      # Loop through team ids and run importer
+      importer = FileScheduleImport.new
+      importer.run(
+        file: params[:file],
+      )
+
+      @events_list += importer.events_list
+      @messages += importer.messages
+    end
+  end
+
 end

--- a/app/views/admin/events/import_file.html.erb
+++ b/app/views/admin/events/import_file.html.erb
@@ -1,0 +1,61 @@
+<p>This tool imports schedules from the <a href="http://www.xmlteam.com/soda/">Sports On Demand API</a> from XML Team that have already been downloaded or obtained through Customer Support.</p>
+
+<% if @messages %>
+
+<h3>Status</h3>
+<ul>
+  <% for message in @messages %>
+  <li><%= message %>
+  <% end %>
+</ul>
+
+<% end %>
+
+<% if @events_list %>
+
+<h3>Imported Events</h3>
+
+<fieldset>
+<table>
+  <thead>
+    <tr>
+      <th>Event ID</th>
+      <th>Entity ID</th>
+      <th>Event Name</th>
+      <th>Start Time</th>
+      <th>Import Key</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% for event in @events_list %>
+    <tr>
+      <td><%= link_to(event.id, admin_event_path(event)) %></td>
+      <td><%= event.entity_id %></td>
+      <td><%= event.event_name %></td>
+      <td><%= event.start_time %></td>
+      <td><%= event.import_key %></td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>
+</fieldset>
+
+<% end %>
+
+<%= form_tag nil, multipart: true do %>
+<fieldset class="inputs">
+<ol>
+  <li class="string input">
+    <%= label_tag :file, "File Upload", :class => 'label' %>
+    <%= file_field_tag 'file' %>
+  </li>
+</ol>
+</fieldset>
+
+<ul class="actions">
+  <ol>
+    <li><%= submit_tag("Import Schedules") %></li>
+  </ol>
+</ul>
+
+<% end %>

--- a/lib/file_schedule_import.rb
+++ b/lib/file_schedule_import.rb
@@ -1,0 +1,56 @@
+##
+# File Schedule Import class
+class FileScheduleImport
+  attr_accessor :messages, :events_list
+
+  ##
+  # Initialize new object
+  def initialize
+    self.messages = []
+    self.events_list = []
+  end
+
+  ##
+  # Run the importer
+  def run(options = {})
+    # Parse the uploaded file
+    schedule_document = Nokogiri::XML(options[:file].read)
+
+    # Obtain the Entity from the header
+    team_id = nil
+    schedule_document.css(
+      'sports-metadata sports-content-codes '\
+      'sports-content-code[@code-type="team"]'
+    ).each do |sportscontent|
+      team_id = sportscontent['code-key']
+    end
+    if team_id.nil?
+      messages << 'Unable to find an Entity to associate with this schedule'
+      return
+    else
+      entity = Entity.find_by_import_key(team_id)
+      if entity.nil?
+        messages << "Could not find entity that matched #{team_id}"
+        return
+      end
+    end
+
+    # Parse the schedule and create the events
+    schedule = SodaXmlTeam::Schedule.parse_schedule(schedule_document)
+
+    schedule.each do |row|
+
+      # Map in entity_id for import
+      row[:entity_id] = entity.id
+
+      # Skip the away games
+      next unless row[:home_team_id] == entity.import_key
+
+      # Create or update the row
+      events_list << Event.import(row)
+    end
+
+    # Done with that team
+    messages << 'Schedule imported!'
+  end
+end


### PR DESCRIPTION
With the MLB schedules this year, the data provider was lousy about keeping/publishing the regular season schedules separate of the pre-season schedules. As such, we were going to have to wait until opening day to get the regular season schedules.

They resolved this by sending me a free ZIP file of all MLB schedules. As the current iteration of the importer was only written to communicate with the API, this PR adds the ability to import them as one-off files. Will be handy for development purposes later anyway.
