### PR TITLE
Move from organization to personal account

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# SeatShare [![Circle CI](https://circleci.com/gh/seatshare/seatshare-rails.svg?style=svg&circle-token=b15e16199f58286483c6319a05cb11452131ab70)](https://circleci.com/gh/seatshare/seatshare-rails)
+# SeatShare [![Circle CI](https://circleci.com/gh/stephenyeargin/seatshare-rails.svg?style=svg&circle-token=b15e16199f58286483c6319a05cb11452131ab70)](https://circleci.com/gh/stephenyeargin/seatshare-rails)
 
 This project allows a group of people to manage a pool of tickets to events. The most common use case is to share season tickets to a sports team.
 
 ## Installation
 
-Please see the complete [installation instructions](https://github.com/seatshare/seatshare-rails/wiki/Installation) in the wiki.
+Please see the complete [installation instructions](https://github.com/stephenyeargin/seatshare-rails/wiki/Installation) in the wiki.
 
 ## Getting started with the application
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -2,7 +2,7 @@
 lock '3.2.1'
 
 set :application, 'seatshare'
-set :repo_url, 'git@github.com:seatshare/seatshare-rails.git'
+set :repo_url, 'git@github.com:stephenyeargin/seatshare-rails.git'
 
 # Default branch is :master
 # Uncomment the following line to have Capistrano ask which branch to deploy.

--- a/test/mailers/ticket_notifier_test.rb
+++ b/test/mailers/ticket_notifier_test.rb
@@ -30,7 +30,7 @@ class TicketNotifierTest < ActionMailer::TestCase
         'following event in your group Geeks Watching Hockey.</p>'
     )
     fails_intermittently(
-      'https://github.com/seatshare/seatshare-rails/issues/109',
+      'https://github.com/stephenyeargin/seatshare-rails/issues/109',
       'Rails.configuration.time_zone' => Rails.configuration.time_zone,
       'Time.zone.name' => Time.zone.name, 'user.timezone' => user.timezone
     ) do
@@ -68,7 +68,7 @@ class TicketNotifierTest < ActionMailer::TestCase
         'following event in your group Geeks Watching Hockey.</p>'
     )
     fails_intermittently(
-      'https://github.com/seatshare/seatshare-rails/issues/109',
+      'https://github.com/stephenyeargin/seatshare-rails/issues/109',
       'Rails.configuration.time_zone' => Rails.configuration.time_zone,
       'Time.zone.name' => Time.zone.name,
       'user.timezone' => user.timezone

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -26,7 +26,7 @@ class EventTest < ActiveSupport::TestCase
     assert event.date_tba? == false, 'new event date is not TBA'
     assert event.time_tba? == false, 'new event time is not TBA'
     fails_intermittently(
-      'https://github.com/seatshare/seatshare-rails/issues/109',
+      'https://github.com/stephenyeargin/seatshare-rails/issues/109',
       'Rails.configuration.time_zone' => Rails.configuration.time_zone,
       'Time.zone.name' => Time.zone.name
     ) do


### PR DESCRIPTION
Our coupon expired, so I've moved this under my personal account. These changes are to make it deployable again.
