### PR TITLE
Bump version of soda_xml_team

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,7 @@ gem 'activeadmin', github: 'activeadmin'
 gem 'mailchimp-api', '~> 2.0.5'
 
 # SeatShare's own SODA gem
-gem 'soda_xml_team', '~> 1.3.0'
+gem 'soda_xml_team', '~> 1.4.3'
 
 # Capistrano
 gem 'capistrano', '~> 3.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,7 +157,7 @@ GEM
     hike (1.2.3)
     hitimes (1.2.2)
     http_parser.rb (0.6.0)
-    httparty (0.13.3)
+    httparty (0.13.5)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
     i18n (0.6.11)
@@ -294,8 +294,9 @@ GEM
       capistrano (>= 3.0.1)
       json
     slop (3.6.0)
-    soda_xml_team (1.3.1)
+    soda_xml_team (1.4.3)
       httparty (>= 0.13)
+      json (>= 1.7.7)
       nokogiri (>= 1.6.3)
     spork (1.0.0rc4)
     spork-rails (4.0.0)
@@ -387,7 +388,7 @@ DEPENDENCIES
   select2-rails
   slack-notifier (~> 1.1.0)
   slackistrano
-  soda_xml_team (~> 1.3.0)
+  soda_xml_team (~> 1.4.3)
   spork-minitest!
   spork-rails
   thin


### PR DESCRIPTION
Had to do some minor fixes on the Gem in order to support some rather annoying changes made upstream by SODA.
- Must provide a publisher database (because they recently lost access to their original data provider)
- Some files are coming in with a mysterious empty node (all node attributes are present, none of the values are filled in)
