### PR TITLE
Replace SimpleForm

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -8,9 +8,6 @@ export ADMIN_API_KEY=admin_api_key
 export MAILCHIMP_API_KEY=the_api_key
 export MAILCHIMP_LIST_ID=the_list_id
 
-export SIMPLE_FORM_API_TOKEN=the_private_token
-export SIMPLE_FORM_FORM_API_TOKEN=the_public_token
-
 export SODA_USERNAME=the_soda_username
 export SODA_PASSWORD=the_soda_password
 export SODA_ENVIRONMENT=development

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -3,54 +3,11 @@ ActiveAdmin.register_page 'Dashboard' do
   menu priority: 1, label: proc { I18n.t('active_admin.dashboard') }
 
   content title: proc { I18n.t('active_admin.dashboard') } do
-
     columns do
-
       column do
-
-        panel 'Recent Contact Messages' do
-          token = ENV['SIMPLE_FORM_API_TOKEN']
-          begin
-            contact_form_messages = HTTParty.get(
-              "http://getsimpleform.com/messages.json?api_token=#{token}", no_follow: true
-            )
-          rescue
-            contact_form_messages = []
-          end
-          div do
-            if contact_form_messages.count > 0
-              contact_form_messages.first(5).each do |message|
-                h4 mail_to(
-                  message['data']['email'],
-                  message['data']['name'] + ' - ' + message['data']['email']
-                )
-                div do
-                  simple_format "#{message['data']['message']}"
-                end
-                div "#{message['created_at']} - #{message['request_ip']}"
-                hr
-              end
-            else
-              h4 'No recent messages. '\
-                'Messages sent through the contact form appear here.'
-              hr
-            end
-          end
-          div style: 'text-align: right' do
-            token = ENV['SIMPLE_FORM_API_TOKEN']
-            link_to(
-              'Manage Messages',
-              "http://getsimpleform.com/messages?api_token=#{token}",
-              target: '_blank'
-            )
-          end
-        end
-
         panel 'Twilio' do
           client = TwilioSMS.new
-
           h3 'Account Summary'
-
           usage = client.sms_usage
           if usage.is_a? String
             h4 usage
@@ -67,9 +24,7 @@ ActiveAdmin.register_page 'Dashboard' do
               end
             end
           end
-
           h3 'Recent Messages'
-
           usage = client.recent_messages
           if usage.is_a? String
             h4 usage

--- a/app/controllers/public_controller.rb
+++ b/app/controllers/public_controller.rb
@@ -58,6 +58,20 @@ class PublicController < ApplicationController
   def contact
   end
 
+  ##
+  # Send Contact Form
+  def do_contact
+    ContactMailer.support_ticket(
+      params[:name],
+      params[:email],
+      params[:subject],
+      params[:message]
+    ).deliver
+    redirect_to(
+      controller: 'public', action: 'contact', status: 302, thank_you: 1
+    ) && return
+  end
+
   private
 
   ##

--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -1,0 +1,34 @@
+
+##
+# Contact Mailer
+class ContactMailer < ActionMailer::Base
+  default from: 'no-reply@myseatshare.com'
+
+  ##
+  # Send Support Ticket
+  # - name: string of name
+  # - email: string of email
+  # - subject: string of message subject
+  # - message: string of message body
+  def support_ticket(name, email, subject, message)
+    if name.blank? || email.blank? || subject.blank? || message.blank?
+      return false
+    end
+
+    @message = message
+
+    from = Mail::Address.new email # ex: "john@example.com"
+    from.display_name = name.dup # ex: "John Doe"
+
+    mail(
+      to: 'SeatShare Support <contact@myseatshare.com>',
+      from: from.format,
+      subject: subject,
+      reply_to: "#{name} <#{email}>"
+    )
+
+    headers['X-MC-Tags'] = 'SupportTicket'
+    headers['X-MC-Subaccount'] = 'SeatShare'
+    headers['X-MC-SigningDomain'] = 'myseatshare.com'
+  end
+end

--- a/app/views/contact_mailer/support_ticket.html.erb
+++ b/app/views/contact_mailer/support_ticket.html.erb
@@ -1,0 +1,1 @@
+<%= simple_format(@message) %>

--- a/app/views/public/contact.html.erb
+++ b/app/views/public/contact.html.erb
@@ -17,8 +17,7 @@
 </div>
 <% end %>
 
-<%= form_tag "https://getsimpleform.com/messages?form_api_token=#{ENV['SIMPLE_FORM_FORM_API_TOKEN']}", :class => "form-horizontal", :role => "form" do |f| %>
-
+<%= form_tag contact_path, :class => "form-horizontal", :role => "form" do |f| %>
   <div class="form-group">
     <label for="name" class="col-sm-2 control-label">Your Name</label>
     <div class="col-sm-10">
@@ -50,9 +49,6 @@
       </p>
     </div>
   </div>
-
-  <%= hidden_field_tag :redirect_to, url_for({:controller => 'public', :action => 'contact', :host => 'myseatshare.com', :thank_you => 1}) %>
-
 <% end %>
 
 <p class="text-muted">We hate spam email as much as you do. We will only use the provided contact information to discuss your message. We will not to sign you up for any email lists or share with a third party. See our <%= link_to "privacy policy", privacy_path %> for more details.</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ SeatShare::Application.routes.draw do
   get 'tos' => 'public#tos'
   get 'privacy' => 'public#privacy'
   get 'contact' => 'public#contact'
+  post 'contact' => 'public#do_contact'
 
   devise_scope :user do
     get "register/group/:group_code", to: "registrations#new", as: 'register_with_group_code'

--- a/test/mailers/contact_mailer_test.rb
+++ b/test/mailers/contact_mailer_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+##
+# Contact Mailer Test
+class ContactMailerTest < ActionMailer::TestCase
+  test 'send support ticket' do
+    email = ContactMailer.support_ticket(
+      'John Doe',
+      'john@example.com',
+      'This is a sample message',
+      "This is a long message that\n has a line break or\n two in it."
+    ).deliver
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    assert_equal ['john@example.com'], email.from
+    assert_equal ['john@example.com'], email.reply_to
+    assert_equal ['contact@myseatshare.com'], email.to
+    assert_equal 'This is a sample message', email.subject
+
+    assert_includes(
+      email.body.to_s,
+      "<p>This is a long message that\n<br /> has a line "\
+      "break or\n<br /> two in it.</p>"
+    )
+  end
+end


### PR DESCRIPTION
Fixes #141

All emails from the contact form are forwarded to `contact@myseatshare.com`, which are then picked up by HelpScout for processing as actual support tickets.
