### PR TITLE
Fix data leak between groups, user alias save bug

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -8,7 +8,7 @@ class EventsController < ApplicationController
   def show
     @group = Group.find_by_id(params[:group_id]) || not_found
     @event = Event.find_by_id(params[:id]) || not_found
-    @tickets = @event.tickets.by_seat
+    @tickets = @event.tickets.where("group_id = #{@group.id}").by_seat
     @ticket_stats = @event.ticket_stats(@group, current_user)
 
     respond_to do |format|

--- a/app/views/user_aliases/new.html.erb
+++ b/app/views/user_aliases/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title do %>Add User Alias<% end %>
 
-<%= form_for @user_alias, url: new_user_alias_path, html: {class: "form-horizontal", role: "form"} do |f| %>
+<%= form_for @user_alias, url: user_aliases_path, html: {class: "form-horizontal", role: "form"} do |f| %>
 
   <fieldset>
     <legend>User Alias details</legend>


### PR DESCRIPTION
- Fixes #207 where viewing an event page would show tickets across all groups even if a user was not a member
- FIxes an issue where saving a User Alias would cause a fatal error
