### PR TITLE
Fix for assignment SMS not sending

### DIFF
--- a/lib/twilio_sms.rb
+++ b/lib/twilio_sms.rb
@@ -17,7 +17,7 @@ class TwilioSMS
   # Send notification of an assigned ticket
   def assign_ticket(ticket, acting_user)
     assignee = ticket.assigned
-    return false unless !assignee.mobile.blank? && user.sms_notify
+    return false unless !assignee.mobile.blank? && assignee.sms_notify
     twilio_client.messages.create(
       from: ENV['TWILIO_OUTBOUND_NUMBER'], to: assignee.mobile_e164,
       body: "#{acting_user.display_name} has assigned you "\


### PR DESCRIPTION
Noticed this last night that I didn't get the notification SMS (but did get the email) for Jonathan's ticket for Friday. Went to debug it and it looks like a simple variable miss in the mass refactoring of the `Profile` removal PR. Easy nuff.

Fixes #188
