### PR TITLE
Convert Mixpanel distinct_id to email address

### DIFF
--- a/app/views/layouts/_mixpanel.html.erb
+++ b/app/views/layouts/_mixpanel.html.erb
@@ -2,7 +2,16 @@
 <script type="text/javascript">
 mixpanel.init('<%= ENV['MIXPANEL_API_KEY'] %>');
 <% if user_signed_in? %>
-mixpanel.identify("<%= current_user.id %>");
+<% if flash[:conversion] == true %>
+// Track what happened prior to signup (converts old UUID to new ID)
+mixpanel.alias(<%= current_user.email.to_json.html_safe %>);
+<% end %>
+
+// Alias older numeric user.id to email address
+mixpanel.alias(<%= current_user.email.to_json.html_safe %>, <%= current_user.id.to_json.html_safe %>);
+
+// Authoritative Tracking
+mixpanel.identify(<%= current_user.email.to_json.html_safe %>);
 mixpanel.people.set({
     "$first_name": <%= current_user.first_name.to_json.html_safe %>,
     "$last_name": <%= current_user.last_name.to_json.html_safe %>,


### PR DESCRIPTION
- New user data associated with pre-registration activity
- Migrate any user with a numeric identifier to their email address
- All users identified by email address

Fixes #216
