### PR TITLE
INNER JOIN users to profile in migration to avoid orphans

### DIFF
--- a/db/migrate/20150407030117_move_profile_fields_to_user.rb
+++ b/db/migrate/20150407030117_move_profile_fields_to_user.rb
@@ -15,13 +15,16 @@ class MoveProfileFieldsToUser < ActiveRecord::Migration
       t.boolean  :sms_notify
     end
 
-    Profile.find_each do |profile|
-      profile.user.update_attributes(
-        bio: profile.bio,
-        location: profile.location,
-        mobile: profile.mobile,
-        sms_notify: profile.sms_notify
-      )
+    Profile.joins(:user).find_each do |profile|
+      begin
+        profile.user.update_attributes(
+          bio: profile.bio,
+          location: profile.location,
+          mobile: profile.mobile,
+          sms_notify: profile.sms_notify
+        )
+      rescue
+      end
     end
 
      drop_table :profiles


### PR DESCRIPTION
Also rescue the update_attributes Just In Case™. This data is not very
important at the moment, so #yolorescue.
