### PR TITLE
Improve test coverage for Schedule mailer

### DIFF
--- a/test/fixtures/tickets.yml
+++ b/test/fixtures/tickets.yml
@@ -95,3 +95,29 @@ rick_2:
   note: For Jill
   alias_id: 0
   cost: 32.00
+
+jim_3:
+  id: 8
+  group_id: 1
+  event_id: 7
+  section: 326
+  row: K
+  seat: 10
+  owner_id: 1
+  user_id: 1
+  note: 
+  alias_id: 0
+  cost: 32.00
+
+jim_4:
+  id: 9
+  group_id: 1
+  event_id: 7
+  section: 326
+  row: K
+  seat: 11
+  owner_id: 1
+  user_id: 0
+  note: 
+  alias_id: 0
+  cost: 32.00

--- a/test/mailers/schedule_notifier_test.rb
+++ b/test/mailers/schedule_notifier_test.rb
@@ -29,6 +29,18 @@ class ScheduleNotifierTest < ActionMailer::TestCase
       '<td><a href="http://localhost:3000/groups/1/event-7">Nashville '\
         'Predators vs. Florida Panthers</a></td>'
     )
+    assert_includes(
+      email.body.to_s,
+      '<li><span style="font-weight:bold;">1</span> available in the group</li>'
+    )
+    assert_includes(
+      email.body.to_s,
+      '<li><span style="font-weight:bold;">2</span> total in the group</li>'
+    )
+    assert_includes(
+      email.body.to_s,
+      '<li><span style="font-weight:bold;">1</span> held by you</li>'
+    )
   end
 
   test 'send weekly schedule' do
@@ -52,6 +64,18 @@ class ScheduleNotifierTest < ActionMailer::TestCase
       email.body.to_s,
       '<td><a href="http://localhost:3000/groups/1/event-6">Nashville '\
         'Predators vs. Los Angeles Kings</a></td>'
+    )
+    assert_includes(
+      email.body.to_s,
+      '<li><span style="font-weight:bold;">1</span> available in the group</li>'
+    )
+    assert_includes(
+      email.body.to_s,
+      '<li><span style="font-weight:bold;">2</span> total in the group</li>'
+    )
+    assert_includes(
+      email.body.to_s,
+      '<li><span style="font-weight:bold;">1</span> held by you</li>'
     )
   end
 end


### PR DESCRIPTION
Related: #192

This doesn't solve the bug, but it does verify that if the correct filtered events are provided, the email will be correct. The bug exists somewhere in the model or the rake task.
