### PR TITLE
Fix broken User Alias delete / validation

### DIFF
--- a/app/controllers/user_aliases_controller.rb
+++ b/app/controllers/user_aliases_controller.rb
@@ -18,10 +18,14 @@ class UserAliasesController < ApplicationController
       last_name: user_alias_params[:last_name],
       user_id: current_user.id
     )
-    user_alias.save!
     flash.keep
-    flash[:notice] = 'User alias created!'
-    redirect_to(controller: :users, action: :edit) && return
+    if user_alias.save
+      flash[:notice] = 'User alias created!'
+      redirect_to(controller: :users, action: :edit) && return
+    else
+      flash[:error] = 'Could not create User Alias.'
+      redirect_to(controller: :user_aliases, action: :new) && return
+    end
   end
 
   ##
@@ -39,10 +43,16 @@ class UserAliasesController < ApplicationController
     user_alias = UserAlias.find_by_id(params[:id]) || not_found
     user_alias.first_name = user_alias_params[:first_name]
     user_alias.last_name = user_alias_params[:last_name]
-    user_alias.save!
     flash.keep
-    flash[:notice] = 'User Alias updated!'
-    redirect_to(controller: :users, action: :edit) && return
+    if user_alias.save
+      flash[:notice] = 'User Alias updated!'
+      redirect_to(controller: :users, action: :edit) && return
+    else
+      flash[:error] = 'Could not update User Alias.'
+      redirect_to(
+        controller: :user_aliases, action: :edit, id: user_alias.id
+      ) && return
+    end
   end
 
   ##

--- a/app/views/tickets/edit.html.erb
+++ b/app/views/tickets/edit.html.erb
@@ -26,6 +26,12 @@
       </div>
     </div>
   </div>
+  <% else %>
+  <div class="form-group">
+    <div class="col-md-9 col-md-offset-3">
+      <span class="help-block"><i class="fa fa-info-circle"></i> Create <%= link_to "User Aliases", edit_user_path %> to reserve tickets for people without accounts.</span>
+    </div>
+  </div>
   <% end %>
   <div class="form-group">
     <%= f.label :cost, :class => 'col-md-3 control-label' %>

--- a/app/views/tickets/new.html.erb
+++ b/app/views/tickets/new.html.erb
@@ -59,6 +59,12 @@
       </div>
     </div>
   </div>
+  <% else %>
+  <div class="form-group">
+    <div class="col-md-9 col-md-offset-3">
+      <span class="help-block"><i class="fa fa-info-circle"></i> Create <%= link_to "User Aliases", edit_user_path %> to reserve tickets for people without accounts.</span>
+    </div>
+  </div>
   <% end %>
 
 </fieldset>

--- a/app/views/user_aliases/edit.html.erb
+++ b/app/views/user_aliases/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title do %>Edit User Alias<% end %>
 
-<%= form_for @user_alias, url: edit_user_alias_path, html: {class: "form-horizontal", role: "form"} do |f| %>
+<%= form_for @user_alias, url: user_alias_path, html: {class: "form-horizontal", role: "form"} do |f| %>
 
   <fieldset>
     <legend>User Alias details</legend>

--- a/app/views/users/_add_mobile_alerts.html.erb
+++ b/app/views/users/_add_mobile_alerts.html.erb
@@ -4,7 +4,7 @@
     <div class="sidebar-icon"><%= link_to raw('<span class="fa fa-mobile"></span>'), user_path %></div>
     <h3>Never miss an alert from SeatShare</h3>
     <p>Add your mobile phone number to receive a text message when someone requests or assigns you a ticket.</p>
-    <p><%= link_to 'Add Mobile Number', user_path, class: 'btn btn-info' %></p>
+    <p><%= link_to 'Add Mobile Number', user_path, class: 'btn btn-primary' %></p>
   </div>
 </div>
 <% end %>

--- a/app/views/users/_add_tickets.html.erb
+++ b/app/views/users/_add_tickets.html.erb
@@ -1,10 +1,10 @@
 <% if @group.tickets.count == 0 && @group.events.future.count > 0 %>
 <div class="panel panel-default">
   <div class="panel-body">
-    <div class="sidebar-icon"><%= link_to raw('<span class="fa fa-ticket"></span>'), user_path %></div>
+    <div class="sidebar-icon"><%= link_to raw('<span class="fa fa-ticket"></span>'), { :controller => 'tickets', :action => 'new', :group_id => @group.id } %></div>
     <h3>Add Your Tickets</h3>
     <p>Have tickets for your group? Add them to SeatShare.</p>
-    <p><%= link_to 'Add Tickets', { :controller => 'tickets', :action => 'new', :group_id => @group.id }, class: 'btn btn-info' %></p>
+    <p><%= link_to 'Add Tickets', { :controller => 'tickets', :action => 'new', :group_id => @group.id }, class: 'btn btn-primary' %></p>
   </div>
 </div>
 <% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -93,8 +93,8 @@
     <tbody>
       <% for user_alias in @user_aliases %>
       <tr>
-        <td><%= link_to user_alias.display_name, :controller => 'user_aliases', :action => 'edit', :id => user_alias.id %></td>
-        <td><%= link_to raw('<span class="fa fa-trash"></span>'), { :controller => 'user_aliases', :action => 'destroy', :id => user_alias.id }, :class => 'btn btn-sm btn-danger confirm' %></td>
+        <td><%= link_to user_alias.display_name, edit_user_alias_path(user_alias) %></td>
+        <td><%= link_to raw('<span class="fa fa-trash"></span>'), user_alias_path(user_alias), :method => 'delete', :class => 'btn btn-sm btn-danger confirm' %></td>
       </tr>
       <% end %>
     </tbody>


### PR DESCRIPTION
While checking other things, I noticed that you could not delete a User Alias after creating it. This PR takes care of that by ensuring all the CRUD functionality is working as expected, and adds a note at ticket creation that User Aliases can be used to reserve tickets for non-users.
