### PR TITLE
Add custom database config for CircleCI to run db:migrate

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,7 @@
 machine:
   ruby:
     version: 2.1.0
+database:
+  override:
+    - mv config/database.ci.yml config/database.yml
+    - bundle exec rake db:create db:migrate --trace

--- a/config/database.ci.yml
+++ b/config/database.ci.yml
@@ -1,0 +1,5 @@
+test:
+  host: localhost
+  username: ubuntu
+  database: circle_ruby_test
+  adapter: postgresql


### PR DESCRIPTION
db:schema:load, the CircleCI default, doesn't catch migration errors
