### PR TITLE
s/Add/Move/ in migration name

### DIFF
--- a/db/migrate/20150407030117_move_profile_fields_to_user.rb
+++ b/db/migrate/20150407030117_move_profile_fields_to_user.rb
@@ -1,4 +1,4 @@
-class AddProfileFieldsToUser < ActiveRecord::Migration
+class MoveProfileFieldsToUser < ActiveRecord::Migration
   class User < ActiveRecord::Base
     has_one :profile
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150407030434) do
+ActiveRecord::Schema.define(version: 20150407030117) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
@bval: This whined when run locally.

```
Stephens-Air:seatshare-rails (master) stephen$ rake db:migrate
rake aborted!
NameError: uninitialized constant MoveProfileFieldsToUser
```
