### PR TITLE
Update seed data to stop having hard-coded IDs

### DIFF
--- a/db/seeds/000_entity_types.rb
+++ b/db/seeds/000_entity_types.rb
@@ -1,38 +1,75 @@
+# -*- coding: utf-8 -*-
 EntityType.create([
   {
-    id: 1, entity_type_name: 'National Hockey League', entity_type_abbreviation: 'NHL', sort: 40, import_key: 'http://api.seatgeek.com/2/performers?taxonomies.name=nhl'
+    entity_type_name: 'National Hockey League',
+    entity_type_abbreviation: 'NHL',
+    sort: 40,
+    import_key: 'http://api.seatgeek.com/2/performers?taxonomies.name=nhl'
   },
   {
-    id: 2, entity_type_name: 'Major League Baseball', entity_type_abbreviation: 'MLB', sort: 20, import_key: 'http://api.seatgeek.com/2/performers?taxonomies.name=mlb'
+    entity_type_name: 'Major League Baseball',
+    entity_type_abbreviation: 'MLB',
+    sort: 20,
+    import_key: 'http://api.seatgeek.com/2/performers?taxonomies.name=mlb'
   },
   {
-    id: 3, entity_type_name: 'National Basketball Association', entity_type_abbreviation: 'NBA', sort: 30, import_key: 'http://api.seatgeek.com/2/performers?taxonomies.name=nba'
+    entity_type_name: 'National Basketball Association',
+    entity_type_abbreviation: 'NBA',
+    sort: 30,
+    import_key: 'http://api.seatgeek.com/2/performers?taxonomies.name=nba'
   },
   {
-    id: 4, entity_type_name: 'National Football League', entity_type_abbreviation: 'NFL', sort: 10, import_key: 'http://api.seatgeek.com/2/performers?taxonomies.name=nfl'
+    entity_type_name: 'National Football League',
+    entity_type_abbreviation: 'NFL',
+    sort: 10,
+    import_key: 'http://api.seatgeek.com/2/performers?taxonomies.name=nfl'
   },
   {
-    id: 5, entity_type_name: 'Major League Soccer', entity_type_abbreviation: 'MLS', sort: 50, import_key: 'http://api.seatgeek.com/2/performers?taxonomies.name=mls'
+    entity_type_name: 'Major League Soccer',
+    entity_type_abbreviation: 'MLS',
+    sort: 50,
+    import_key: 'http://api.seatgeek.com/2/performers?taxonomies.name=mls'
   },
   {
-    id: 6, entity_type_name: 'Canadian Football League', entity_type_abbreviation: 'CFL', sort: 60, import_key: 'http://api.seatgeek.com/2/performers?taxonomies.name=football'
+    entity_type_name: 'Canadian Football League',
+    entity_type_abbreviation: 'CFL',
+    sort: 60,
+    import_key: 'http://api.seatgeek.com/2/performers?taxonomies.name=football'
   },
   {
-    id: 7, entity_type_name: 'NCAA Football', entity_type_abbreviation: 'NCAAF', sort: 70, import_key: 'http://api.seatgeek.com/2/performers?taxonomies.name=ncaa_football'
+    entity_type_name: 'NCAA Football',
+    entity_type_abbreviation: 'NCAAF',
+    sort: 70,
+    import_key: 'http://api.seatgeek.com/2/performers?taxonomies.name=ncaa_football'
   },
   {
-    id: 8, entity_type_name: 'NCAA Men\'s Basketball', entity_type_abbreviation: 'NCAAMB', sort: 80, import_key: 'http://api.seatgeek.com/2/performers?taxonomies.name=ncaa_basketball'
+    entity_type_name: 'NCAA Men\'s Basketball',
+    entity_type_abbreviation: 'NCAAMB',
+    sort: 80,
+    import_key: 'http://api.seatgeek.com/2/performers?taxonomies.name=ncaa_basketball'
   },
   {
-    id: 9, entity_type_name: 'Women\'s Flat Track Derby Assocation', entity_type_abbreviation: 'WFTDA', sort: 110, import_key: 'wftda'
+    entity_type_name: 'Women\'s Flat Track Derby Assocation',
+    entity_type_abbreviation: 'WFTDA',
+    sort: 110,
+    import_key: 'http://api.seatgeek.com/2/performers?q=roller%20derby'
   },
   {
-    id: 10, entity_type_name: 'NCAA Women\'s Basketball', entity_type_abbreviation: 'NCAAWB', sort: 90, import_key: 'http://api.seatgeek.com/2/performers?taxonomies.name=ncaa_womens_basketball'
+    entity_type_name: 'NCAA Women\'s Basketball',
+    entity_type_abbreviation: 'NCAAWB',
+    sort: 90,
+    import_key: 'http://api.seatgeek.com/2/performers?taxonomies.name=ncaa_womens_basketball'
   },
   {
-    id: 11, entity_type_name: 'Minor League Baseball', entity_type_abbreviation: 'MILB', sort: 100, import_key: 'http://api.seatgeek.com/2/performers?taxonomies.name=minor_league_baseball'
+    entity_type_name: 'Minor League Baseball',
+    entity_type_abbreviation: 'MILB',
+    sort: 100,
+    import_key: 'http://api.seatgeek.com/2/performers?taxonomies.name=minor_league_baseball'
   },
   {
-    id: 12, entity_type_name: 'NCAA College Baseball', entity_type_abbreviation: 'NCAACB', sort: 120, import_key: 'http://api.seatgeek.com/2/performers?taxonomies.name=ncaa_college_baseball'
+    entity_type_name: 'NCAA College Baseball',
+    entity_type_abbreviation: 'NCAACB',
+    sort: 120,
+    import_key: 'http://api.seatgeek.com/2/performers?taxonomies.name=ncaa_college_baseball'
   }
 ])

--- a/db/seeds/001_nhl.rb
+++ b/db/seeds/001_nhl.rb
@@ -1,93 +1,94 @@
 # -*- coding: utf-8 -*-
+entity_type_id = EntityType.find_by_entity_type_abbreviation('NHL').id
 Entity.create([
   {
-    id: 101, entity_name: 'Anaheim Ducks', import_key: 'l.nhl.com-t.22', entity_type_id: 1, status: 1
+    entity_name: 'Anaheim Ducks', import_key: 'l.nhl.com-t.22', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 102, entity_name: 'Arizona Coyotes', import_key: 'l.nhl.com-t.25', entity_type_id: 1, status: 1
+    entity_name: 'Arizona Coyotes', import_key: 'l.nhl.com-t.25', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 103, entity_name: 'Boston Bruins', import_key: 'l.nhl.com-t.11', entity_type_id: 1, status: 1
+    entity_name: 'Boston Bruins', import_key: 'l.nhl.com-t.11', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 104, entity_name: 'Buffalo Sabres', import_key: 'l.nhl.com-t.12', entity_type_id: 1, status: 1
+    entity_name: 'Buffalo Sabres', import_key: 'l.nhl.com-t.12', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 105, entity_name: 'Calgary Flames', import_key: 'l.nhl.com-t.28', entity_type_id: 1, status: 1
+    entity_name: 'Calgary Flames', import_key: 'l.nhl.com-t.28', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 106, entity_name: 'Carolina Hurricanes', import_key: 'l.nhl.com-t.6', entity_type_id: 1, status: 1
+    entity_name: 'Carolina Hurricanes', import_key: 'l.nhl.com-t.6', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 107, entity_name: 'Chicago Blackhawks', import_key: 'l.nhl.com-t.16', entity_type_id: 1, status: 1
+    entity_name: 'Chicago Blackhawks', import_key: 'l.nhl.com-t.16', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 108, entity_name: 'Columbus Blue Jackets', import_key: 'l.nhl.com-t.20', entity_type_id: 1, status: 1
+    entity_name: 'Columbus Blue Jackets', import_key: 'l.nhl.com-t.20', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 109, entity_name: 'Colorado Avalanche', import_key: 'l.nhl.com-t.27', entity_type_id: 1, status: 1
+    entity_name: 'Colorado Avalanche', import_key: 'l.nhl.com-t.27', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 110, entity_name: 'Dallas Stars', import_key: 'l.nhl.com-t.21', entity_type_id: 1, status: 1
+    entity_name: 'Dallas Stars', import_key: 'l.nhl.com-t.21', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 111, entity_name: 'Detroit Red Wings', import_key: 'l.nhl.com-t.17', entity_type_id: 1, status: 1
+    entity_name: 'Detroit Red Wings', import_key: 'l.nhl.com-t.17', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 112, entity_name: 'Edmonton Oilers', import_key: 'l.nhl.com-t.29', entity_type_id: 1, status: 1
+    entity_name: 'Edmonton Oilers', import_key: 'l.nhl.com-t.29', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 113, entity_name: 'Florida Panthers', import_key: 'l.nhl.com-t.10', entity_type_id: 1, status: 1
+    entity_name: 'Florida Panthers', import_key: 'l.nhl.com-t.10', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 114, entity_name: 'Los Angeles Kings', import_key: 'l.nhl.com-t.23', entity_type_id: 1, status: 1
+    entity_name: 'Los Angeles Kings', import_key: 'l.nhl.com-t.23', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 115, entity_name: 'Minnesota Wild', import_key: 'l.nhl.com-t.30', entity_type_id: 1, status: 1
+    entity_name: 'Minnesota Wild', import_key: 'l.nhl.com-t.30', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 116, entity_name: 'Montréal Canadiens', import_key: 'l.nhl.com-t.13', entity_type_id: 1, status: 1
+    entity_name: 'Montréal Canadiens', import_key: 'l.nhl.com-t.13', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 117, entity_name: 'Nashville Predators', import_key: 'l.nhl.com-t.19', entity_type_id: 1, status: 1
+    entity_name: 'Nashville Predators', import_key: 'l.nhl.com-t.19', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 118, entity_name: 'New Jersey Devils', import_key: 'l.nhl.com-t.1', entity_type_id: 1, status: 1
+    entity_name: 'New Jersey Devils', import_key: 'l.nhl.com-t.1', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 119, entity_name: 'New York Islanders', import_key: 'l.nhl.com-t.2', entity_type_id: 1, status: 1
+    entity_name: 'New York Islanders', import_key: 'l.nhl.com-t.2', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 120, entity_name: 'New York Rangers', import_key: 'l.nhl.com-t.3', entity_type_id: 1, status: 1
+    entity_name: 'New York Rangers', import_key: 'l.nhl.com-t.3', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 121, entity_name: 'Ottawa Senators', import_key: 'l.nhl.com-t.14', entity_type_id: 1, status: 1
+    entity_name: 'Ottawa Senators', import_key: 'l.nhl.com-t.14', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 122, entity_name: 'Philadelphia Flyers', import_key: 'l.nhl.com-t.4', entity_type_id: 1, status: 1
+    entity_name: 'Philadelphia Flyers', import_key: 'l.nhl.com-t.4', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 123, entity_name: 'Pittsburgh Penguins', import_key: 'l.nhl.com-t.5', entity_type_id: 1, status: 1
+    entity_name: 'Pittsburgh Penguins', import_key: 'l.nhl.com-t.5', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 124, entity_name: 'San Jose Sharks', import_key: 'l.nhl.com-t.24', entity_type_id: 1, status: 1
+    entity_name: 'San Jose Sharks', import_key: 'l.nhl.com-t.24', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 125, entity_name: 'St. Louis Blues', import_key: 'l.nhl.com-t.18', entity_type_id: 1, status: 1
+    entity_name: 'St. Louis Blues', import_key: 'l.nhl.com-t.18', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 126, entity_name: 'Tampa Bay Lightning', import_key: 'l.nhl.com-t.7', entity_type_id: 1, status: 1
+    entity_name: 'Tampa Bay Lightning', import_key: 'l.nhl.com-t.7', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 127, entity_name: 'Toronto Maple Leafs', import_key: 'l.nhl.com-t.15', entity_type_id: 1, status: 1
+    entity_name: 'Toronto Maple Leafs', import_key: 'l.nhl.com-t.15', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 128, entity_name: 'Vancouver Canucks', import_key: 'l.nhl.com-t.26', entity_type_id: 1, status: 1
+    entity_name: 'Vancouver Canucks', import_key: 'l.nhl.com-t.26', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 129, entity_name: 'Washington Capitals', import_key: 'l.nhl.com-t.8', entity_type_id: 1, status: 1
+    entity_name: 'Washington Capitals', import_key: 'l.nhl.com-t.8', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 130, entity_name: 'Winnipeg Jets', import_key: 'l.nhl.com-t.9', entity_type_id: 1, status: 1
+    entity_name: 'Winnipeg Jets', import_key: 'l.nhl.com-t.9', entity_type_id: entity_type_id, status: 1
   }
 ])

--- a/db/seeds/002_mlb.rb
+++ b/db/seeds/002_mlb.rb
@@ -1,93 +1,94 @@
 # -*- coding: utf-8 -*-
+entity_type_id = EntityType.find_by_entity_type_abbreviation('MLB').id
 Entity.create([
   {
-    id: 201, entity_name: 'Anaheim Angels', import_key: 'l.mlb.com-t.11', entity_type_id: 2, status: 1
+    entity_name: 'Anaheim Angels', import_key: 'l.mlb.com-t.11', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 202, entity_name: 'Arizona Diamondbacks', import_key: 'l.mlb.com-t.26', entity_type_id: 2, status: 1
+    entity_name: 'Arizona Diamondbacks', import_key: 'l.mlb.com-t.26', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 203, entity_name: 'Atlanta Braves', import_key: 'l.mlb.com-t.15', entity_type_id: 2, status: 1
+    entity_name: 'Atlanta Braves', import_key: 'l.mlb.com-t.15', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 204, entity_name: 'Baltimore Orioles', import_key: 'l.mlb.com-t.1', entity_type_id: 2, status: 1
+    entity_name: 'Baltimore Orioles', import_key: 'l.mlb.com-t.1', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 205, entity_name: 'Boston Red Sox', import_key: 'l.mlb.com-t.2', entity_type_id: 2, status: 1
+    entity_name: 'Boston Red Sox', import_key: 'l.mlb.com-t.2', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 206, entity_name: 'Chicago Cubs', import_key: 'l.mlb.com-t.20', entity_type_id: 2, status: 1
+    entity_name: 'Chicago Cubs', import_key: 'l.mlb.com-t.20', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 207, entity_name: 'Chicago White Sox', import_key: 'l.mlb.com-t.6', entity_type_id: 2, status: 1
+    entity_name: 'Chicago White Sox', import_key: 'l.mlb.com-t.6', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 208, entity_name: 'Cincinnati Reds', import_key: 'l.mlb.com-t.21', entity_type_id: 2, status: 1
+    entity_name: 'Cincinnati Reds', import_key: 'l.mlb.com-t.21', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 209, entity_name: 'Cleveland Indians', import_key: 'l.mlb.com-t.7', entity_type_id: 2, status: 1
+    entity_name: 'Cleveland Indians', import_key: 'l.mlb.com-t.7', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 210, entity_name: 'Colorado Rockies', import_key: 'l.mlb.com-t.27', entity_type_id: 2, status: 1
+    entity_name: 'Colorado Rockies', import_key: 'l.mlb.com-t.27', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 211, entity_name: 'Detroit Tigers', import_key: 'l.mlb.com-t.8', entity_type_id: 2, status: 1
+    entity_name: 'Detroit Tigers', import_key: 'l.mlb.com-t.8', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 212, entity_name: 'Houston Astros', import_key: 'l.mlb.com-t.22', entity_type_id: 2, status: 1
+    entity_name: 'Houston Astros', import_key: 'l.mlb.com-t.22', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 213, entity_name: 'Kansas City Royals', import_key: 'l.mlb.com-t.9', entity_type_id: 2, status: 1
+    entity_name: 'Kansas City Royals', import_key: 'l.mlb.com-t.9', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 214, entity_name: 'Los Angeles Dodgers', import_key: 'l.mlb.com-t.28', entity_type_id: 2, status: 1
+    entity_name: 'Los Angeles Dodgers', import_key: 'l.mlb.com-t.28', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 215, entity_name: 'Miami Marlins', import_key: 'l.mlb.com-t.16', entity_type_id: 2, status: 1
+    entity_name: 'Miami Marlins', import_key: 'l.mlb.com-t.16', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 216, entity_name: 'Milwaukee Brewers', import_key: 'l.mlb.com-t.23', entity_type_id: 2, status: 1
+    entity_name: 'Milwaukee Brewers', import_key: 'l.mlb.com-t.23', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 217, entity_name: 'Minnesota Twins', import_key: 'l.mlb.com-t.10', entity_type_id: 2, status: 1
+    entity_name: 'Minnesota Twins', import_key: 'l.mlb.com-t.10', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 218, entity_name: 'New York Mets', import_key: 'l.mlb.com-t.18', entity_type_id: 2, status: 1
+    entity_name: 'New York Mets', import_key: 'l.mlb.com-t.18', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 219, entity_name: 'New York Yankees', import_key: 'l.mlb.com-t.3', entity_type_id: 2, status: 1
+    entity_name: 'New York Yankees', import_key: 'l.mlb.com-t.3', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 220, entity_name: 'Oakland Athletics', import_key: 'l.mlb.com-t.12', entity_type_id: 2, status: 1
+    entity_name: 'Oakland Athletics', import_key: 'l.mlb.com-t.12', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 221, entity_name: 'Philadelphia Phillies', import_key: 'l.mlb.com-t.19', entity_type_id: 2, status: 1
+    entity_name: 'Philadelphia Phillies', import_key: 'l.mlb.com-t.19', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 222, entity_name: 'Pittsburgh Pirates', import_key: 'l.mlb.com-t.24', entity_type_id: 2, status: 1
+    entity_name: 'Pittsburgh Pirates', import_key: 'l.mlb.com-t.24', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 223, entity_name: 'San Diego Padres', import_key: 'l.mlb.com-t.29', entity_type_id: 2, status: 1
+    entity_name: 'San Diego Padres', import_key: 'l.mlb.com-t.29', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 224, entity_name: 'San Francisco Giants', import_key: 'l.mlb.com-t.30', entity_type_id: 2, status: 1
+    entity_name: 'San Francisco Giants', import_key: 'l.mlb.com-t.30', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 225, entity_name: 'Seattle Mariners', import_key: 'l.mlb.com-t.13', entity_type_id: 2, status: 1
+    entity_name: 'Seattle Mariners', import_key: 'l.mlb.com-t.13', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 226, entity_name: 'St. Louis Cardinals', import_key: 'l.mlb.com-t.25', entity_type_id: 2, status: 1
+    entity_name: 'St. Louis Cardinals', import_key: 'l.mlb.com-t.25', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 227, entity_name: 'Tampa Bay Rays', import_key: 'l.mlb.com-t.4', entity_type_id: 2, status: 1
+    entity_name: 'Tampa Bay Rays', import_key: 'l.mlb.com-t.4', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 228, entity_name: 'Texas Rangers', import_key: 'l.mlb.com-t.14', entity_type_id: 2, status: 1
+    entity_name: 'Texas Rangers', import_key: 'l.mlb.com-t.14', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 229, entity_name: 'Toronto Blue Jays', import_key: 'l.mlb.com-t.5', entity_type_id: 2, status: 1
+    entity_name: 'Toronto Blue Jays', import_key: 'l.mlb.com-t.5', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 230, entity_name: 'Washington Nationals', import_key: 'l.mlb.com-t.17', entity_type_id: 2, status: 1
+    entity_name: 'Washington Nationals', import_key: 'l.mlb.com-t.17', entity_type_id: entity_type_id, status: 1
   }
 ])

--- a/db/seeds/003_nba.rb
+++ b/db/seeds/003_nba.rb
@@ -1,93 +1,94 @@
 # -*- coding: utf-8 -*-
+entity_type_id = EntityType.find_by_entity_type_abbreviation('NBA').id
 Entity.create([
   {
-    id: 301, entity_name: 'Atlanta Hawks', import_key: 'l.nba.com-t.8', entity_type_id: 3, status: 1
+    entity_name: 'Atlanta Hawks', import_key: 'l.nba.com-t.8', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 302, entity_name: 'Boston Celtics', import_key: 'l.nba.com-t.1', entity_type_id: 3, status: 1
+    entity_name: 'Boston Celtics', import_key: 'l.nba.com-t.1', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 303, entity_name: 'Brooklyn Nets', import_key: 'l.nba.com-t.3', entity_type_id: 3, status: 1
+    entity_name: 'Brooklyn Nets', import_key: 'l.nba.com-t.3', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 304, entity_name: 'Charlotte Hornets', import_key: 'l.nba.com-t.32', entity_type_id: 3, status: 1
+    entity_name: 'Charlotte Hornets', import_key: 'l.nba.com-t.32', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 305, entity_name: 'Chicago Bulls', import_key: 'l.nba.com-t.10', entity_type_id: 3, status: 1
+    entity_name: 'Chicago Bulls', import_key: 'l.nba.com-t.10', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 306, entity_name: 'Cleveland Cavaliers', import_key: 'l.nba.com-t.11', entity_type_id: 3, status: 1
+    entity_name: 'Cleveland Cavaliers', import_key: 'l.nba.com-t.11', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 307, entity_name: 'Dallas Mavericks', import_key: 'l.nba.com-t.16', entity_type_id: 3, status: 1
+    entity_name: 'Dallas Mavericks', import_key: 'l.nba.com-t.16', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 308, entity_name: 'Denver Nuggets', import_key: 'l.nba.com-t.17', entity_type_id: 3, status: 1
+    entity_name: 'Denver Nuggets', import_key: 'l.nba.com-t.17', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 309, entity_name: 'Detroit Pistons', import_key: 'l.nba.com-t.12', entity_type_id: 3, status: 1
+    entity_name: 'Detroit Pistons', import_key: 'l.nba.com-t.12', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 310, entity_name: 'Golden State Warriors', import_key: 'l.nba.com-t.23', entity_type_id: 3, status: 1
+    entity_name: 'Golden State Warriors', import_key: 'l.nba.com-t.23', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 311, entity_name: 'Houston Rockets', import_key: 'l.nba.com-t.18', entity_type_id: 3, status: 1
+    entity_name: 'Houston Rockets', import_key: 'l.nba.com-t.18', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 312, entity_name: 'Indiana Pacers', import_key: 'l.nba.com-t.13', entity_type_id: 3, status: 1
+    entity_name: 'Indiana Pacers', import_key: 'l.nba.com-t.13', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 313, entity_name: 'Los Angeles Clippers', import_key: 'l.nba.com-t.24', entity_type_id: 3, status: 1
+    entity_name: 'Los Angeles Clippers', import_key: 'l.nba.com-t.24', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 314, entity_name: 'Los Angeles Lakers', import_key: 'l.nba.com-t.25', entity_type_id: 3, status: 1
+    entity_name: 'Los Angeles Lakers', import_key: 'l.nba.com-t.25', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 315, entity_name: 'Memphis Grizzlies', import_key: 'l.nba.com-t.19', entity_type_id: 3, status: 1
+    entity_name: 'Memphis Grizzlies', import_key: 'l.nba.com-t.19', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 316, entity_name: 'Miami Heat', import_key: 'l.nba.com-t.2', entity_type_id: 3, status: 1
+    entity_name: 'Miami Heat', import_key: 'l.nba.com-t.2', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 317, entity_name: 'Milwaukee Bucks', import_key: 'l.nba.com-t.14', entity_type_id: 3, status: 1
+    entity_name: 'Milwaukee Bucks', import_key: 'l.nba.com-t.14', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 318, entity_name: 'Minnesota Timberwolves', import_key: 'l.nba.com-t.20', entity_type_id: 3, status: 1
+    entity_name: 'Minnesota Timberwolves', import_key: 'l.nba.com-t.20', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 319, entity_name: 'New Orleans Pelicans', import_key: 'l.nba.com-t.9', entity_type_id: 3, status: 1
+    entity_name: 'New Orleans Pelicans', import_key: 'l.nba.com-t.9', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 320, entity_name: 'New York Knicks', import_key: 'l.nba.com-t.4', entity_type_id: 3, status: 1
+    entity_name: 'New York Knicks', import_key: 'l.nba.com-t.4', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 321, entity_name: 'Oklahoma City Thunder', import_key: 'l.nba.com-t.29', entity_type_id: 3, status: 1
+    entity_name: 'Oklahoma City Thunder', import_key: 'l.nba.com-t.29', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 322, entity_name: 'Orlando Magic', import_key: 'l.nba.com-t.5', entity_type_id: 3, status: 1
+    entity_name: 'Orlando Magic', import_key: 'l.nba.com-t.5', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 323, entity_name: 'Philadelphia 76ers', import_key: 'l.nba.com-t.6', entity_type_id: 3, status: 1
+    entity_name: 'Philadelphia 76ers', import_key: 'l.nba.com-t.6', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 324, entity_name: 'Phoenix Suns', import_key: 'l.nba.com-t.26', entity_type_id: 3, status: 1
+    entity_name: 'Phoenix Suns', import_key: 'l.nba.com-t.26', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 325, entity_name: 'Portland Trail Blazers', import_key: 'l.nba.com-t.27', entity_type_id: 3, status: 1
+    entity_name: 'Portland Trail Blazers', import_key: 'l.nba.com-t.27', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 326, entity_name: 'Sacramento Kings', import_key: 'l.nba.com-t.28', entity_type_id: 3, status: 1
+    entity_name: 'Sacramento Kings', import_key: 'l.nba.com-t.28', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 327, entity_name: 'San Antonio Spurs', import_key: 'l.nba.com-t.21', entity_type_id: 3, status: 1
+    entity_name: 'San Antonio Spurs', import_key: 'l.nba.com-t.21', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 328, entity_name: 'Toronto Raptors', import_key: 'l.nba.com-t.15', entity_type_id: 3, status: 1
+    entity_name: 'Toronto Raptors', import_key: 'l.nba.com-t.15', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 329, entity_name: 'Utah Jazz', import_key: 'l.nba.com-t.22', entity_type_id: 3, status: 1
+    entity_name: 'Utah Jazz', import_key: 'l.nba.com-t.22', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 330, entity_name: 'Washington Wizards', import_key: 'l.nba.com-t.7', entity_type_id: 3, status: 1
+    entity_name: 'Washington Wizards', import_key: 'l.nba.com-t.7', entity_type_id: entity_type_id, status: 1
   }
 ])

--- a/db/seeds/004_nfl.rb
+++ b/db/seeds/004_nfl.rb
@@ -1,99 +1,100 @@
 # -*- coding: utf-8 -*-
+entity_type_id = EntityType.find_by_entity_type_abbreviation('NFL').id
 Entity.create([
   {
-    id: 401, entity_name: 'Arizona Cardinals', import_key: 'l.nfl.com-t.17', entity_type_id: 4, status: 1
+    entity_name: 'Arizona Cardinals', import_key: 'l.nfl.com-t.17', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 402, entity_name: 'Atlanta Falcons', import_key: 'l.nfl.com-t.27', entity_type_id: 4, status: 1
+    entity_name: 'Atlanta Falcons', import_key: 'l.nfl.com-t.27', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 403, entity_name: 'Baltimore Ravens', import_key: 'l.nfl.com-t.6', entity_type_id: 4, status: 1
+    entity_name: 'Baltimore Ravens', import_key: 'l.nfl.com-t.6', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 404, entity_name: 'Buffalo Bills', import_key: 'l.nfl.com-t.1', entity_type_id: 4, status: 1
+    entity_name: 'Buffalo Bills', import_key: 'l.nfl.com-t.1', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 405, entity_name: 'Carolina Panthers', import_key: 'l.nfl.com-t.29', entity_type_id: 4, status: 1
+    entity_name: 'Carolina Panthers', import_key: 'l.nfl.com-t.29', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 406, entity_name: 'Chicago Bears', import_key: 'l.nfl.com-t.22', entity_type_id: 4, status: 1
+    entity_name: 'Chicago Bears', import_key: 'l.nfl.com-t.22', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 407, entity_name: 'Cincinnati Bengals', import_key: 'l.nfl.com-t.7', entity_type_id: 4, status: 1
+    entity_name: 'Cincinnati Bengals', import_key: 'l.nfl.com-t.7', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 408, entity_name: 'Cleveland Browns', import_key: 'l.nfl.com-t.8', entity_type_id: 4, status: 1
+    entity_name: 'Cleveland Browns', import_key: 'l.nfl.com-t.8', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 409, entity_name: 'Dallas Cowboys', import_key: 'l.nfl.com-t.18', entity_type_id: 4, status: 1
+    entity_name: 'Dallas Cowboys', import_key: 'l.nfl.com-t.18', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 410, entity_name: 'Denver Broncos', import_key: 'l.nfl.com-t.12', entity_type_id: 4, status: 1
+    entity_name: 'Denver Broncos', import_key: 'l.nfl.com-t.12', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 411, entity_name: 'Detroit Lions', import_key: 'l.nfl.com-t.23', entity_type_id: 4, status: 1
+    entity_name: 'Detroit Lions', import_key: 'l.nfl.com-t.23', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 412, entity_name: 'Green Bay Packers', import_key: 'l.nfl.com-t.24', entity_type_id: 4, status: 1
+    entity_name: 'Green Bay Packers', import_key: 'l.nfl.com-t.24', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 413, entity_name: 'Houston Texans', import_key: 'l.nfl.com-t.32', entity_type_id: 4, status: 1
+    entity_name: 'Houston Texans', import_key: 'l.nfl.com-t.32', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 414, entity_name: 'Indianapolis Colts', import_key: 'l.nfl.com-t.2', entity_type_id: 4, status: 1
+    entity_name: 'Indianapolis Colts', import_key: 'l.nfl.com-t.2', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 415, entity_name: 'Jacksonville Jaguars', import_key: 'l.nfl.com-t.9', entity_type_id: 4, status: 1
+    entity_name: 'Jacksonville Jaguars', import_key: 'l.nfl.com-t.9', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 416, entity_name: 'Kansas City Chiefs', import_key: 'l.nfl.com-t.13', entity_type_id: 4, status: 1
+    entity_name: 'Kansas City Chiefs', import_key: 'l.nfl.com-t.13', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 417, entity_name: 'Miami Dolphins', import_key: 'l.nfl.com-t.3', entity_type_id: 4, status: 1
+    entity_name: 'Miami Dolphins', import_key: 'l.nfl.com-t.3', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 418, entity_name: 'Minnesota Vikings', import_key: 'l.nfl.com-t.25', entity_type_id: 4, status: 1
+    entity_name: 'Minnesota Vikings', import_key: 'l.nfl.com-t.25', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 419, entity_name: 'New England Patriots', import_key: 'l.nfl.com-t.4', entity_type_id: 4, status: 1
+    entity_name: 'New England Patriots', import_key: 'l.nfl.com-t.4', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 420, entity_name: 'New Orleans Saints', import_key: 'l.nfl.com-t.30', entity_type_id: 4, status: 1
+    entity_name: 'New Orleans Saints', import_key: 'l.nfl.com-t.30', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 421, entity_name: 'New York Giants', import_key: 'l.nfl.com-t.19', entity_type_id: 4, status: 1
+    entity_name: 'New York Giants', import_key: 'l.nfl.com-t.19', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 422, entity_name: 'New York Jets', import_key: 'l.nfl.com-t.5', entity_type_id: 4, status: 1
+    entity_name: 'New York Jets', import_key: 'l.nfl.com-t.5', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 423, entity_name: 'Oakland Raiders', import_key: 'l.nfl.com-t.14', entity_type_id: 4, status: 1
+    entity_name: 'Oakland Raiders', import_key: 'l.nfl.com-t.14', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 424, entity_name: 'Philadelphia Eagles', import_key: 'l.nfl.com-t.20', entity_type_id: 4, status: 1
+    entity_name: 'Philadelphia Eagles', import_key: 'l.nfl.com-t.20', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 425, entity_name: 'Pittsburgh Steelers', import_key: 'l.nfl.com-t.10', entity_type_id: 4, status: 1
+    entity_name: 'Pittsburgh Steelers', import_key: 'l.nfl.com-t.10', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 426, entity_name: 'San Diego Chargers', import_key: 'l.nfl.com-t.15', entity_type_id: 4, status: 1
+    entity_name: 'San Diego Chargers', import_key: 'l.nfl.com-t.15', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 427, entity_name: 'San Francisco 49ers', import_key: 'l.nfl.com-t.31', entity_type_id: 4, status: 1
+    entity_name: 'San Francisco 49ers', import_key: 'l.nfl.com-t.31', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 428, entity_name: 'Seattle Seahawks', import_key: 'l.nfl.com-t.16', entity_type_id: 4, status: 1
+    entity_name: 'Seattle Seahawks', import_key: 'l.nfl.com-t.16', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 429, entity_name: 'St. Louis Rams', import_key: 'l.nfl.com-t.28', entity_type_id: 4, status: 1
+    entity_name: 'St. Louis Rams', import_key: 'l.nfl.com-t.28', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 430, entity_name: 'Tampa Bay Buccaneers', import_key: 'l.nfl.com-t.26', entity_type_id: 4, status: 1
+    entity_name: 'Tampa Bay Buccaneers', import_key: 'l.nfl.com-t.26', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 431, entity_name: 'Tennessee Titans', import_key: 'l.nfl.com-t.11', entity_type_id: 4, status: 1
+    entity_name: 'Tennessee Titans', import_key: 'l.nfl.com-t.11', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 432, entity_name: 'Washington Redskins', import_key: 'l.nfl.com-t.21', entity_type_id: 4, status: 1
+    entity_name: 'Washington Redskins', import_key: 'l.nfl.com-t.21', entity_type_id: entity_type_id, status: 1
   }
 ])

--- a/db/seeds/005_mls.rb
+++ b/db/seeds/005_mls.rb
@@ -1,66 +1,67 @@
 # -*- coding: utf-8 -*-
+entity_type_id = EntityType.find_by_entity_type_abbreviation('MLS').id
 Entity.create([
   {
-    id: 501, entity_name: 'Chicago Fire', entity_type_id: 5, status: 1, import_key: 'l.mlsnet.com-t.986'
+    entity_name: 'Chicago Fire', entity_type_id: entity_type_id, status: 1, import_key: 'l.mlsnet.com-t.986'
   },
   {
-    id: 502, entity_name: 'Columbus Crew', entity_type_id: 5, status: 1, import_key: 'l.mlsnet.com-t.991'
+    entity_name: 'Columbus Crew', entity_type_id: entity_type_id, status: 1, import_key: 'l.mlsnet.com-t.991'
   },
   {
-    id: 503, entity_name: 'D.C. United', entity_type_id: 5, status: 1, import_key: 'l.mlsnet.com-t.999'
+    entity_name: 'D.C. United', entity_type_id: entity_type_id, status: 1, import_key: 'l.mlsnet.com-t.999'
   },
   {
-    id: 504, entity_name: 'Houston Dynamo', entity_type_id: 5, status: 1, import_key: 'l.mlsnet.com-t.997'
+    entity_name: 'Houston Dynamo', entity_type_id: entity_type_id, status: 1, import_key: 'l.mlsnet.com-t.997'
   },
   {
-    id: 505, entity_name: 'Montreal Impact', entity_type_id: 5, status: 1, import_key: 'l.mlsnet.com-t.ZR2'
+    entity_name: 'Montreal Impact', entity_type_id: entity_type_id, status: 1, import_key: 'l.mlsnet.com-t.ZR2'
   },
   {
-    id: 506, entity_name: 'New England Revolution', entity_type_id: 5, status: 1, import_key: 'l.mlsnet.com-t.995'
+    entity_name: 'New England Revolution', entity_type_id: entity_type_id, status: 1, import_key: 'l.mlsnet.com-t.995'
   },
   {
-    id: 507, entity_name: 'New York Red Bulls', entity_type_id: 5, status: 1, import_key: 'l.mlsnet.com-t.996'
+    entity_name: 'New York Red Bulls', entity_type_id: entity_type_id, status: 1, import_key: 'l.mlsnet.com-t.996'
   },
   {
-    id: 508, entity_name: 'Philadelphia Union', entity_type_id: 5, status: 1, import_key: 'l.mlsnet.com-t.ZP6'
+    entity_name: 'Philadelphia Union', entity_type_id: entity_type_id, status: 1, import_key: 'l.mlsnet.com-t.ZP6'
   },
   {
-    id: 509, entity_name: 'Sporting Kansas City', entity_type_id: 5, status: 1, import_key: 'l.mlsnet.com-t.993'
+    entity_name: 'Sporting Kansas City', entity_type_id: entity_type_id, status: 1, import_key: 'l.mlsnet.com-t.993'
   },
   {
-    id: 510, entity_name: 'Toronto FC', entity_type_id: 5, status: 1, import_key: 'l.mlsnet.com-t.981'
+    entity_name: 'Toronto FC', entity_type_id: entity_type_id, status: 1, import_key: 'l.mlsnet.com-t.981'
   },
   {
-    id: 512, entity_name: 'Chivas USA', entity_type_id: 5, status: 1, import_key: 'l.mlsnet.com-t.984'
+    entity_name: 'Chivas USA', entity_type_id: entity_type_id, status: 1, import_key: 'l.mlsnet.com-t.984'
   },
   {
-    id: 513, entity_name: 'Colorado Rapids', entity_type_id: 5, status: 1, import_key: 'l.mlsnet.com-t.990'
+    entity_name: 'Colorado Rapids', entity_type_id: entity_type_id, status: 1, import_key: 'l.mlsnet.com-t.990'
   },
   {
-    id: 514, entity_name: 'FC Dallas', entity_type_id: 5, status: 1, import_key: 'l.mlsnet.com-t.992'
+    entity_name: 'FC Dallas', entity_type_id: entity_type_id, status: 1, import_key: 'l.mlsnet.com-t.992'
   },
   {
-    id: 515, entity_name: 'LA Galaxy', entity_type_id: 5, status: 1, import_key: 'l.mlsnet.com-t.994'
+    entity_name: 'LA Galaxy', entity_type_id: entity_type_id, status: 1, import_key: 'l.mlsnet.com-t.994'
   },
   {
-    id: 516, entity_name: 'Portland Timbers', entity_type_id: 5, status: 1, import_key: 'l.mlsnet.com-t.ZP8'
+    entity_name: 'Portland Timbers', entity_type_id: entity_type_id, status: 1, import_key: 'l.mlsnet.com-t.ZP8'
   },
   {
-    id: 517, entity_name: 'Real Salt Lake', entity_type_id: 5, status: 1, import_key: 'l.mlsnet.com-t.985'
+    entity_name: 'Real Salt Lake', entity_type_id: entity_type_id, status: 1, import_key: 'l.mlsnet.com-t.985'
   },
   {
-    id: 518, entity_name: 'San Jose Earthquakes', entity_type_id: 5, status: 1, import_key: 'l.mlsnet.com-t.979'
+    entity_name: 'San Jose Earthquakes', entity_type_id: entity_type_id, status: 1, import_key: 'l.mlsnet.com-t.979'
   },
   {
-    id: 519, entity_name: 'Seattle Sounders FC', entity_type_id: 5, status: 1, import_key: 'l.mlsnet.com-t.AA0'
+    entity_name: 'Seattle Sounders FC', entity_type_id: entity_type_id, status: 1, import_key: 'l.mlsnet.com-t.AA0'
   },
   {
-    id: 520, entity_name: 'Vancouver Whitecaps FC', entity_type_id: 5, status: 1, import_key: 'l.mlsnet.com-t.ZP9'
+    entity_name: 'Vancouver Whitecaps FC', entity_type_id: entity_type_id, status: 1, import_key: 'l.mlsnet.com-t.ZP9'
   },
   {
-    id: 521, entity_name: 'New York City FC', entity_type_id: 5, status: 0, import_key: 'mls-new-york-city-fc'
+    entity_name: 'New York City FC', entity_type_id: entity_type_id, status: 0, import_key: 'mls-new-york-city-fc'
   },
   {
-    id: 522, entity_name: 'Orlando City SC', entity_type_id: 5, status: 0, import_key: 'mls-orlando-city-fc'
+    entity_name: 'Orlando City SC', entity_type_id: entity_type_id, status: 0, import_key: 'mls-orlando-city-fc'
   }
 ])

--- a/db/seeds/006_cfl.rb
+++ b/db/seeds/006_cfl.rb
@@ -1,30 +1,31 @@
 # -*- coding: utf-8 -*-
+entity_type_id = EntityType.find_by_entity_type_abbreviation('CFL').id
 Entity.create([
   {
-    id: 601, entity_name: 'Hamilton Tiger-Cats', entity_type_id: 6, status: 1, import_key: 'l.cfl.ca-t.4'
+    entity_name: 'Hamilton Tiger-Cats', entity_type_id: entity_type_id, status: 1, import_key: 'l.cfl.ca-t.4'
   },
   {
-    id: 602, entity_name: 'Montreal Alouettes', entity_type_id: 6, status: 1, import_key: 'l.cfl.ca-t.5'
+    entity_name: 'Montreal Alouettes', entity_type_id: entity_type_id, status: 1, import_key: 'l.cfl.ca-t.5'
   },
   {
-    id: 603, entity_name: 'Ottawa Redblacks', entity_type_id: 6, status: 1, import_key: 'l.cfl.ca-t.6'
+    entity_name: 'Ottawa Redblacks', entity_type_id: entity_type_id, status: 1, import_key: 'l.cfl.ca-t.6'
   },
   {
-    id: 604, entity_name: 'Toronto Argonauts', entity_type_id: 6, status: 1, import_key: 'l.cfl.ca-t.8'
+    entity_name: 'Toronto Argonauts', entity_type_id: entity_type_id, status: 1, import_key: 'l.cfl.ca-t.8'
   },
   {
-    id: 605, entity_name: 'BC Lions', entity_type_id: 6, status: 1, import_key: 'l.cfl.ca-t.1'
+    entity_name: 'BC Lions', entity_type_id: entity_type_id, status: 1, import_key: 'l.cfl.ca-t.1'
   },
   {
-    id: 606, entity_name: 'Calgary Stampeders', entity_type_id: 6, status: 1, import_key: 'l.cfl.ca-t.2'
+    entity_name: 'Calgary Stampeders', entity_type_id: entity_type_id, status: 1, import_key: 'l.cfl.ca-t.2'
   },
   {
-    id: 607, entity_name: 'Edmonton Eskimos', entity_type_id: 6, status: 1, import_key: 'l.cfl.ca-t.3'
+    entity_name: 'Edmonton Eskimos', entity_type_id: entity_type_id, status: 1, import_key: 'l.cfl.ca-t.3'
   },
   {
-    id: 608, entity_name: 'Saskatchewan Roughriders', entity_type_id: 6, status: 1, import_key: 'l.cfl.ca-t.7'
+    entity_name: 'Saskatchewan Roughriders', entity_type_id: entity_type_id, status: 1, import_key: 'l.cfl.ca-t.7'
   },
   {
-    id: 609, entity_name: 'Winnipeg Blue Bombers', entity_type_id: 6, status: 1, import_key: 'l.cfl.ca-t.9'
+    entity_name: 'Winnipeg Blue Bombers', entity_type_id: entity_type_id, status: 1, import_key: 'l.cfl.ca-t.9'
   }
 ])

--- a/db/seeds/007_ncaaf.rb
+++ b/db/seeds/007_ncaaf.rb
@@ -1,2298 +1,2299 @@
 # -*- coding: utf-8 -*-
+entity_type_id = EntityType.find_by_entity_type_abbreviation('NCAAF').id
 Entity.create([
   {
-    id: 2001, import_key: 'l.ncaa.org.mfoot-t.648', entity_name: 'Central Florida Knights', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.648', entity_name: 'Central Florida Knights', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2002, import_key: 'l.ncaa.org.mfoot-t.476', entity_name: 'Cincinnati Bearcats', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.476', entity_name: 'Cincinnati Bearcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2003, import_key: 'l.ncaa.org.mfoot-t.483', entity_name: 'Connecticut Huskies', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.483', entity_name: 'Connecticut Huskies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2004, import_key: 'l.ncaa.org.mfoot-t.509', entity_name: 'Houston Cougars', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.509', entity_name: 'Houston Cougars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2005, import_key: 'l.ncaa.org.mfoot-t.531', entity_name: 'Louisville Cardinals', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.531', entity_name: 'Louisville Cardinals', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2006, import_key: 'l.ncaa.org.mfoot-t.537', entity_name: 'Memphis Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.537', entity_name: 'Memphis Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2007, import_key: 'l.ncaa.org.mfoot-t.588', entity_name: 'Rutgers Scarlet Knights', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.588', entity_name: 'Rutgers Scarlet Knights', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2008, import_key: 'l.ncaa.org.mfoot-t.596', entity_name: 'SMU Mustangs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.596', entity_name: 'SMU Mustangs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2009, import_key: 'l.ncaa.org.mfoot-t.709', entity_name: 'South Florida Bulls', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.709', entity_name: 'South Florida Bulls', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2010, import_key: 'l.ncaa.org.mfoot-t.604', entity_name: 'Temple Owls', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.604', entity_name: 'Temple Owls', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2011, import_key: 'l.ncaa.org.mfoot-t.468', entity_name: 'Boston College Eagles', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.468', entity_name: 'Boston College Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2012, import_key: 'l.ncaa.org.mfoot-t.478', entity_name: 'Clemson Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.478', entity_name: 'Clemson Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2013, import_key: 'l.ncaa.org.mfoot-t.498', entity_name: 'Florida St. Seminoles', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.498', entity_name: 'Florida St. Seminoles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2014, import_key: 'l.ncaa.org.mfoot-t.534', entity_name: 'Maryland Terrapins', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.534', entity_name: 'Maryland Terrapins', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2015, import_key: 'l.ncaa.org.mfoot-t.562', entity_name: 'N.C. State Wolfpack', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.562', entity_name: 'N.C. State Wolfpack', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2016, import_key: 'l.ncaa.org.mfoot-t.603', entity_name: 'Syracuse Orange', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.603', entity_name: 'Syracuse Orange', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2017, import_key: 'l.ncaa.org.mfoot-t.626', entity_name: 'Wake Forest Demon Deacons', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.626', entity_name: 'Wake Forest Demon Deacons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2018, import_key: 'l.ncaa.org.mfoot-t.490', entity_name: 'Duke Blue Devils', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.490', entity_name: 'Duke Blue Devils', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2019, import_key: 'l.ncaa.org.mfoot-t.504', entity_name: 'Georgia Tech Yellow Jackets', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.504', entity_name: 'Georgia Tech Yellow Jackets', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2020, import_key: 'l.ncaa.org.mfoot-t.538', entity_name: 'Miami Hurricanes', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.538', entity_name: 'Miami Hurricanes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2021, import_key: 'l.ncaa.org.mfoot-t.560', entity_name: 'North Carolina Tar Heels', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.560', entity_name: 'North Carolina Tar Heels', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2022, import_key: 'l.ncaa.org.mfoot-t.581', entity_name: 'Pittsburgh Panthers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.581', entity_name: 'Pittsburgh Panthers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2023, import_key: 'l.ncaa.org.mfoot-t.625', entity_name: 'Virginia Tech Hokies', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.625', entity_name: 'Virginia Tech Hokies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2024, import_key: 'l.ncaa.org.mfoot-t.623', entity_name: 'Virginia Cavaliers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.623', entity_name: 'Virginia Cavaliers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2025, import_key: 'l.ncaa.org.mfoot-t.465', entity_name: 'Baylor Bears', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.465', entity_name: 'Baylor Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2026, import_key: 'l.ncaa.org.mfoot-t.518', entity_name: 'Iowa St. Cyclones', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.518', entity_name: 'Iowa St. Cyclones', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2027, import_key: 'l.ncaa.org.mfoot-t.522', entity_name: 'Kansas St. Wildcats', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.522', entity_name: 'Kansas St. Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2028, import_key: 'l.ncaa.org.mfoot-t.521', entity_name: 'Kansas Jayhawks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.521', entity_name: 'Kansas Jayhawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2029, import_key: 'l.ncaa.org.mfoot-t.575', entity_name: 'Oklahoma St. Cowboys', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.575', entity_name: 'Oklahoma St. Cowboys', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2030, import_key: 'l.ncaa.org.mfoot-t.574', entity_name: 'Oklahoma Sooners', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.574', entity_name: 'Oklahoma Sooners', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2031, import_key: 'l.ncaa.org.mfoot-t.612', entity_name: 'TCU Horned Frogs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.612', entity_name: 'TCU Horned Frogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2032, import_key: 'l.ncaa.org.mfoot-t.615', entity_name: 'Texas Tech Red Raiders', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.615', entity_name: 'Texas Tech Red Raiders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2033, import_key: 'l.ncaa.org.mfoot-t.609', entity_name: 'Texas Longhorns', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.609', entity_name: 'Texas Longhorns', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2034, import_key: 'l.ncaa.org.mfoot-t.635', entity_name: 'West Virginia Mountaineers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.635', entity_name: 'West Virginia Mountaineers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2035, import_key: 'l.ncaa.org.mfoot-t.491', entity_name: 'East Carolina Pirates', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.491', entity_name: 'East Carolina Pirates', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2036, import_key: 'l.ncaa.org.mfoot-t.820', entity_name: 'Fla. International Golden Panthers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.820', entity_name: 'Fla. International Golden Panthers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2037, import_key: 'l.ncaa.org.mfoot-t.710', entity_name: 'Florida Atlantic Owls', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.710', entity_name: 'Florida Atlantic Owls', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2038, import_key: 'l.ncaa.org.mfoot-t.533', entity_name: 'Marshall Thundering Herd', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.533', entity_name: 'Marshall Thundering Herd', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2039, import_key: 'l.ncaa.org.mfoot-t.542', entity_name: 'Middle Tenn. St. Blue Raiders', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.542', entity_name: 'Middle Tenn. St. Blue Raiders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2040, import_key: 'l.ncaa.org.mfoot-t.597', entity_name: 'Southern Miss. Golden Eagles', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.597', entity_name: 'Southern Miss. Golden Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2041, import_key: 'l.ncaa.org.mfoot-t.703', entity_name: 'UAB Blazers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.703', entity_name: 'UAB Blazers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2042, import_key: 'l.ncaa.org.mfoot-t.530', entity_name: 'Louisiana Tech Bulldogs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.530', entity_name: 'Louisiana Tech Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2043, import_key: 'l.ncaa.org.mfoot-t.563', entity_name: 'North Texas Mean Green', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.563', entity_name: 'North Texas Mean Green', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2044, import_key: 'l.ncaa.org.mfoot-t.586', entity_name: 'Rice Owls', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.586', entity_name: 'Rice Owls', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2045, import_key: 'l.ncaa.org.mfoot-t.YX5', entity_name: 'Texas-San Antonio Roadrunners', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.YX5', entity_name: 'Texas-San Antonio Roadrunners', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2046, import_key: 'l.ncaa.org.mfoot-t.617', entity_name: 'Tulane Green Wave', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.617', entity_name: 'Tulane Green Wave', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2047, import_key: 'l.ncaa.org.mfoot-t.618', entity_name: 'Tulsa Golden Hurricane', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.618', entity_name: 'Tulsa Golden Hurricane', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2048, import_key: 'l.ncaa.org.mfoot-t.613', entity_name: 'UTEP Miners', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.613', entity_name: 'UTEP Miners', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2049, import_key: 'l.ncaa.org.mfoot-t.461', entity_name: 'Army Black Knights', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.461', entity_name: 'Army Black Knights', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2050, import_key: 'l.ncaa.org.mfoot-t.471', entity_name: 'BYU Cougars', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.471', entity_name: 'BYU Cougars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2051, import_key: 'l.ncaa.org.mfoot-t.511', entity_name: 'Idaho Vandals', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.511', entity_name: 'Idaho Vandals', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2052, import_key: 'l.ncaa.org.mfoot-t.552', entity_name: 'Navy Midshipmen', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.552', entity_name: 'Navy Midshipmen', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2053, import_key: 'l.ncaa.org.mfoot-t.558', entity_name: 'New Mexico St. Aggies', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.558', entity_name: 'New Mexico St. Aggies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2054, import_key: 'l.ncaa.org.mfoot-t.571', entity_name: 'Notre Dame Fighting Irish', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.571', entity_name: 'Notre Dame Fighting Irish', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2055, import_key: 'l.ncaa.org.mfoot-t.452', entity_name: 'Akron Zips', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.452', entity_name: 'Akron Zips', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2056, import_key: 'l.ncaa.org.mfoot-t.470', entity_name: 'Bowling Green Falcons', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.470', entity_name: 'Bowling Green Falcons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2057, import_key: 'l.ncaa.org.mfoot-t.664', entity_name: 'Buffalo Bulls', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.664', entity_name: 'Buffalo Bulls', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2058, import_key: 'l.ncaa.org.mfoot-t.523', entity_name: 'Kent St. Golden Flashes', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.523', entity_name: 'Kent St. Golden Flashes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2059, import_key: 'l.ncaa.org.mfoot-t.539', entity_name: 'Miami (Ohio) RedHawks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.539', entity_name: 'Miami (Ohio) RedHawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2060, import_key: 'l.ncaa.org.mfoot-t.573', entity_name: 'Ohio Bobcats', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.573', entity_name: 'Ohio Bobcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2061, import_key: 'l.ncaa.org.mfoot-t.535', entity_name: 'UMass Minutemen', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.535', entity_name: 'UMass Minutemen', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2062, import_key: 'l.ncaa.org.mfoot-t.464', entity_name: 'Ball St. Cardinals', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.464', entity_name: 'Ball St. Cardinals', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2063, import_key: 'l.ncaa.org.mfoot-t.475', entity_name: 'Central Michigan Chippewas', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.475', entity_name: 'Central Michigan Chippewas', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2064, import_key: 'l.ncaa.org.mfoot-t.495', entity_name: 'Eastern Michigan Eagles', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.495', entity_name: 'Eastern Michigan Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2065, import_key: 'l.ncaa.org.mfoot-t.567', entity_name: 'Northern Illinois Huskies', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.567', entity_name: 'Northern Illinois Huskies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2066, import_key: 'l.ncaa.org.mfoot-t.616', entity_name: 'Toledo Rockets', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.616', entity_name: 'Toledo Rockets', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2067, import_key: 'l.ncaa.org.mfoot-t.633', entity_name: 'Western Michigan Broncos', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.633', entity_name: 'Western Michigan Broncos', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2068, import_key: 'l.ncaa.org.mfoot-t.451', entity_name: 'Air Force Falcons', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.451', entity_name: 'Air Force Falcons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2069, import_key: 'l.ncaa.org.mfoot-t.467', entity_name: 'Boise St. Broncos', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.467', entity_name: 'Boise St. Broncos', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2070, import_key: 'l.ncaa.org.mfoot-t.481', entity_name: 'Colorado St. Rams', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.481', entity_name: 'Colorado St. Rams', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2071, import_key: 'l.ncaa.org.mfoot-t.557', entity_name: 'New Mexico Lobos', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.557', entity_name: 'New Mexico Lobos', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2072, import_key: 'l.ncaa.org.mfoot-t.621', entity_name: 'Utah State Aggies', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.621', entity_name: 'Utah State Aggies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2073, import_key: 'l.ncaa.org.mfoot-t.639', entity_name: 'Wyoming Cowboys', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.639', entity_name: 'Wyoming Cowboys', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2074, import_key: 'l.ncaa.org.mfoot-t.590', entity_name: 'San Jose St. Spartans', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.590', entity_name: 'San Jose St. Spartans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2075, import_key: 'l.ncaa.org.mfoot-t.499', entity_name: 'Fresno St. Bulldogs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.499', entity_name: 'Fresno St. Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2076, import_key: 'l.ncaa.org.mfoot-t.507', entity_name: 'Hawaii Warriors', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.507', entity_name: 'Hawaii Warriors', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2077, import_key: 'l.ncaa.org.mfoot-t.555', entity_name: 'Nevada Wolf Pack', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.555', entity_name: 'Nevada Wolf Pack', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2078, import_key: 'l.ncaa.org.mfoot-t.589', entity_name: 'San Diego St. Aztecs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.589', entity_name: 'San Diego St. Aztecs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2079, import_key: 'l.ncaa.org.mfoot-t.554', entity_name: 'UNLV Rebels', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.554', entity_name: 'UNLV Rebels', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2080, import_key: 'l.ncaa.org.mfoot-t.474', entity_name: 'California Golden Bears', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.474', entity_name: 'California Golden Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2081, import_key: 'l.ncaa.org.mfoot-t.577', entity_name: 'Oregon St. Beavers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.577', entity_name: 'Oregon St. Beavers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2082, import_key: 'l.ncaa.org.mfoot-t.576', entity_name: 'Oregon Ducks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.576', entity_name: 'Oregon Ducks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2083, import_key: 'l.ncaa.org.mfoot-t.602', entity_name: 'Stanford Cardinal', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.602', entity_name: 'Stanford Cardinal', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2084, import_key: 'l.ncaa.org.mfoot-t.628', entity_name: 'Washington St. Cougars', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.628', entity_name: 'Washington St. Cougars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2085, import_key: 'l.ncaa.org.mfoot-t.627', entity_name: 'Washington Huskies', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.627', entity_name: 'Washington Huskies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2086, import_key: 'l.ncaa.org.mfoot-t.458', entity_name: 'Arizona St. Sun Devils', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.458', entity_name: 'Arizona St. Sun Devils', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2087, import_key: 'l.ncaa.org.mfoot-t.457', entity_name: 'Arizona Wildcats', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.457', entity_name: 'Arizona Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2088, import_key: 'l.ncaa.org.mfoot-t.480', entity_name: 'Colorado Buffaloes', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.480', entity_name: 'Colorado Buffaloes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2089, import_key: 'l.ncaa.org.mfoot-t.619', entity_name: 'UCLA Bruins', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.619', entity_name: 'UCLA Bruins', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2090, import_key: 'l.ncaa.org.mfoot-t.594', entity_name: 'USC Trojans', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.594', entity_name: 'USC Trojans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2091, import_key: 'l.ncaa.org.mfoot-t.620', entity_name: 'Utah Utes', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.620', entity_name: 'Utah Utes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2092, import_key: 'l.ncaa.org.mfoot-t.496', entity_name: 'Florida Gators', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.496', entity_name: 'Florida Gators', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2093, import_key: 'l.ncaa.org.mfoot-t.502', entity_name: 'Georgia Bulldogs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.502', entity_name: 'Georgia Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2094, import_key: 'l.ncaa.org.mfoot-t.524', entity_name: 'Kentucky Wildcats', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.524', entity_name: 'Kentucky Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2095, import_key: 'l.ncaa.org.mfoot-t.547', entity_name: 'Missouri Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.547', entity_name: 'Missouri Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2096, import_key: 'l.ncaa.org.mfoot-t.591', entity_name: 'South Carolina Gamecocks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.591', entity_name: 'South Carolina Gamecocks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2097, import_key: 'l.ncaa.org.mfoot-t.605', entity_name: 'Tennessee Volunteers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.605', entity_name: 'Tennessee Volunteers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2098, import_key: 'l.ncaa.org.mfoot-t.622', entity_name: 'Vanderbilt Commodores', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.622', entity_name: 'Vanderbilt Commodores', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2099, import_key: 'l.ncaa.org.mfoot-t.453', entity_name: 'Alabama Crimson Tide', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.453', entity_name: 'Alabama Crimson Tide', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2100, import_key: 'l.ncaa.org.mfoot-t.459', entity_name: 'Arkansas Razorbacks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.459', entity_name: 'Arkansas Razorbacks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2101, import_key: 'l.ncaa.org.mfoot-t.462', entity_name: 'Auburn Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.462', entity_name: 'Auburn Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2102, import_key: 'l.ncaa.org.mfoot-t.529', entity_name: 'LSU Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.529', entity_name: 'LSU Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2103, import_key: 'l.ncaa.org.mfoot-t.545', entity_name: 'Mississippi St. Bulldogs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.545', entity_name: 'Mississippi St. Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2104, import_key: 'l.ncaa.org.mfoot-t.544', entity_name: 'Mississippi Rebels', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.544', entity_name: 'Mississippi Rebels', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2105, import_key: 'l.ncaa.org.mfoot-t.610', entity_name: 'Texas A&M Aggies', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.610', entity_name: 'Texas A&M Aggies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2106, import_key: 'l.ncaa.org.mfoot-t.460', entity_name: 'Arkansas St. Red Wolves', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.460', entity_name: 'Arkansas St. Red Wolves', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2107, import_key: 'l.ncaa.org.mfoot-t.Y32', entity_name: 'Georgia State Panthers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y32', entity_name: 'Georgia State Panthers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2108, import_key: 'l.ncaa.org.mfoot-t.601', entity_name: 'Louisiana Ragin Cajuns', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.601', entity_name: 'Louisiana Ragin Cajuns', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2109, import_key: 'l.ncaa.org.mfoot-t.YX2', entity_name: 'South Alabama Jaguars', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.YX2', entity_name: 'South Alabama Jaguars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2110, import_key: 'l.ncaa.org.mfoot-t.600', entity_name: 'Texas State Bobcats', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.600', entity_name: 'Texas State Bobcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2111, import_key: 'l.ncaa.org.mfoot-t.634', entity_name: 'Troy Trojans', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.634', entity_name: 'Troy Trojans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2112, import_key: 'l.ncaa.org.mfoot-t.565', entity_name: 'ULM Warhawks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.565', entity_name: 'ULM Warhawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2113, import_key: 'l.ncaa.org.mfoot-t.632', entity_name: 'Western Kentucky Hilltoppers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.632', entity_name: 'Western Kentucky Hilltoppers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2114, import_key: 'l.ncaa.org.mfoot-t.691', entity_name: 'Blue All-Stars', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.691', entity_name: 'Blue All-Stars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2115, import_key: 'l.ncaa.org.mfoot-t.969', entity_name: 'East-Las Vegas All-Stars', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.969', entity_name: 'East-Las Vegas All-Stars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2116, import_key: 'l.ncaa.org.mfoot-t.692', entity_name: 'Gray All-Stars', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.692', entity_name: 'Gray All-Stars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2117, import_key: 'l.ncaa.org.mfoot-t.695', entity_name: 'Hula-East All-Stars', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.695', entity_name: 'Hula-East All-Stars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2118, import_key: 'l.ncaa.org.mfoot-t.696', entity_name: 'Hula-West All-Stars', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.696', entity_name: 'Hula-West All-Stars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2119, import_key: 'l.ncaa.org.mfoot-t.973', entity_name: 'IA All-Stars', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.973', entity_name: 'IA All-Stars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2120, import_key: 'l.ncaa.org.mfoot-t.978', entity_name: 'Nation All-Stars', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.978', entity_name: 'Nation All-Stars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2121, import_key: 'l.ncaa.org.mfoot-t.975', entity_name: 'North All-Stars', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.975', entity_name: 'North All-Stars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2122, import_key: 'l.ncaa.org.mfoot-t.693', entity_name: 'North-Gridiron All-Stars', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.693', entity_name: 'North-Gridiron All-Stars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2123, import_key: 'l.ncaa.org.mfoot-t.699', entity_name: 'Senior-North All-Stars', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.699', entity_name: 'Senior-North All-Stars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2124, import_key: 'l.ncaa.org.mfoot-t.700', entity_name: 'Senior-South All-Stars', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.700', entity_name: 'Senior-South All-Stars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2125, import_key: 'l.ncaa.org.mfoot-t.697', entity_name: 'Shrine-East All-Stars', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.697', entity_name: 'Shrine-East All-Stars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2126, import_key: 'l.ncaa.org.mfoot-t.698', entity_name: 'Shrine-West All-Stars', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.698', entity_name: 'Shrine-West All-Stars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2127, import_key: 'l.ncaa.org.mfoot-t.976', entity_name: 'South All-Stars', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.976', entity_name: 'South All-Stars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2128, import_key: 'l.ncaa.org.mfoot-t.694', entity_name: 'South-Gridiron All-Stars', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.694', entity_name: 'South-Gridiron All-Stars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2129, import_key: 'l.ncaa.org.mfoot-t.1YY', entity_name: 'Stars', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.1YY', entity_name: 'Stars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2130, import_key: 'l.ncaa.org.mfoot-t.2YY', entity_name: 'Stripes', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.2YY', entity_name: 'Stripes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2131, import_key: 'l.ncaa.org.mfoot-t.977', entity_name: 'Texas All-Stars', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.977', entity_name: 'Texas All-Stars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2132, import_key: 'l.ncaa.org.mfoot-t.970', entity_name: 'West-Las Vegas All-Stars', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.970', entity_name: 'West-Las Vegas All-Stars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2133, import_key: 'l.ncaa.org.mfoot-t.513', entity_name: 'Illinois Fighting Illini', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.513', entity_name: 'Illinois Fighting Illini', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2134, import_key: 'l.ncaa.org.mfoot-t.515', entity_name: 'Indiana Hoosiers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.515', entity_name: 'Indiana Hoosiers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2135, import_key: 'l.ncaa.org.mfoot-t.572', entity_name: 'Ohio St. Buckeyes', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.572', entity_name: 'Ohio St. Buckeyes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2136, import_key: 'l.ncaa.org.mfoot-t.579', entity_name: 'Penn St. Nittany Lions', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.579', entity_name: 'Penn St. Nittany Lions', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2137, import_key: 'l.ncaa.org.mfoot-t.584', entity_name: 'Purdue Boilermakers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.584', entity_name: 'Purdue Boilermakers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2138, import_key: 'l.ncaa.org.mfoot-t.638', entity_name: 'Wisconsin Badgers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.638', entity_name: 'Wisconsin Badgers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2139, import_key: 'l.ncaa.org.mfoot-t.517', entity_name: 'Iowa Hawkeyes', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.517', entity_name: 'Iowa Hawkeyes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2140, import_key: 'l.ncaa.org.mfoot-t.541', entity_name: 'Michigan St. Spartans', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.541', entity_name: 'Michigan St. Spartans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2141, import_key: 'l.ncaa.org.mfoot-t.540', entity_name: 'Michigan Wolverines', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.540', entity_name: 'Michigan Wolverines', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2142, import_key: 'l.ncaa.org.mfoot-t.543', entity_name: 'Minnesota Golden Gophers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.543', entity_name: 'Minnesota Golden Gophers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2143, import_key: 'l.ncaa.org.mfoot-t.553', entity_name: 'Nebraska Cornhuskers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.553', entity_name: 'Nebraska Cornhuskers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2144, import_key: 'l.ncaa.org.mfoot-t.569', entity_name: 'Northwestern Wildcats', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.569', entity_name: 'Northwestern Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2145, import_key: 'l.ncaa.org.mfoot-t.YX9', entity_name: 'American', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.YX9', entity_name: 'American', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2146, import_key: 'l.ncaa.org.mfoot-t.YX8', entity_name: 'National', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.YX8', entity_name: 'National', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2147, import_key: 'l.ncaa.org.mfoot-t.500', entity_name: 'Cal Poly-SLO Mustangs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.500', entity_name: 'Cal Poly-SLO Mustangs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2148, import_key: 'l.ncaa.org.mfoot-t.489', entity_name: 'Eastern Washington Eagles', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.489', entity_name: 'Eastern Washington Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2149, import_key: 'l.ncaa.org.mfoot-t.512', entity_name: 'Idaho St. Bengals', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.512', entity_name: 'Idaho St. Bengals', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2150, import_key: 'l.ncaa.org.mfoot-t.549', entity_name: 'Montana St. Bobcats', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.549', entity_name: 'Montana St. Bobcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2151, import_key: 'l.ncaa.org.mfoot-t.548', entity_name: 'Montana Grizzlies', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.548', entity_name: 'Montana Grizzlies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2152, import_key: 'l.ncaa.org.mfoot-t.V37', entity_name: 'North Dakota Fighting Sioux', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V37', entity_name: 'North Dakota Fighting Sioux', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2153, import_key: 'l.ncaa.org.mfoot-t.566', entity_name: 'Northern Arizona Lumberjacks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.566', entity_name: 'Northern Arizona Lumberjacks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2154, import_key: 'l.ncaa.org.mfoot-t.826', entity_name: 'Northern Colorado Bears', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.826', entity_name: 'Northern Colorado Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2155, import_key: 'l.ncaa.org.mfoot-t.717', entity_name: 'Portland St. Vikings', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.717', entity_name: 'Portland St. Vikings', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2156, import_key: 'l.ncaa.org.mfoot-t.716', entity_name: 'Sacramento St. Hornets', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.716', entity_name: 'Sacramento St. Hornets', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2157, import_key: 'l.ncaa.org.mfoot-t.705', entity_name: 'Southern Utah Thunderbirds', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.705', entity_name: 'Southern Utah Thunderbirds', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2158, import_key: 'l.ncaa.org.mfoot-t.775', entity_name: 'UC Davis Aggies', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.775', entity_name: 'UC Davis Aggies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2159, import_key: 'l.ncaa.org.mfoot-t.629', entity_name: 'Weber St. Wildcats', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.629', entity_name: 'Weber St. Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2160, import_key: 'l.ncaa.org.mfoot-t.765', entity_name: 'Charleston Southern Buccaneers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.765', entity_name: 'Charleston Southern Buccaneers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2161, import_key: 'l.ncaa.org.mfoot-t.850', entity_name: 'Coastal Carolina Chanticleers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.850', entity_name: 'Coastal Carolina Chanticleers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2162, import_key: 'l.ncaa.org.mfoot-t.469', entity_name: 'Gardner-Webb Bulldogs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.469', entity_name: 'Gardner-Webb Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2163, import_key: 'l.ncaa.org.mfoot-t.645', entity_name: 'Liberty Flames', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.645', entity_name: 'Liberty Flames', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2164, import_key: 'l.ncaa.org.mfoot-t.624', entity_name: 'Virginia Military Keydets', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.624', entity_name: 'Virginia Military Keydets', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2165, import_key: 'l.ncaa.org.mfoot-t.801', entity_name: 'Albany, N.Y. Great Danes', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.801', entity_name: 'Albany, N.Y. Great Danes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2166, import_key: 'l.ncaa.org.mfoot-t.487', entity_name: 'Delaware Blue Hens', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.487', entity_name: 'Delaware Blue Hens', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2167, import_key: 'l.ncaa.org.mfoot-t.520', entity_name: 'James Madison Dukes', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.520', entity_name: 'James Madison Dukes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2168, import_key: 'l.ncaa.org.mfoot-t.532', entity_name: 'Maine Black Bears', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.532', entity_name: 'Maine Black Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2169, import_key: 'l.ncaa.org.mfoot-t.556', entity_name: 'New Hampshire Wildcats', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.556', entity_name: 'New Hampshire Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2170, import_key: 'l.ncaa.org.mfoot-t.585', entity_name: 'Rhode Island Rams', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.585', entity_name: 'Rhode Island Rams', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2171, import_key: 'l.ncaa.org.mfoot-t.587', entity_name: 'Richmond Spiders', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.587', entity_name: 'Richmond Spiders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2172, import_key: 'l.ncaa.org.mfoot-t.722', entity_name: 'Stony Brook Seawolves', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.722', entity_name: 'Stony Brook Seawolves', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2173, import_key: 'l.ncaa.org.mfoot-t.644', entity_name: 'Towson Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.644', entity_name: 'Towson Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2174, import_key: 'l.ncaa.org.mfoot-t.643', entity_name: 'Villanova Wildcats', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.643', entity_name: 'Villanova Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2175, import_key: 'l.ncaa.org.mfoot-t.637', entity_name: 'William & Mary Tribe', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.637', entity_name: 'William & Mary Tribe', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2176, import_key: 'l.ncaa.org.mfoot-t.777', entity_name: 'Presbyterian Blue Hose', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.777', entity_name: 'Presbyterian Blue Hose', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2177, import_key: 'l.ncaa.org.mfoot-t.V47', entity_name: 'Abilene Christian Wildcats', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V47', entity_name: 'Abilene Christian Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2178, import_key: 'l.ncaa.org.mfoot-t.YX6', entity_name: 'Charlotte 49ers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.YX6', entity_name: 'Charlotte 49ers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2179, import_key: 'l.ncaa.org.mfoot-t.YW1', entity_name: 'Houston Baptist Huskies', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.YW1', entity_name: 'Houston Baptist Huskies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2180, import_key: 'l.ncaa.org.mfoot-t.Y81', entity_name: 'Incarnate Word', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y81', entity_name: 'Incarnate Word', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2181, import_key: 'l.ncaa.org.mfoot-t.708', entity_name: 'Monmouth, N.J. Hawks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.708', entity_name: 'Monmouth, N.J. Hawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2182, import_key: 'l.ncaa.org.mfoot-t.YX1', entity_name: 'Old Dominion Monarchs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.YX1', entity_name: 'Old Dominion Monarchs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2183, import_key: 'l.ncaa.org.mfoot-t.472', entity_name: 'Brown Bears', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.472', entity_name: 'Brown Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2184, import_key: 'l.ncaa.org.mfoot-t.482', entity_name: 'Columbia Lions', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.482', entity_name: 'Columbia Lions', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2185, import_key: 'l.ncaa.org.mfoot-t.484', entity_name: 'Cornell Big Red', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.484', entity_name: 'Cornell Big Red', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2186, import_key: 'l.ncaa.org.mfoot-t.485', entity_name: 'Dartmouth Big Green', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.485', entity_name: 'Dartmouth Big Green', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2187, import_key: 'l.ncaa.org.mfoot-t.506', entity_name: 'Harvard Crimson', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.506', entity_name: 'Harvard Crimson', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2188, import_key: 'l.ncaa.org.mfoot-t.580', entity_name: 'Penn Quakers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.580', entity_name: 'Penn Quakers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2189, import_key: 'l.ncaa.org.mfoot-t.583', entity_name: 'Princeton Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.583', entity_name: 'Princeton Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2190, import_key: 'l.ncaa.org.mfoot-t.640', entity_name: 'Yale Bulldogs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.640', entity_name: 'Yale Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2191, import_key: 'l.ncaa.org.mfoot-t.466', entity_name: 'Bethune-Cookman Wildcats', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.466', entity_name: 'Bethune-Cookman Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2192, import_key: 'l.ncaa.org.mfoot-t.488', entity_name: 'Delaware St. Hornets', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.488', entity_name: 'Delaware St. Hornets', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2193, import_key: 'l.ncaa.org.mfoot-t.497', entity_name: 'Florida A&M Rattlers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.497', entity_name: 'Florida A&M Rattlers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2194, import_key: 'l.ncaa.org.mfoot-t.528', entity_name: 'Hampton Pirates', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.528', entity_name: 'Hampton Pirates', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2195, import_key: 'l.ncaa.org.mfoot-t.510', entity_name: 'Howard Bison', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.510', entity_name: 'Howard Bison', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2196, import_key: 'l.ncaa.org.mfoot-t.642', entity_name: 'Morgan St. Bears', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.642', entity_name: 'Morgan St. Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2197, import_key: 'l.ncaa.org.mfoot-t.561', entity_name: 'N.C. A&T Aggies', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.561', entity_name: 'N.C. A&T Aggies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2198, import_key: 'l.ncaa.org.mfoot-t.578', entity_name: 'Norfolk St. Spartans', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.578', entity_name: 'Norfolk St. Spartans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2199, import_key: 'l.ncaa.org.mfoot-t.592', entity_name: 'South Carolina State Bulldogs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.592', entity_name: 'South Carolina State Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2200, import_key: 'l.ncaa.org.mfoot-t.514', entity_name: 'Illinois St. Redbirds', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.514', entity_name: 'Illinois St. Redbirds', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2201, import_key: 'l.ncaa.org.mfoot-t.516', entity_name: 'Indiana St. Sycamores', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.516', entity_name: 'Indiana St. Sycamores', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2202, import_key: 'l.ncaa.org.mfoot-t.599', entity_name: 'Missouri St. Bears', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.599', entity_name: 'Missouri St. Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2203, import_key: 'l.ncaa.org.mfoot-t.713', entity_name: 'North Dakota St. Bison', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.713', entity_name: 'North Dakota St. Bison', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2204, import_key: 'l.ncaa.org.mfoot-t.568', entity_name: 'Northern Iowa Panthers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.568', entity_name: 'Northern Iowa Panthers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2205, import_key: 'l.ncaa.org.mfoot-t.V36', entity_name: 'South Dakota St. Jackrabbits', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V36', entity_name: 'South Dakota St. Jackrabbits', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2206, import_key: 'l.ncaa.org.mfoot-t.V38', entity_name: 'South Dakota Coyotes', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V38', entity_name: 'South Dakota Coyotes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2207, import_key: 'l.ncaa.org.mfoot-t.595', entity_name: 'Southern Illinois Salukis', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.595', entity_name: 'Southern Illinois Salukis', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2208, import_key: 'l.ncaa.org.mfoot-t.631', entity_name: 'Western Illinois Leathernecks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.631', entity_name: 'Western Illinois Leathernecks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2209, import_key: 'l.ncaa.org.mfoot-t.641', entity_name: 'Youngstown St. Penguins', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.641', entity_name: 'Youngstown St. Penguins', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2210, import_key: 'l.ncaa.org.mfoot-t.771', entity_name: 'Bryant Bulldogs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.771', entity_name: 'Bryant Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2211, import_key: 'l.ncaa.org.mfoot-t.666', entity_name: 'Central Connecticut St. Blue Devils', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.666', entity_name: 'Central Connecticut St. Blue Devils', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2212, import_key: 'l.ncaa.org.mfoot-t.657', entity_name: 'Duquesne Dukes', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.657', entity_name: 'Duquesne Dukes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2213, import_key: 'l.ncaa.org.mfoot-t.655', entity_name: 'Robert Morris Colonials', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.655', entity_name: 'Robert Morris Colonials', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2214, import_key: 'l.ncaa.org.mfoot-t.728', entity_name: 'Sacred Heart Pioneers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.728', entity_name: 'Sacred Heart Pioneers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2215, import_key: 'l.ncaa.org.mfoot-t.653', entity_name: 'St. Francis, Pa. Red Flash', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.653', entity_name: 'St. Francis, Pa. Red Flash', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2216, import_key: 'l.ncaa.org.mfoot-t.668', entity_name: 'Wagner Seahawks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.668', entity_name: 'Wagner Seahawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2217, import_key: 'l.ncaa.org.mfoot-t.463', entity_name: 'Austin Peay Governors', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.463', entity_name: 'Austin Peay Governors', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2218, import_key: 'l.ncaa.org.mfoot-t.493', entity_name: 'Eastern Illinois Panthers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.493', entity_name: 'Eastern Illinois Panthers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2219, import_key: 'l.ncaa.org.mfoot-t.494', entity_name: 'Eastern Kentucky Colonels', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.494', entity_name: 'Eastern Kentucky Colonels', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2220, import_key: 'l.ncaa.org.mfoot-t.669', entity_name: 'Jacksonville St. Gamecocks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.669', entity_name: 'Jacksonville St. Gamecocks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2221, import_key: 'l.ncaa.org.mfoot-t.551', entity_name: 'Murray St. Racers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.551', entity_name: 'Murray St. Racers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2222, import_key: 'l.ncaa.org.mfoot-t.649', entity_name: 'SE Missouri St. Redhawks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.649', entity_name: 'SE Missouri St. Redhawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2223, import_key: 'l.ncaa.org.mfoot-t.650', entity_name: 'Tenn.-Martin Skyhawks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.650', entity_name: 'Tenn.-Martin Skyhawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2224, import_key: 'l.ncaa.org.mfoot-t.607', entity_name: 'Tennessee St. Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.607', entity_name: 'Tennessee St. Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2225, import_key: 'l.ncaa.org.mfoot-t.608', entity_name: 'Tennessee Tech Golden Eagles', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.608', entity_name: 'Tennessee Tech Golden Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2226, import_key: 'l.ncaa.org.mfoot-t.473', entity_name: 'Bucknell Bison', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.473', entity_name: 'Bucknell Bison', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2227, import_key: 'l.ncaa.org.mfoot-t.479', entity_name: 'Colgate Red Raiders', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.479', entity_name: 'Colgate Red Raiders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2228, import_key: 'l.ncaa.org.mfoot-t.646', entity_name: 'Fordham Rams', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.646', entity_name: 'Fordham Rams', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2229, import_key: 'l.ncaa.org.mfoot-t.659', entity_name: 'Georgetown Hoyas', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.659', entity_name: 'Georgetown Hoyas', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2230, import_key: 'l.ncaa.org.mfoot-t.508', entity_name: 'Holy Cross Crusaders', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.508', entity_name: 'Holy Cross Crusaders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2231, import_key: 'l.ncaa.org.mfoot-t.525', entity_name: 'Lafayette Leopards', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.525', entity_name: 'Lafayette Leopards', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2232, import_key: 'l.ncaa.org.mfoot-t.527', entity_name: 'Lehigh Mountain Hawks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.527', entity_name: 'Lehigh Mountain Hawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2233, import_key: 'l.ncaa.org.mfoot-t.706', entity_name: 'Butler Bulldogs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.706', entity_name: 'Butler Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2234, import_key: 'l.ncaa.org.mfoot-t.EE1', entity_name: 'Campbell Fighting Camels', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.EE1', entity_name: 'Campbell Fighting Camels', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2235, import_key: 'l.ncaa.org.mfoot-t.486', entity_name: 'Davidson Wildcats', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.486', entity_name: 'Davidson Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2236, import_key: 'l.ncaa.org.mfoot-t.651', entity_name: 'Dayton Flyers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.651', entity_name: 'Dayton Flyers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2237, import_key: 'l.ncaa.org.mfoot-t.652', entity_name: 'Drake Bulldogs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.652', entity_name: 'Drake Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2238, import_key: 'l.ncaa.org.mfoot-t.781', entity_name: 'Jacksonville Dolphins', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.781', entity_name: 'Jacksonville Dolphins', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2239, import_key: 'l.ncaa.org.mfoot-t.654', entity_name: 'Marist Red Foxes', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.654', entity_name: 'Marist Red Foxes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2240, import_key: 'l.ncaa.org.mfoot-t.550', entity_name: 'Morehead St. Eagles', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.550', entity_name: 'Morehead St. Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2241, import_key: 'l.ncaa.org.mfoot-t.665', entity_name: 'San Diego Toreros', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.665', entity_name: 'San Diego Toreros', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2242, import_key: 'l.ncaa.org.mfoot-t.707', entity_name: 'Valparaiso Crusaders', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.707', entity_name: 'Valparaiso Crusaders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2243, import_key: 'l.ncaa.org.mfoot-t.YQ1', entity_name: 'Mercer Bears', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.YQ1', entity_name: 'Mercer Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2244, import_key: 'l.ncaa.org.mfoot-t.YQ2', entity_name: 'Stetson Hatters', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.YQ2', entity_name: 'Stetson Hatters', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2245, import_key: 'l.ncaa.org.mfoot-t.456', entity_name: 'Appalachian St. Mountaineers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.456', entity_name: 'Appalachian St. Mountaineers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2246, import_key: 'l.ncaa.org.mfoot-t.606', entity_name: 'Chattanooga Mocs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.606', entity_name: 'Chattanooga Mocs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2247, import_key: 'l.ncaa.org.mfoot-t.745', entity_name: 'Elon Phoenix', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.745', entity_name: 'Elon Phoenix', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2248, import_key: 'l.ncaa.org.mfoot-t.501', entity_name: 'Furman Paladins', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.501', entity_name: 'Furman Paladins', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2249, import_key: 'l.ncaa.org.mfoot-t.503', entity_name: 'Georgia Southern Eagles', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.503', entity_name: 'Georgia Southern Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2250, import_key: 'l.ncaa.org.mfoot-t.647', entity_name: 'Samford Bulldogs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.647', entity_name: 'Samford Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2251, import_key: 'l.ncaa.org.mfoot-t.477', entity_name: 'The Citadel Bulldogs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.477', entity_name: 'The Citadel Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2252, import_key: 'l.ncaa.org.mfoot-t.630', entity_name: 'Western Carolina Catamounts', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.630', entity_name: 'Western Carolina Catamounts', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2253, import_key: 'l.ncaa.org.mfoot-t.636', entity_name: 'Wofford Terriers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.636', entity_name: 'Wofford Terriers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2254, import_key: 'l.ncaa.org.mfoot-t.849', entity_name: 'Central Arkansas Bears', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.849', entity_name: 'Central Arkansas Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2255, import_key: 'l.ncaa.org.mfoot-t.536', entity_name: 'McNeese St. Cowboys', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.536', entity_name: 'McNeese St. Cowboys', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2256, import_key: 'l.ncaa.org.mfoot-t.559', entity_name: 'Nicholls Colonels', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.559', entity_name: 'Nicholls Colonels', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2257, import_key: 'l.ncaa.org.mfoot-t.570', entity_name: 'Northwestern St. Demons', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.570', entity_name: 'Northwestern St. Demons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2258, import_key: 'l.ncaa.org.mfoot-t.593', entity_name: 'Sam Houston St. Bearkats', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.593', entity_name: 'Sam Houston St. Bearkats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2259, import_key: 'l.ncaa.org.mfoot-t.848', entity_name: 'SE Louisiana Lions', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.848', entity_name: 'SE Louisiana Lions', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2260, import_key: 'l.ncaa.org.mfoot-t.611', entity_name: 'Stephen F. Austin Lumberjacks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.611', entity_name: 'Stephen F. Austin Lumberjacks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2261, import_key: 'l.ncaa.org.mfoot-t.YX4', entity_name: 'Lamar Cardinals', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.YX4', entity_name: 'Lamar Cardinals', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2262, import_key: 'l.ncaa.org.mfoot-t.670', entity_name: 'Alabama A&M Bulldogs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.670', entity_name: 'Alabama A&M Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2263, import_key: 'l.ncaa.org.mfoot-t.454', entity_name: 'Alabama St. Hornets', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.454', entity_name: 'Alabama St. Hornets', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2264, import_key: 'l.ncaa.org.mfoot-t.455', entity_name: 'Alcorn St. Braves', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.455', entity_name: 'Alcorn St. Braves', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2265, import_key: 'l.ncaa.org.mfoot-t.519', entity_name: 'Jackson St. Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.519', entity_name: 'Jackson St. Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2266, import_key: 'l.ncaa.org.mfoot-t.546', entity_name: 'MVSU Delta Devils', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.546', entity_name: 'MVSU Delta Devils', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2267, import_key: 'l.ncaa.org.mfoot-t.701', entity_name: 'Ark.-Pine Bluff Golden Lions', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.701', entity_name: 'Ark.-Pine Bluff Golden Lions', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2268, import_key: 'l.ncaa.org.mfoot-t.505', entity_name: 'Grambling St. Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.505', entity_name: 'Grambling St. Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2269, import_key: 'l.ncaa.org.mfoot-t.582', entity_name: 'Prairie View Panthers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.582', entity_name: 'Prairie View Panthers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2270, import_key: 'l.ncaa.org.mfoot-t.598', entity_name: 'Southern U. Jaguars', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.598', entity_name: 'Southern U. Jaguars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2271, import_key: 'l.ncaa.org.mfoot-t.614', entity_name: 'Texas Southern Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.614', entity_name: 'Texas Southern Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2272, import_key: 'l.ncaa.org.mfoot-t.971', entity_name: 'East-HCBU All-Stars', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.971', entity_name: 'East-HCBU All-Stars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2273, import_key: 'l.ncaa.org.mfoot-t.974', entity_name: 'IAA All-Stars', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.974', entity_name: 'IAA All-Stars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2274, import_key: 'l.ncaa.org.mfoot-t.972', entity_name: 'West-HCBU All-Stars', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.972', entity_name: 'West-HCBU All-Stars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2275, import_key: 'l.ncaa.org.mfoot-t.764', entity_name: 'N.C. Central Eagles', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.764', entity_name: 'N.C. Central Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2276, import_key: 'l.ncaa.org.mfoot-t.763', entity_name: 'Savannah St. Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.763', entity_name: 'Savannah St. Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2277, import_key: 'l.ncaa.org.mfoot-t.780', entity_name: 'Midwestern St. Mustangs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.780', entity_name: 'Midwestern St. Mustangs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2278, import_key: 'l.ncaa.org.mfoot-t.846', entity_name: 'Adams St. Cougars', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.846', entity_name: 'Adams St. Cougars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2279, import_key: 'l.ncaa.org.mfoot-t.712', entity_name: 'Albany St., Ga. Golden Rams', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.712', entity_name: 'Albany St., Ga. Golden Rams', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2280, import_key: 'l.ncaa.org.mfoot-t.824', entity_name: 'American International Yellow Jackets', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.824', entity_name: 'American International Yellow Jackets', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2281, import_key: 'l.ncaa.org.mfoot-t.748', entity_name: 'Angelo St. Rams', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.748', entity_name: 'Angelo St. Rams', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2282, import_key: 'l.ncaa.org.mfoot-t.747', entity_name: 'Ark.-Monticello Boll Weevils', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.747', entity_name: 'Ark.-Monticello Boll Weevils', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2283, import_key: 'l.ncaa.org.mfoot-t.V07', entity_name: 'Arkansas Tech Wonder Boys', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V07', entity_name: 'Arkansas Tech Wonder Boys', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2284, import_key: 'l.ncaa.org.mfoot-t.V32', entity_name: 'Ashland Eagles', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V32', entity_name: 'Ashland Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2285, import_key: 'l.ncaa.org.mfoot-t.807', entity_name: 'Assumption Greyhounds', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.807', entity_name: 'Assumption Greyhounds', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2286, import_key: 'l.ncaa.org.mfoot-t.843', entity_name: 'Augustana, S.D. Vikings', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.843', entity_name: 'Augustana, S.D. Vikings', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2287, import_key: 'l.ncaa.org.mfoot-t.Y69', entity_name: 'Baker', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y69', entity_name: 'Baker', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2288, import_key: 'l.ncaa.org.mfoot-t.Y41', entity_name: 'Barber-Scotia', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y41', entity_name: 'Barber-Scotia', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2289, import_key: 'l.ncaa.org.mfoot-t.V19', entity_name: 'Bemidji St. Beavers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V19', entity_name: 'Bemidji St. Beavers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2290, import_key: 'l.ncaa.org.mfoot-t.Y11', entity_name: 'Benedictine (KS)', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y11', entity_name: 'Benedictine (KS)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2291, import_key: 'l.ncaa.org.mfoot-t.812', entity_name: 'Benedict Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.812', entity_name: 'Benedict Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2292, import_key: 'l.ncaa.org.mfoot-t.V50', entity_name: 'Bentley Falcons', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V50', entity_name: 'Bentley Falcons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2293, import_key: 'l.ncaa.org.mfoot-t.Y78', entity_name: 'Bethany (KS)', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y78', entity_name: 'Bethany (KS)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2294, import_key: 'l.ncaa.org.mfoot-t.Y63', entity_name: 'Black Hills State', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y63', entity_name: 'Black Hills State', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2295, import_key: 'l.ncaa.org.mfoot-t.V41', entity_name: 'Bloomsburg Huskies', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V41', entity_name: 'Bloomsburg Huskies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2296, import_key: 'l.ncaa.org.mfoot-t.816', entity_name: 'Bowie St. Bulldogs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.816', entity_name: 'Bowie St. Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2297, import_key: 'l.ncaa.org.mfoot-t.Y55', entity_name: 'Brevard', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y55', entity_name: 'Brevard', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2298, import_key: 'l.ncaa.org.mfoot-t.959', entity_name: 'California, Pa. Vulcans', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.959', entity_name: 'California, Pa. Vulcans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2299, import_key: 'l.ncaa.org.mfoot-t.Y16', entity_name: 'Carroll (MT)', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y16', entity_name: 'Carroll (MT)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2300, import_key: 'l.ncaa.org.mfoot-t.963', entity_name: 'Carson-Newman Eagles', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.963', entity_name: 'Carson-Newman Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2301, import_key: 'l.ncaa.org.mfoot-t.815', entity_name: 'Catawba Indians', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.815', entity_name: 'Catawba Indians', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2302, import_key: 'l.ncaa.org.mfoot-t.V10', entity_name: 'Central Missouri Mules', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V10', entity_name: 'Central Missouri Mules', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2303, import_key: 'l.ncaa.org.mfoot-t.V45', entity_name: 'Central Oklahoma Broncos', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V45', entity_name: 'Central Oklahoma Broncos', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2304, import_key: 'l.ncaa.org.mfoot-t.Y49', entity_name: 'Central State Marauders', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y49', entity_name: 'Central State Marauders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2305, import_key: 'l.ncaa.org.mfoot-t.743', entity_name: 'Central Washington Wildcats', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.743', entity_name: 'Central Washington Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2306, import_key: 'l.ncaa.org.mfoot-t.721', entity_name: 'Chadron St. Eagles', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.721', entity_name: 'Chadron St. Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2307, import_key: 'l.ncaa.org.mfoot-t.853', entity_name: 'Charleston (WV) Golden Eagles', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.853', entity_name: 'Charleston (WV) Golden Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2308, import_key: 'l.ncaa.org.mfoot-t.V43', entity_name: 'Cheyney Wolves', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V43', entity_name: 'Cheyney Wolves', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2309, import_key: 'l.ncaa.org.mfoot-t.W48', entity_name: 'Chowan Braves', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W48', entity_name: 'Chowan Braves', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2310, import_key: 'l.ncaa.org.mfoot-t.810', entity_name: 'Clarion Golden Eagles', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.810', entity_name: 'Clarion Golden Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2311, import_key: 'l.ncaa.org.mfoot-t.817', entity_name: 'Clark Atlanta Panthers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.817', entity_name: 'Clark Atlanta Panthers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2312, import_key: 'l.ncaa.org.mfoot-t.YB6 ', entity_name: 'Cole College', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.YB6 ', entity_name: 'Cole College', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2313, import_key: 'l.ncaa.org.mfoot-t.YA2 ', entity_name: 'College of Faith', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.YA2 ', entity_name: 'College of Faith', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2314, import_key: 'l.ncaa.org.mfoot-t.V54', entity_name: 'Colorado Mines Orediggers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V54', entity_name: 'Colorado Mines Orediggers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2315, import_key: 'l.ncaa.org.mfoot-t.Y73', entity_name: 'Colorado State-Pueblo', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y73', entity_name: 'Colorado State-Pueblo', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2316, import_key: 'l.ncaa.org.mfoot-t.V18', entity_name: 'Concordia-St. Paul Golden Bears', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V18', entity_name: 'Concordia-St. Paul Golden Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2317, import_key: 'l.ncaa.org.mfoot-t.778', entity_name: 'Concord Mountain Lions', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.778', entity_name: 'Concord Mountain Lions', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2318, import_key: 'l.ncaa.org.mfoot-t.808', entity_name: 'C.W. Post Pioneers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.808', entity_name: 'C.W. Post Pioneers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2319, import_key: 'l.ncaa.org.mfoot-t.Y61', entity_name: 'Dakota State', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y61', entity_name: 'Dakota State', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2320, import_key: 'l.ncaa.org.mfoot-t.718', entity_name: 'Delta St. Statesmen', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.718', entity_name: 'Delta St. Statesmen', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2321, import_key: 'l.ncaa.org.mfoot-t.Y64', entity_name: 'Dickinson State', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y64', entity_name: 'Dickinson State', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2322, import_key: 'l.ncaa.org.mfoot-t.Y54', entity_name: 'Dixie State Rebels', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y54', entity_name: 'Dixie State Rebels', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2323, import_key: 'l.ncaa.org.mfoot-t.845', entity_name: 'East Central Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.845', entity_name: 'East Central Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2324, import_key: 'l.ncaa.org.mfoot-t.V40', entity_name: 'East Stroudsburg Warriors', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V40', entity_name: 'East Stroudsburg Warriors', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2325, import_key: 'l.ncaa.org.mfoot-t.V48', entity_name: 'Eastern New Mexico Greyhounds', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V48', entity_name: 'Eastern New Mexico Greyhounds', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2326, import_key: 'l.ncaa.org.mfoot-t.950', entity_name: 'Edinboro Fighting Scots', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.950', entity_name: 'Edinboro Fighting Scots', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2327, import_key: 'l.ncaa.org.mfoot-t.V01', entity_name: 'Elizabeth City St. Vikings', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V01', entity_name: 'Elizabeth City St. Vikings', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2328, import_key: 'l.ncaa.org.mfoot-t.V11', entity_name: 'Emporia St. Hornets', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V11', entity_name: 'Emporia St. Hornets', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2329, import_key: 'l.ncaa.org.mfoot-t.Y77', entity_name: 'Evangel', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y77', entity_name: 'Evangel', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2330, import_key: 'l.ncaa.org.mfoot-t.719', entity_name: 'Fairmont St. Falcons', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.719', entity_name: 'Fairmont St. Falcons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2331, import_key: 'l.ncaa.org.mfoot-t.Y70', entity_name: 'Faulkner', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y70', entity_name: 'Faulkner', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2332, import_key: 'l.ncaa.org.mfoot-t.768', entity_name: 'Fayetteville St. Broncos', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.768', entity_name: 'Fayetteville St. Broncos', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2333, import_key: 'l.ncaa.org.mfoot-t.V27', entity_name: 'Ferris St. Bulldogs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V27', entity_name: 'Ferris St. Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2334, import_key: 'l.ncaa.org.mfoot-t.V25', entity_name: 'Findlay Oilers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V25', entity_name: 'Findlay Oilers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2335, import_key: 'l.ncaa.org.mfoot-t.V55', entity_name: 'Fort Hays St. Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V55', entity_name: 'Fort Hays St. Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2336, import_key: 'l.ncaa.org.mfoot-t.V56', entity_name: 'Fort Lewis Skyhawks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V56', entity_name: 'Fort Lewis Skyhawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2337, import_key: 'l.ncaa.org.mfoot-t.814', entity_name: 'Fort Valley St. Wildcats', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.814', entity_name: 'Fort Valley St. Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2338, import_key: 'l.ncaa.org.mfoot-t.828', entity_name: 'Gannon Golden Knights', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.828', entity_name: 'Gannon Golden Knights', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2339, import_key: 'l.ncaa.org.mfoot-t.782', entity_name: 'Glenville St. Pioneers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.782', entity_name: 'Glenville St. Pioneers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2340, import_key: 'l.ncaa.org.mfoot-t.956', entity_name: 'Grand Valley St. Lakers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.956', entity_name: 'Grand Valley St. Lakers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2341, import_key: 'l.ncaa.org.mfoot-t.Y75', entity_name: 'Grand View', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y75', entity_name: 'Grand View', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2342, import_key: 'l.ncaa.org.mfoot-t.783', entity_name: 'Harding Bison', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.783', entity_name: 'Harding Bison', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2343, import_key: 'l.ncaa.org.mfoot-t.Y06', entity_name: 'Haskell Indian Nations', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y06', entity_name: 'Haskell Indian Nations', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2344, import_key: 'l.ncaa.org.mfoot-t.724', entity_name: 'Henderson St. Reddies', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.724', entity_name: 'Henderson St. Reddies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2345, import_key: 'l.ncaa.org.mfoot-t.V29', entity_name: 'Hillsdale Chargers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V29', entity_name: 'Hillsdale Chargers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2346, import_key: 'l.ncaa.org.mfoot-t.756', entity_name: 'Humboldt St. Lumberjacks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.756', entity_name: 'Humboldt St. Lumberjacks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2347, import_key: 'l.ncaa.org.mfoot-t.847', entity_name: 'Indiana, Pa. Indians', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.847', entity_name: 'Indiana, Pa. Indians', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2348, import_key: 'l.ncaa.org.mfoot-t.V28', entity_name: 'Indianapolis Greyhounds', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V28', entity_name: 'Indianapolis Greyhounds', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2349, import_key: 'l.ncaa.org.mfoot-t.Y42', entity_name: 'Iowa Wesleyan', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y42', entity_name: 'Iowa Wesleyan', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2350, import_key: 'l.ncaa.org.mfoot-t.769', entity_name: 'Johnson C. Smith Golden Bulls', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.769', entity_name: 'Johnson C. Smith Golden Bulls', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2351, import_key: 'l.ncaa.org.mfoot-t.Y12', entity_name: 'Kansas Wesleyan', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y12', entity_name: 'Kansas Wesleyan', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2352, import_key: 'l.ncaa.org.mfoot-t.Y76', entity_name: 'Kentucky Christian', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y76', entity_name: 'Kentucky Christian', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2353, import_key: 'l.ncaa.org.mfoot-t.746', entity_name: 'Kentucky St. Thorobred', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.746', entity_name: 'Kentucky St. Thorobred', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2354, import_key: 'l.ncaa.org.mfoot-t.786', entity_name: 'Kutztown Golden Bears', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.786', entity_name: 'Kutztown Golden Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2355, import_key: 'l.ncaa.org.mfoot-t.787', entity_name: 'Kentucky Wesleyan Panthers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.787', entity_name: 'Kentucky Wesleyan Panthers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2356, import_key: 'l.ncaa.org.mfoot-t.Y72', entity_name: 'Lake Erie', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y72', entity_name: 'Lake Erie', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2357, import_key: 'l.ncaa.org.mfoot-t.784', entity_name: 'Lane Dragons', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.784', entity_name: 'Lane Dragons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2358, import_key: 'l.ncaa.org.mfoot-t.792', entity_name: 'Lenoir-Rhyne Bears', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.792', entity_name: 'Lenoir-Rhyne Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2359, import_key: 'l.ncaa.org.mfoot-t.859', entity_name: 'Lincoln, Mo. Blue Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.859', entity_name: 'Lincoln, Mo. Blue Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2360, import_key: 'l.ncaa.org.mfoot-t.Y71', entity_name: 'Lincoln (PA)', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y71', entity_name: 'Lincoln (PA)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2361, import_key: 'l.ncaa.org.mfoot-t.835', entity_name: 'Lindenwood', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.835', entity_name: 'Lindenwood', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2362, import_key: 'l.ncaa.org.mfoot-t.V02', entity_name: 'Livingstone Blue Bears', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V02', entity_name: 'Livingstone Blue Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2363, import_key: 'l.ncaa.org.mfoot-t.761', entity_name: 'Lock Haven Eagles', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.761', entity_name: 'Lock Haven Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2364, import_key: 'l.ncaa.org.mfoot-t.YB5 ', entity_name: 'LU-Belleville', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.YB5 ', entity_name: 'LU-Belleville', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2365, import_key: 'l.ncaa.org.mfoot-t.V42', entity_name: 'Mansfield', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V42', entity_name: 'Mansfield', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2366, import_key: 'l.ncaa.org.mfoot-t.790', entity_name: 'Mars Hill Lions', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.790', entity_name: 'Mars Hill Lions', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2367, import_key: 'l.ncaa.org.mfoot-t.Y56', entity_name: 'Mary Marauders', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y56', entity_name: 'Mary Marauders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2368, import_key: 'l.ncaa.org.mfoot-t.YA1 ', entity_name: 'McKendree', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.YA1 ', entity_name: 'McKendree', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2369, import_key: 'l.ncaa.org.mfoot-t.V33', entity_name: 'Mercyhurst Lakers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V33', entity_name: 'Mercyhurst Lakers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2370, import_key: 'l.ncaa.org.mfoot-t.V52', entity_name: 'Merrimack Warriors', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V52', entity_name: 'Merrimack Warriors', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2371, import_key: 'l.ncaa.org.mfoot-t.702', entity_name: 'Mesa State Mavericks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.702', entity_name: 'Mesa State Mavericks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2372, import_key: 'l.ncaa.org.mfoot-t.V30', entity_name: 'Michigan Tech Huskies', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V30', entity_name: 'Michigan Tech Huskies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2373, import_key: 'l.ncaa.org.mfoot-t.749', entity_name: 'Miles Golden Bears', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.749', entity_name: 'Miles Golden Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2374, import_key: 'l.ncaa.org.mfoot-t.740', entity_name: 'Millersville Marauders', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.740', entity_name: 'Millersville Marauders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2375, import_key: 'l.ncaa.org.mfoot-t.855', entity_name: 'Minnesota State Mavericks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.855', entity_name: 'Minnesota State Mavericks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2376, import_key: 'l.ncaa.org.mfoot-t.V23', entity_name: 'Minn.-Crookston Golden Eagles', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V23', entity_name: 'Minn.-Crookston Golden Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2377, import_key: 'l.ncaa.org.mfoot-t.V16', entity_name: 'Minn.-Duluth Bulldogs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V16', entity_name: 'Minn.-Duluth Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2378, import_key: 'l.ncaa.org.mfoot-t.YB2 ', entity_name: 'Misericordia ', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.YB2 ', entity_name: 'Misericordia ', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2379, import_key: 'l.ncaa.org.mfoot-t.830', entity_name: 'Missouri-Rolla Miners', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.830', entity_name: 'Missouri-Rolla Miners', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2380, import_key: 'l.ncaa.org.mfoot-t.V14', entity_name: 'Missouri Southern Lions', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V14', entity_name: 'Missouri Southern Lions', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2381, import_key: 'l.ncaa.org.mfoot-t.V13', entity_name: 'Missouri Western Griffons', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V13', entity_name: 'Missouri Western Griffons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2382, import_key: 'l.ncaa.org.mfoot-t.Y84', entity_name: 'Monterrey Tech', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y84', entity_name: 'Monterrey Tech', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2383, import_key: 'l.ncaa.org.mfoot-t.V20', entity_name: 'Minn.-Moorhead Dragons', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V20', entity_name: 'Minn.-Moorhead Dragons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2384, import_key: 'l.ncaa.org.mfoot-t.V53', entity_name: 'Nebraska-Kearney Lopers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V53', entity_name: 'Nebraska-Kearney Lopers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2385, import_key: 'l.ncaa.org.mfoot-t.V35', entity_name: 'Nebraska-Omaha Mavericks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V35', entity_name: 'Nebraska-Omaha Mavericks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2386, import_key: 'l.ncaa.org.mfoot-t.738', entity_name: 'New Haven', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.738', entity_name: 'New Haven', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2387, import_key: 'l.ncaa.org.mfoot-t.779', entity_name: 'Newberry Indians', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.779', entity_name: 'Newberry Indians', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2388, import_key: 'l.ncaa.org.mfoot-t.854', entity_name: 'New Mexico Highlands Cowboys', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.854', entity_name: 'New Mexico Highlands Cowboys', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2389, import_key: 'l.ncaa.org.mfoot-t.723', entity_name: 'North Alabama Lions', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.723', entity_name: 'North Alabama Lions', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2390, import_key: 'l.ncaa.org.mfoot-t.751', entity_name: 'North Greenville Mounties', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.751', entity_name: 'North Greenville Mounties', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2391, import_key: 'l.ncaa.org.mfoot-t.V46', entity_name: 'Northeastern St. Redmen', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V46', entity_name: 'Northeastern St. Redmen', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2392, import_key: 'l.ncaa.org.mfoot-t.856', entity_name: 'Northern Michigan Wildcats', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.856', entity_name: 'Northern Michigan Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2393, import_key: 'l.ncaa.org.mfoot-t.V21', entity_name: 'Northern St., S.D. Wolves', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V21', entity_name: 'Northern St., S.D. Wolves', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2394, import_key: 'l.ncaa.org.mfoot-t.V09', entity_name: 'NW Missouri St. Bearcats', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V09', entity_name: 'NW Missouri St. Bearcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2395, import_key: 'l.ncaa.org.mfoot-t.V26', entity_name: 'Northwood, Mich. Timberwolves', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V26', entity_name: 'Northwood, Mich. Timberwolves', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2396, import_key: 'l.ncaa.org.mfoot-t.Y87 ', entity_name: 'Notre Dame (OH)', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y87 ', entity_name: 'Notre Dame (OH)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2397, import_key: 'l.ncaa.org.mfoot-t.Y10', entity_name: 'NW Oklahoma', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y10', entity_name: 'NW Oklahoma', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2398, import_key: 'l.ncaa.org.mfoot-t.Y43', entity_name: 'Ohio Dominican', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y43', entity_name: 'Ohio Dominican', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2399, import_key: 'l.ncaa.org.mfoot-t.V06', entity_name: 'Ouachita Baptist Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V06', entity_name: 'Ouachita Baptist Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2400, import_key: 'l.ncaa.org.mfoot-t.965', entity_name: 'Pace Setters', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.965', entity_name: 'Pace Setters', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2401, import_key: 'l.ncaa.org.mfoot-t.851', entity_name: 'Panhandle St. Aggies', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.851', entity_name: 'Panhandle St. Aggies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2402, import_key: 'l.ncaa.org.mfoot-t.Y05', entity_name: 'Peru State', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y05', entity_name: 'Peru State', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2403, import_key: 'l.ncaa.org.mfoot-t.V12', entity_name: 'Pittsburg St. Gorillas', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V12', entity_name: 'Pittsburg St. Gorillas', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2404, import_key: 'l.ncaa.org.mfoot-t.YA9', entity_name: 'Point U.', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.YA9', entity_name: 'Point U.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2405, import_key: 'l.ncaa.org.mfoot-t.YA4', entity_name: 'Robert Morris-IL', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.YA4', entity_name: 'Robert Morris-IL', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2406, import_key: 'l.ncaa.org.mfoot-t.V24', entity_name: 'Saginaw Valley St. Cardinals', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V24', entity_name: 'Saginaw Valley St. Cardinals', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2407, import_key: 'l.ncaa.org.mfoot-t.791', entity_name: 'SE Oklahoma Savages', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.791', entity_name: 'SE Oklahoma Savages', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2408, import_key: 'l.ncaa.org.mfoot-t.Y52', entity_name: 'Seton Hill Griffins', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y52', entity_name: 'Seton Hill Griffins', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2409, import_key: 'l.ncaa.org.mfoot-t.V04', entity_name: 'Shaw Bears', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V04', entity_name: 'Shaw Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2410, import_key: 'l.ncaa.org.mfoot-t.V58', entity_name: 'Shepherd Rams', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V58', entity_name: 'Shepherd Rams', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2411, import_key: 'l.ncaa.org.mfoot-t.V39', entity_name: 'Shippensburg Raiders', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V39', entity_name: 'Shippensburg Raiders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2412, import_key: 'l.ncaa.org.mfoot-t.Y60', entity_name: 'Shorter', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y60', entity_name: 'Shorter', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2413, import_key: 'l.ncaa.org.mfoot-t.714', entity_name: 'Simon Fraser', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.714', entity_name: 'Simon Fraser', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2414, import_key: 'l.ncaa.org.mfoot-t.789', entity_name: 'Slippery Rock Rock Pride', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.789', entity_name: 'Slippery Rock Rock Pride', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2415, import_key: 'l.ncaa.org.mfoot-t.Y62', entity_name: 'South Dakota Tech', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y62', entity_name: 'South Dakota Tech', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2416, import_key: 'l.ncaa.org.mfoot-t.V05', entity_name: 'S. Arkansas Mulerriders', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V05', entity_name: 'S. Arkansas Mulerriders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2417, import_key: 'l.ncaa.org.mfoot-t.V51', entity_name: 'S. Connecticut St. Owls', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V51', entity_name: 'S. Connecticut St. Owls', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2418, import_key: 'l.ncaa.org.mfoot-t.Y07', entity_name: 'Southern Nazarene', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y07', entity_name: 'Southern Nazarene', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2419, import_key: 'l.ncaa.org.mfoot-t.Y01', entity_name: 'Southern Virginia', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y01', entity_name: 'Southern Virginia', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2420, import_key: 'l.ncaa.org.mfoot-t.V22', entity_name: 'SW Minn. St. Mustangs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V22', entity_name: 'SW Minn. St. Mustangs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2421, import_key: 'l.ncaa.org.mfoot-t.Y04', entity_name: 'Southwestern KS', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y04', entity_name: 'Southwestern KS', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2422, import_key: 'l.ncaa.org.mfoot-t.966', entity_name: 'St. Anselm Hawks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.966', entity_name: 'St. Anselm Hawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2423, import_key: 'l.ncaa.org.mfoot-t.V03', entity_name: 'St. Augustines Falcons', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V03', entity_name: 'St. Augustines Falcons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2424, import_key: 'l.ncaa.org.mfoot-t.V34', entity_name: 'St. Cloud St. Huskies', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V34', entity_name: 'St. Cloud St. Huskies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2425, import_key: 'l.ncaa.org.mfoot-t.733', entity_name: 'St. Joseph\'s, Ind. Pumas', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.733', entity_name: 'St. Joseph\'s, Ind. Pumas', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2426, import_key: 'l.ncaa.org.mfoot-t.Y15', entity_name: 'St Mary (KS)', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y15', entity_name: 'St Mary (KS)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2427, import_key: 'l.ncaa.org.mfoot-t.Y03', entity_name: 'Saint Paul\'s, Va. Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y03', entity_name: 'Saint Paul\'s, Va. Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2428, import_key: 'l.ncaa.org.mfoot-t.833', entity_name: 'Stillman Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.833', entity_name: 'Stillman Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2429, import_key: 'l.ncaa.org.mfoot-t.964', entity_name: 'Stonehill Chieftains', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.964', entity_name: 'Stonehill Chieftains', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2430, import_key: 'l.ncaa.org.mfoot-t.829', entity_name: 'SW Baptist Bearcats', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.829', entity_name: 'SW Baptist Bearcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2431, import_key: 'l.ncaa.org.mfoot-t.839', entity_name: 'SW Oklahoma Bulldogs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.839', entity_name: 'SW Oklahoma Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2432, import_key: 'l.ncaa.org.mfoot-t.730', entity_name: 'Tarleton St. Texans', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.730', entity_name: 'Tarleton St. Texans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2433, import_key: 'l.ncaa.org.mfoot-t.788', entity_name: 'Tiffin Dragons', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.788', entity_name: 'Tiffin Dragons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2434, import_key: 'l.ncaa.org.mfoot-t.795', entity_name: 'Truman Bulldogs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.795', entity_name: 'Truman Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2435, import_key: 'l.ncaa.org.mfoot-t.773', entity_name: 'Tusculum Pioneers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.773', entity_name: 'Tusculum Pioneers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2436, import_key: 'l.ncaa.org.mfoot-t.711', entity_name: 'Tuskegee Golden Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.711', entity_name: 'Tuskegee Golden Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2437, import_key: 'l.ncaa.org.mfoot-t.813', entity_name: 'Texas A&M Commerce Lions', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.813', entity_name: 'Texas A&M Commerce Lions', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2438, import_key: 'l.ncaa.org.mfoot-t.753', entity_name: 'Texas A&M-Kingsville Javelines', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.753', entity_name: 'Texas A&M-Kingsville Javelines', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2439, import_key: 'l.ncaa.org.mfoot-t.818', entity_name: 'UNC-Pembroke Braves', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.818', entity_name: 'UNC-Pembroke Braves', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2440, import_key: 'l.ncaa.org.mfoot-t.V73', entity_name: 'Upper Iowa Peacocks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V73', entity_name: 'Upper Iowa Peacocks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2441, import_key: 'l.ncaa.org.mfoot-t.Y26', entity_name: 'Urbana Blue Knights', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y26', entity_name: 'Urbana Blue Knights', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2442, import_key: 'l.ncaa.org.mfoot-t.ZY3', entity_name: 'VA-Lynchburg', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.ZY3', entity_name: 'VA-Lynchburg', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2443, import_key: 'l.ncaa.org.mfoot-t.857', entity_name: 'Valdosta St. Blazers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.857', entity_name: 'Valdosta St. Blazers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2444, import_key: 'l.ncaa.org.mfoot-t.766', entity_name: 'Virginia St. Trojans', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.766', entity_name: 'Virginia St. Trojans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2445, import_key: 'l.ncaa.org.mfoot-t.770', entity_name: 'Virginia Union Panthers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.770', entity_name: 'Virginia Union Panthers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2446, import_key: 'l.ncaa.org.mfoot-t.Y02', entity_name: 'Walsh', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y02', entity_name: 'Walsh', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2447, import_key: 'l.ncaa.org.mfoot-t.V15', entity_name: 'Washburn Ichabods', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V15', entity_name: 'Washburn Ichabods', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2448, import_key: 'l.ncaa.org.mfoot-t.YB3 ', entity_name: 'Wayland Baptist', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.YB3 ', entity_name: 'Wayland Baptist', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2449, import_key: 'l.ncaa.org.mfoot-t.V31', entity_name: 'Wayne St. Warriors', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V31', entity_name: 'Wayne St. Warriors', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2450, import_key: 'l.ncaa.org.mfoot-t.758', entity_name: 'Wayne, Neb. Wildcats', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.758', entity_name: 'Wayne, Neb. Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2451, import_key: 'l.ncaa.org.mfoot-t.958', entity_name: 'West Alabama Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.958', entity_name: 'West Alabama Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2452, import_key: 'l.ncaa.org.mfoot-t.744', entity_name: 'West Chester Golden Rams', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.744', entity_name: 'West Chester Golden Rams', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2453, import_key: 'l.ncaa.org.mfoot-t.V08', entity_name: 'West Georgia Braves', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V08', entity_name: 'West Georgia Braves', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2454, import_key: 'l.ncaa.org.mfoot-t.827', entity_name: 'West Liberty Hilltoppers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.827', entity_name: 'West Liberty Hilltoppers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2455, import_key: 'l.ncaa.org.mfoot-t.V49', entity_name: 'West Texas A&M Buffs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V49', entity_name: 'West Texas A&M Buffs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2456, import_key: 'l.ncaa.org.mfoot-t.785', entity_name: 'West Virginia St. Yellow Jackets', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.785', entity_name: 'West Virginia St. Yellow Jackets', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2457, import_key: 'l.ncaa.org.mfoot-t.V57', entity_name: 'W.V. Wesleyan Bobcats', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V57', entity_name: 'W.V. Wesleyan Bobcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2458, import_key: 'l.ncaa.org.mfoot-t.776', entity_name: 'Western New Mexico Mustangs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.776', entity_name: 'Western New Mexico Mustangs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2459, import_key: 'l.ncaa.org.mfoot-t.727', entity_name: 'Western Oregon Wolves', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.727', entity_name: 'Western Oregon Wolves', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2460, import_key: 'l.ncaa.org.mfoot-t.834', entity_name: 'Western St., Colo. Mountaineers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.834', entity_name: 'Western St., Colo. Mountaineers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2461, import_key: 'l.ncaa.org.mfoot-t.755', entity_name: 'Western Washington Vikings', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.755', entity_name: 'Western Washington Vikings', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2462, import_key: 'l.ncaa.org.mfoot-t.Y88 ', entity_name: 'William Jewell', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y88 ', entity_name: 'William Jewell', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2463, import_key: 'l.ncaa.org.mfoot-t.802', entity_name: 'Wingate Bulldogs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.802', entity_name: 'Wingate Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2464, import_key: 'l.ncaa.org.mfoot-t.V17', entity_name: 'Winona St. Warriors', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V17', entity_name: 'Winona St. Warriors', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2465, import_key: 'l.ncaa.org.mfoot-t.767', entity_name: 'Winston-Salem St ', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.767', entity_name: 'Winston-Salem St ', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2466, import_key: 'l.ncaa.org.mfoot-t.774', entity_name: 'WVU Tech', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.774', entity_name: 'WVU Tech', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2467, import_key: 'l.ncaa.org.mfoot-t.V44', entity_name: 'Morehouse Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V44', entity_name: 'Morehouse Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2468, import_key: 'l.ncaa.org.mfoot-t.739', entity_name: 'Azusa Pacific Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.739', entity_name: 'Azusa Pacific Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2469, import_key: 'l.ncaa.org.mfoot-t.V95', entity_name: 'Fairleigh Dickinson Knights', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V95', entity_name: 'Fairleigh Dickinson Knights', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2470, import_key: 'l.ncaa.org.mfoot-t.V60', entity_name: 'Adrian Bulldogs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V60', entity_name: 'Adrian Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2471, import_key: 'l.ncaa.org.mfoot-t.729', entity_name: 'Albion Britons', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.729', entity_name: 'Albion Britons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2472, import_key: 'l.ncaa.org.mfoot-t.V94', entity_name: 'Albright Lions', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V94', entity_name: 'Albright Lions', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2473, import_key: 'l.ncaa.org.mfoot-t.Y17', entity_name: 'Alfred State', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y17', entity_name: 'Alfred State', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2474, import_key: 'l.ncaa.org.mfoot-t.W09', entity_name: 'Alfred Saxons', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W09', entity_name: 'Alfred Saxons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2475, import_key: 'l.ncaa.org.mfoot-t.W77', entity_name: 'Allegheny Gators', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W77', entity_name: 'Allegheny Gators', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2476, import_key: 'l.ncaa.org.mfoot-t.V59', entity_name: 'Alma Scots', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V59', entity_name: 'Alma Scots', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2477, import_key: 'l.ncaa.org.mfoot-t.X05', entity_name: 'Amherst Lord Jeffs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X05', entity_name: 'Amherst Lord Jeffs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2478, import_key: 'l.ncaa.org.mfoot-t.W36', entity_name: 'Anderson, Ind. Ravens', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W36', entity_name: 'Anderson, Ind. Ravens', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2479, import_key: 'l.ncaa.org.mfoot-t.Y82', entity_name: 'Anna Maria', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y82', entity_name: 'Anna Maria', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2480, import_key: 'l.ncaa.org.mfoot-t.X59', entity_name: 'Augsburg Auggies', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X59', entity_name: 'Augsburg Auggies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2481, import_key: 'l.ncaa.org.mfoot-t.W12', entity_name: 'Augustana Ill. Vikings', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W12', entity_name: 'Augustana Ill. Vikings', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2482, import_key: 'l.ncaa.org.mfoot-t.742', entity_name: 'Aurora Spartans', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.742', entity_name: 'Aurora Spartans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2483, import_key: 'l.ncaa.org.mfoot-t.W54', entity_name: 'Austin Kangaroos', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W54', entity_name: 'Austin Kangaroos', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2484, import_key: 'l.ncaa.org.mfoot-t.YA6 ', entity_name: 'Ave Maria', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.YA6 ', entity_name: 'Ave Maria', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2485, import_key: 'l.ncaa.org.mfoot-t.W47', entity_name: 'Averett Cougars', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W47', entity_name: 'Averett Cougars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2486, import_key: 'l.ncaa.org.mfoot-t.W95', entity_name: 'Baldwin-Wallace Yellow Jackets', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W95', entity_name: 'Baldwin-Wallace Yellow Jackets', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2487, import_key: 'l.ncaa.org.mfoot-t.X10', entity_name: 'Bates Bobcats', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X10', entity_name: 'Bates Bobcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2488, import_key: 'l.ncaa.org.mfoot-t.Y51', entity_name: 'Becker', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y51', entity_name: 'Becker', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2489, import_key: 'l.ncaa.org.mfoot-t.Y25', entity_name: 'Belhaven', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y25', entity_name: 'Belhaven', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2490, import_key: 'l.ncaa.org.mfoot-t.X15', entity_name: 'Beloit Buccaneers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X15', entity_name: 'Beloit Buccaneers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2491, import_key: 'l.ncaa.org.mfoot-t.W04', entity_name: 'Benedictine, Ill. Eagles', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W04', entity_name: 'Benedictine, Ill. Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2492, import_key: 'l.ncaa.org.mfoot-t.X30', entity_name: 'Bethany, W.Va. Bison', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X30', entity_name: 'Bethany, W.Va. Bison', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2493, import_key: 'l.ncaa.org.mfoot-t.X56', entity_name: 'Bethel, Minn. Royals', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X56', entity_name: 'Bethel, Minn. Royals', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2494, import_key: 'l.ncaa.org.mfoot-t.Y66', entity_name: 'Birmingham Southern', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y66', entity_name: 'Birmingham Southern', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2495, import_key: 'l.ncaa.org.mfoot-t.W31', entity_name: 'Blackburn Beavers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W31', entity_name: 'Blackburn Beavers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2496, import_key: 'l.ncaa.org.mfoot-t.W41', entity_name: 'Bluffton Beavers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W41', entity_name: 'Bluffton Beavers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2497, import_key: 'l.ncaa.org.mfoot-t.X11', entity_name: 'Bowdoin Polar Bears', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X11', entity_name: 'Bowdoin Polar Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2498, import_key: 'l.ncaa.org.mfoot-t.X41', entity_name: 'Bridgewater St. Bears', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X41', entity_name: 'Bridgewater St. Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2499, import_key: 'l.ncaa.org.mfoot-t.W68', entity_name: 'Bridgewater, Va. Eagles', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W68', entity_name: 'Bridgewater, Va. Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2500, import_key: 'l.ncaa.org.mfoot-t.W20', entity_name: 'Brockport Golden Eagles', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W20', entity_name: 'Brockport Golden Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2501, import_key: 'l.ncaa.org.mfoot-t.V72', entity_name: 'Buena Vista Beavers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V72', entity_name: 'Buena Vista Beavers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2502, import_key: 'l.ncaa.org.mfoot-t.759', entity_name: 'Buffalo St. Bengals', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.759', entity_name: 'Buffalo St. Bengals', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2503, import_key: 'l.ncaa.org.mfoot-t.W64', entity_name: 'Cal Lutheran Kingsmen', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W64', entity_name: 'Cal Lutheran Kingsmen', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2504, import_key: 'l.ncaa.org.mfoot-t.W96', entity_name: 'Capital Crusaders', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W96', entity_name: 'Capital Crusaders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2505, import_key: 'l.ncaa.org.mfoot-t.X60', entity_name: 'Carleton Knights', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X60', entity_name: 'Carleton Knights', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2506, import_key: 'l.ncaa.org.mfoot-t.X25', entity_name: 'Carnegie-Mellon Tartans', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X25', entity_name: 'Carnegie-Mellon Tartans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2507, import_key: 'l.ncaa.org.mfoot-t.X20', entity_name: 'Carroll, Wis. Pioneers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X20', entity_name: 'Carroll, Wis. Pioneers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2508, import_key: 'l.ncaa.org.mfoot-t.W16', entity_name: 'Carthage Redmen', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W16', entity_name: 'Carthage Redmen', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2509, import_key: 'l.ncaa.org.mfoot-t.X23', entity_name: 'Case Reserve Spartans', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X23', entity_name: 'Case Reserve Spartans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2510, import_key: 'l.ncaa.org.mfoot-t.Y83', entity_name: 'Castleton State', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y83', entity_name: 'Castleton State', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2511, import_key: 'l.ncaa.org.mfoot-t.732', entity_name: 'Catholic Cardinals', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.732', entity_name: 'Catholic Cardinals', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2512, import_key: 'l.ncaa.org.mfoot-t.Y44', entity_name: 'Central Methodist', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y44', entity_name: 'Central Methodist', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2513, import_key: 'l.ncaa.org.mfoot-t.V67', entity_name: 'Central Dutch', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V67', entity_name: 'Central Dutch', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2514, import_key: 'l.ncaa.org.mfoot-t.800', entity_name: 'Centre Colonels', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.800', entity_name: 'Centre Colonels', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2515, import_key: 'l.ncaa.org.mfoot-t.W28', entity_name: 'Chapman Panthers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W28', entity_name: 'Chapman Panthers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2516, import_key: 'l.ncaa.org.mfoot-t.X24', entity_name: 'Chicago Maroons', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X24', entity_name: 'Chicago Maroons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2517, import_key: 'l.ncaa.org.mfoot-t.W42', entity_name: 'Christopher Newport Captains', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W42', entity_name: 'Christopher Newport Captains', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2518, import_key: 'l.ncaa.org.mfoot-t.W63', entity_name: 'Claremont-Mudd Stags', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W63', entity_name: 'Claremont-Mudd Stags', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2519, import_key: 'l.ncaa.org.mfoot-t.V79', entity_name: 'Coast Guard Bears', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V79', entity_name: 'Coast Guard Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2520, import_key: 'l.ncaa.org.mfoot-t.V65', entity_name: 'Coe Kohawks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V65', entity_name: 'Coe Kohawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2521, import_key: 'l.ncaa.org.mfoot-t.X08', entity_name: 'Colby White Mules', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X08', entity_name: 'Colby White Mules', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2522, import_key: 'l.ncaa.org.mfoot-t.957', entity_name: 'College of New Jersey Lions', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.957', entity_name: 'College of New Jersey Lions', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2523, import_key: 'l.ncaa.org.mfoot-t.W76', entity_name: 'Wooster Scots', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W76', entity_name: 'Wooster Scots', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2524, import_key: 'l.ncaa.org.mfoot-t.W30', entity_name: 'Colorado College Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W30', entity_name: 'Colorado College Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2525, import_key: 'l.ncaa.org.mfoot-t.W02', entity_name: 'Concordia, Ill. Cougars', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W02', entity_name: 'Concordia, Ill. Cougars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2526, import_key: 'l.ncaa.org.mfoot-t.V99', entity_name: 'Concordia, Wis. Falcons', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V99', entity_name: 'Concordia, Wis. Falcons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2527, import_key: 'l.ncaa.org.mfoot-t.X53', entity_name: 'Concordia-Moorhead Cobbers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X53', entity_name: 'Concordia-Moorhead Cobbers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2528, import_key: 'l.ncaa.org.mfoot-t.V70', entity_name: 'Cornell, Iowa Rams', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V70', entity_name: 'Cornell, Iowa Rams', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2529, import_key: 'l.ncaa.org.mfoot-t.Y19', entity_name: 'Crown Storm', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y19', entity_name: 'Crown Storm', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2530, import_key: 'l.ncaa.org.mfoot-t.PS1', entity_name: 'Culver-Stockton', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.PS1', entity_name: 'Culver-Stockton', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2531, import_key: 'l.ncaa.org.mfoot-t.X46', entity_name: 'Curry Colonels', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X46', entity_name: 'Curry Colonels', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2532, import_key: 'l.ncaa.org.mfoot-t.W40', entity_name: 'Defiance Yellow Jackets', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W40', entity_name: 'Defiance Yellow Jackets', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2533, import_key: 'l.ncaa.org.mfoot-t.V96', entity_name: 'Delaware Valley Aggies', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V96', entity_name: 'Delaware Valley Aggies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2534, import_key: 'l.ncaa.org.mfoot-t.W81', entity_name: 'Denison Big Red', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W81', entity_name: 'Denison Big Red', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2535, import_key: 'l.ncaa.org.mfoot-t.W89', entity_name: 'DePauw Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W89', entity_name: 'DePauw Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2536, import_key: 'l.ncaa.org.mfoot-t.V83', entity_name: 'Dickinson Red Devils', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V83', entity_name: 'Dickinson Red Devils', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2537, import_key: 'l.ncaa.org.mfoot-t.V74', entity_name: 'Dubuque Spartans', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V74', entity_name: 'Dubuque Spartans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2538, import_key: 'l.ncaa.org.mfoot-t.W78', entity_name: 'Earlham Quakers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W78', entity_name: 'Earlham Quakers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2539, import_key: 'l.ncaa.org.mfoot-t.W52', entity_name: 'East Texas Baptist Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W52', entity_name: 'East Texas Baptist Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2540, import_key: 'l.ncaa.org.mfoot-t.726', entity_name: 'Eastern Oregon', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.726', entity_name: 'Eastern Oregon', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2541, import_key: 'l.ncaa.org.mfoot-t.W17', entity_name: 'Elmhurst Blue Jays', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W17', entity_name: 'Elmhurst Blue Jays', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2542, import_key: 'l.ncaa.org.mfoot-t.794', entity_name: 'Emory & Henry Wasps', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.794', entity_name: 'Emory & Henry Wasps', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2543, import_key: 'l.ncaa.org.mfoot-t.X51', entity_name: 'Endicott Gulls', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X51', entity_name: 'Endicott Gulls', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2544, import_key: 'l.ncaa.org.mfoot-t.W05', entity_name: 'Eureka Red Devils', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W05', entity_name: 'Eureka Red Devils', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2545, import_key: 'l.ncaa.org.mfoot-t.W43', entity_name: 'Ferrum Panthers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W43', entity_name: 'Ferrum Panthers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2546, import_key: 'l.ncaa.org.mfoot-t.X40', entity_name: 'Fitchburg St. Falcons', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X40', entity_name: 'Fitchburg St. Falcons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2547, import_key: 'l.ncaa.org.mfoot-t.X43', entity_name: 'Framingham St. Rams', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X43', entity_name: 'Framingham St. Rams', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2548, import_key: 'l.ncaa.org.mfoot-t.V84', entity_name: 'Franklin & Marshall Diplomats', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V84', entity_name: 'Franklin & Marshall Diplomats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2549, import_key: 'l.ncaa.org.mfoot-t.W39', entity_name: 'Franklin Grizzlies', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W39', entity_name: 'Franklin Grizzlies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2550, import_key: 'l.ncaa.org.mfoot-t.757', entity_name: 'Frostburg St. Bobcats', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.757', entity_name: 'Frostburg St. Bobcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2551, import_key: 'l.ncaa.org.mfoot-t.Y68', entity_name: 'Gallaudet', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y68', entity_name: 'Gallaudet', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2552, import_key: 'l.ncaa.org.mfoot-t.Y30', entity_name: 'George Mason', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y30', entity_name: 'George Mason', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2553, import_key: 'l.ncaa.org.mfoot-t.V85', entity_name: 'Gettysburg Bullets', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V85', entity_name: 'Gettysburg Bullets', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2554, import_key: 'l.ncaa.org.mfoot-t.W45', entity_name: 'Greensboro Pride', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W45', entity_name: 'Greensboro Pride', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2555, import_key: 'l.ncaa.org.mfoot-t.W06', entity_name: 'Greenville Panthers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W06', entity_name: 'Greenville Panthers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2556, import_key: 'l.ncaa.org.mfoot-t.X18', entity_name: 'Grinnell Pioneers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X18', entity_name: 'Grinnell Pioneers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2557, import_key: 'l.ncaa.org.mfoot-t.X31', entity_name: 'Grove City Wolverines', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X31', entity_name: 'Grove City Wolverines', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2558, import_key: 'l.ncaa.org.mfoot-t.796', entity_name: 'Guilford Quakers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.796', entity_name: 'Guilford Quakers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2559, import_key: 'l.ncaa.org.mfoot-t.X54', entity_name: 'Gustavus Adolphus Gusties', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X54', entity_name: 'Gustavus Adolphus Gusties', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2560, import_key: 'l.ncaa.org.mfoot-t.X12', entity_name: 'Hamilton Continentals', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X12', entity_name: 'Hamilton Continentals', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2561, import_key: 'l.ncaa.org.mfoot-t.X58', entity_name: 'Hamline Pipers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X58', entity_name: 'Hamline Pipers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2562, import_key: 'l.ncaa.org.mfoot-t.811', entity_name: 'Hampden-Sydney Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.811', entity_name: 'Hampden-Sydney Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2563, import_key: 'l.ncaa.org.mfoot-t.W35', entity_name: 'Hanover Panthers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W35', entity_name: 'Hanover Panthers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2564, import_key: 'l.ncaa.org.mfoot-t.W51', entity_name: 'Hardin-Simmons Cowboys', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W51', entity_name: 'Hardin-Simmons Cowboys', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2565, import_key: 'l.ncaa.org.mfoot-t.720', entity_name: 'Hartwick Hawks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.720', entity_name: 'Hartwick Hawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2566, import_key: 'l.ncaa.org.mfoot-t.X01', entity_name: 'Heidelberg Student Princes', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X01', entity_name: 'Heidelberg Student Princes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2567, import_key: 'l.ncaa.org.mfoot-t.W83', entity_name: 'Hiram Terriers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W83', entity_name: 'Hiram Terriers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2568, import_key: 'l.ncaa.org.mfoot-t.W84', entity_name: 'Hobart Statesmen', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W84', entity_name: 'Hobart Statesmen', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2569, import_key: 'l.ncaa.org.mfoot-t.805', entity_name: 'Hope Flying Dutchmen', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.805', entity_name: 'Hope Flying Dutchmen', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2570, import_key: 'l.ncaa.org.mfoot-t.W50', entity_name: 'Howard Payne Yellow Jackets', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W50', entity_name: 'Howard Payne Yellow Jackets', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2571, import_key: 'l.ncaa.org.mfoot-t.W26', entity_name: 'Huntingdon Hawks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W26', entity_name: 'Huntingdon Hawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2572, import_key: 'l.ncaa.org.mfoot-t.W33', entity_name: 'Husson Braves', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W33', entity_name: 'Husson Braves', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2573, import_key: 'l.ncaa.org.mfoot-t.X19', entity_name: 'Illinois College Blue Boys', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X19', entity_name: 'Illinois College Blue Boys', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2574, import_key: 'l.ncaa.org.mfoot-t.W15', entity_name: 'Illinois Wesleyan Titans', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W15', entity_name: 'Illinois Wesleyan Titans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2575, import_key: 'l.ncaa.org.mfoot-t.W07', entity_name: 'Ithaca Bombers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W07', entity_name: 'Ithaca Bombers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2576, import_key: 'l.ncaa.org.mfoot-t.Y29', entity_name: 'Jamestown (ND)', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y29', entity_name: 'Jamestown (ND)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2577, import_key: 'l.ncaa.org.mfoot-t.W94', entity_name: 'John Carroll Blue Streaks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W94', entity_name: 'John Carroll Blue Streaks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2578, import_key: 'l.ncaa.org.mfoot-t.V82', entity_name: 'Johns Hopkins Blue Jays', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V82', entity_name: 'Johns Hopkins Blue Jays', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2579, import_key: 'l.ncaa.org.mfoot-t.V93', entity_name: 'Juniata Eagles', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V93', entity_name: 'Juniata Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2580, import_key: 'l.ncaa.org.mfoot-t.V62', entity_name: 'Kalamazoo Hornets', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V62', entity_name: 'Kalamazoo Hornets', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2581, import_key: 'l.ncaa.org.mfoot-t.W72', entity_name: 'Kean Cougars', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W72', entity_name: 'Kean Cougars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2582, import_key: 'l.ncaa.org.mfoot-t.W82', entity_name: 'Kenyon Lords', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W82', entity_name: 'Kenyon Lords', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2583, import_key: 'l.ncaa.org.mfoot-t.V87', entity_name: 'King\'s College Monarchs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V87', entity_name: 'King\'s College Monarchs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2584, import_key: 'l.ncaa.org.mfoot-t.X16', entity_name: 'Knox Prairie Fire', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X16', entity_name: 'Knox Prairie Fire', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2585, import_key: 'l.ncaa.org.mfoot-t.836', entity_name: 'La Verne Leopards', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.836', entity_name: 'La Verne Leopards', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2586, import_key: 'l.ncaa.org.mfoot-t.Y57', entity_name: 'LaGrange', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y57', entity_name: 'LaGrange', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2587, import_key: 'l.ncaa.org.mfoot-t.X13', entity_name: 'Lake Forest Foresters', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X13', entity_name: 'Lake Forest Foresters', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2588, import_key: 'l.ncaa.org.mfoot-t.W03', entity_name: 'Lakeland Muskies', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W03', entity_name: 'Lakeland Muskies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2589, import_key: 'l.ncaa.org.mfoot-t.X21', entity_name: 'Lawrence Vikings', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X21', entity_name: 'Lawrence Vikings', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2590, import_key: 'l.ncaa.org.mfoot-t.V97', entity_name: 'Lebanon Valley Flying Dutchmen', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V97', entity_name: 'Lebanon Valley Flying Dutchmen', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2591, import_key: 'l.ncaa.org.mfoot-t.X36', entity_name: 'Lewis & Clark Pioneers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X36', entity_name: 'Lewis & Clark Pioneers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2592, import_key: 'l.ncaa.org.mfoot-t.X32', entity_name: 'Linfield Wildcats', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X32', entity_name: 'Linfield Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2593, import_key: 'l.ncaa.org.mfoot-t.V69', entity_name: 'Loras Duhawks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V69', entity_name: 'Loras Duhawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2594, import_key: 'l.ncaa.org.mfoot-t.W55', entity_name: 'Louisiana College Wildcats', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W55', entity_name: 'Louisiana College Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2595, import_key: 'l.ncaa.org.mfoot-t.V71', entity_name: 'Luther Norse', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V71', entity_name: 'Luther Norse', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2596, import_key: 'l.ncaa.org.mfoot-t.V90', entity_name: 'Lycoming Warriors', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V90', entity_name: 'Lycoming Warriors', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2597, import_key: 'l.ncaa.org.mfoot-t.W25', entity_name: 'Macalester Scots', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W25', entity_name: 'Macalester Scots', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2598, import_key: 'l.ncaa.org.mfoot-t.V98', entity_name: 'Mac Murray Highlanders', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V98', entity_name: 'Mac Murray Highlanders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2599, import_key: 'l.ncaa.org.mfoot-t.X42', entity_name: 'Maine Maritime Mariners', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X42', entity_name: 'Maine Maritime Mariners', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2600, import_key: 'l.ncaa.org.mfoot-t.Y23', entity_name: 'Malone', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y23', entity_name: 'Malone', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2601, import_key: 'l.ncaa.org.mfoot-t.W38', entity_name: 'Manchester Spartans', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W38', entity_name: 'Manchester Spartans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2602, import_key: 'l.ncaa.org.mfoot-t.W23', entity_name: 'Maranatha Baptist Crusaders', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W23', entity_name: 'Maranatha Baptist Crusaders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2603, import_key: 'l.ncaa.org.mfoot-t.W98', entity_name: 'Marietta Pioneers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W98', entity_name: 'Marietta Pioneers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2604, import_key: 'l.ncaa.org.mfoot-t.W22', entity_name: 'Martin Luther Knights', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W22', entity_name: 'Martin Luther Knights', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2605, import_key: 'l.ncaa.org.mfoot-t.W49', entity_name: 'Mary Hardin-Baylor Crusaders', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W49', entity_name: 'Mary Hardin-Baylor Crusaders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2606, import_key: 'l.ncaa.org.mfoot-t.W32', entity_name: 'Maryville, Tenn. Scots', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W32', entity_name: 'Maryville, Tenn. Scots', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2607, import_key: 'l.ncaa.org.mfoot-t.X44', entity_name: 'Mass.-Maritime Buccaneers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X44', entity_name: 'Mass.-Maritime Buccaneers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2608, import_key: 'l.ncaa.org.mfoot-t.Y21', entity_name: 'Mayville St', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y21', entity_name: 'Mayville St', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2609, import_key: 'l.ncaa.org.mfoot-t.725', entity_name: 'McDaniel Green Terror', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.725', entity_name: 'McDaniel Green Terror', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2610, import_key: 'l.ncaa.org.mfoot-t.W58', entity_name: 'McMurry Indians', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W58', entity_name: 'McMurry Indians', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2611, import_key: 'l.ncaa.org.mfoot-t.806', entity_name: 'Menlo Oaks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.806', entity_name: 'Menlo Oaks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2612, import_key: 'l.ncaa.org.mfoot-t.821', entity_name: 'Merchant Marine Mariners', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.821', entity_name: 'Merchant Marine Mariners', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2613, import_key: 'l.ncaa.org.mfoot-t.W46', entity_name: 'Methodist Monarchs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W46', entity_name: 'Methodist Monarchs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2614, import_key: 'l.ncaa.org.mfoot-t.X07', entity_name: 'Middlebury Panthers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X07', entity_name: 'Middlebury Panthers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2615, import_key: 'l.ncaa.org.mfoot-t.Y85', entity_name: 'Midland Lutheran', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y85', entity_name: 'Midland Lutheran', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2616, import_key: 'l.ncaa.org.mfoot-t.W13', entity_name: 'Millikin Big Blue', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W13', entity_name: 'Millikin Big Blue', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2617, import_key: 'l.ncaa.org.mfoot-t.W92', entity_name: 'Millsaps Majors', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W92', entity_name: 'Millsaps Majors', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2618, import_key: 'l.ncaa.org.mfoot-t.W34', entity_name: 'Minn.-Morris Cougars', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W34', entity_name: 'Minn.-Morris Cougars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2619, import_key: 'l.ncaa.org.mfoot-t.W53', entity_name: 'Mississippi College Choctaws', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W53', entity_name: 'Mississippi College Choctaws', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2620, import_key: 'l.ncaa.org.mfoot-t.X48', entity_name: 'MIT Engineers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X48', entity_name: 'MIT Engineers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2621, import_key: 'l.ncaa.org.mfoot-t.X17', entity_name: 'Monmouth, Ill. Scots', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X17', entity_name: 'Monmouth, Ill. Scots', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2622, import_key: 'l.ncaa.org.mfoot-t.737', entity_name: 'Montclair St. Red Hawks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.737', entity_name: 'Montclair St. Red Hawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2623, import_key: 'l.ncaa.org.mfoot-t.V89', entity_name: 'Moravian Greyhounds', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V89', entity_name: 'Moravian Greyhounds', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2624, import_key: 'l.ncaa.org.mfoot-t.Y59', entity_name: 'Morrisville St', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y59', entity_name: 'Morrisville St', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2625, import_key: 'l.ncaa.org.mfoot-t.W29', entity_name: 'Mount Ida Mustangs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W29', entity_name: 'Mount Ida Mustangs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2626, import_key: 'l.ncaa.org.mfoot-t.W37', entity_name: 'Mount St. Joseph Lions', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W37', entity_name: 'Mount St. Joseph Lions', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2627, import_key: 'l.ncaa.org.mfoot-t.W93', entity_name: 'Mount Union Purple Raiders', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W93', entity_name: 'Mount Union Purple Raiders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2628, import_key: 'l.ncaa.org.mfoot-t.Y79', entity_name: 'MSU-Bottineau', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y79', entity_name: 'MSU-Bottineau', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2629, import_key: 'l.ncaa.org.mfoot-t.V81', entity_name: 'Muhlenberg Mules', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V81', entity_name: 'Muhlenberg Mules', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2630, import_key: 'l.ncaa.org.mfoot-t.W97', entity_name: 'Muskingum Muskies', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W97', entity_name: 'Muskingum Muskies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2631, import_key: 'l.ncaa.org.mfoot-t.V64', entity_name: 'Apprentice Builders', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V64', entity_name: 'Apprentice Builders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2632, import_key: 'l.ncaa.org.mfoot-t.X47', entity_name: 'Nichols Bison', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X47', entity_name: 'Nichols Bison', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2633, import_key: 'l.ncaa.org.mfoot-t.Y40', entity_name: 'NC Wesleyan Battling Bishops', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y40', entity_name: 'NC Wesleyan Battling Bishops', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2634, import_key: 'l.ncaa.org.mfoot-t.W14', entity_name: 'North Central Cardinals', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W14', entity_name: 'North Central Cardinals', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2635, import_key: 'l.ncaa.org.mfoot-t.W18', entity_name: 'North Park Vikings', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W18', entity_name: 'North Park Vikings', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2636, import_key: 'l.ncaa.org.mfoot-t.Y18', entity_name: 'Northwestern, Minn. Eagles', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y18', entity_name: 'Northwestern, Minn. Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2637, import_key: 'l.ncaa.org.mfoot-t.V78', entity_name: 'Norwich Cadets', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V78', entity_name: 'Norwich Cadets', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2638, import_key: 'l.ncaa.org.mfoot-t.W80', entity_name: 'Oberlin Yeomen', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W80', entity_name: 'Oberlin Yeomen', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2639, import_key: 'l.ncaa.org.mfoot-t.W65', entity_name: 'Occidental Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W65', entity_name: 'Occidental Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2640, import_key: 'l.ncaa.org.mfoot-t.961', entity_name: 'Ohio Northern Polar Bears', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.961', entity_name: 'Ohio Northern Polar Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2641, import_key: 'l.ncaa.org.mfoot-t.W79', entity_name: 'Ohio Wesleyan Battling Bishops', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W79', entity_name: 'Ohio Wesleyan Battling Bishops', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2642, import_key: 'l.ncaa.org.mfoot-t.Y27', entity_name: 'Olivet Nazarene', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y27', entity_name: 'Olivet Nazarene', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2643, import_key: 'l.ncaa.org.mfoot-t.V61', entity_name: 'Olivet Comets', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V61', entity_name: 'Olivet Comets', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2644, import_key: 'l.ncaa.org.mfoot-t.X02', entity_name: 'Otterbein Cardinals', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X02', entity_name: 'Otterbein Cardinals', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2645, import_key: 'l.ncaa.org.mfoot-t.Y86', entity_name: 'Pacific (OR)', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y86', entity_name: 'Pacific (OR)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2646, import_key: 'l.ncaa.org.mfoot-t.X35', entity_name: 'Pacific Lutheran Lutes', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X35', entity_name: 'Pacific Lutheran Lutes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2647, import_key: 'l.ncaa.org.mfoot-t.V80', entity_name: 'Plymouth St. Panthers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V80', entity_name: 'Plymouth St. Panthers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2648, import_key: 'l.ncaa.org.mfoot-t.W67', entity_name: 'Pomona-Pitzer Sagehens', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W67', entity_name: 'Pomona-Pitzer Sagehens', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2649, import_key: 'l.ncaa.org.mfoot-t.Y93 ', entity_name: 'Presentation', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y93 ', entity_name: 'Presentation', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2650, import_key: 'l.ncaa.org.mfoot-t.W24', entity_name: 'Principia Panthers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W24', entity_name: 'Principia Panthers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2651, import_key: 'l.ncaa.org.mfoot-t.X37', entity_name: 'Puget Sound Loggers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X37', entity_name: 'Puget Sound Loggers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2652, import_key: 'l.ncaa.org.mfoot-t.799', entity_name: 'Randolph-Macon Yellow Jackets', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.799', entity_name: 'Randolph-Macon Yellow Jackets', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2653, import_key: 'l.ncaa.org.mfoot-t.741', entity_name: 'Redlands Bulldogs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.741', entity_name: 'Redlands Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2654, import_key: 'l.ncaa.org.mfoot-t.W91', entity_name: 'Rhodes Lynx', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W91', entity_name: 'Rhodes Lynx', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2655, import_key: 'l.ncaa.org.mfoot-t.X14', entity_name: 'Ripon Red Hawks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X14', entity_name: 'Ripon Red Hawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2656, import_key: 'l.ncaa.org.mfoot-t.W87', entity_name: 'Rochester Yellow Jackets', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W87', entity_name: 'Rochester Yellow Jackets', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2657, import_key: 'l.ncaa.org.mfoot-t.W27', entity_name: 'Rockford Regents', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W27', entity_name: 'Rockford Regents', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2658, import_key: 'l.ncaa.org.mfoot-t.W90', entity_name: 'Rose-Hulman Engineers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W90', entity_name: 'Rose-Hulman Engineers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2659, import_key: 'l.ncaa.org.mfoot-t.W70', entity_name: 'Rowan Profs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W70', entity_name: 'Rowan Profs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2660, import_key: 'l.ncaa.org.mfoot-t.W86', entity_name: 'RPI Engineers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W86', entity_name: 'RPI Engineers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2661, import_key: 'l.ncaa.org.mfoot-t.Y67', entity_name: 'Saint Vincent', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y67', entity_name: 'Saint Vincent', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2662, import_key: 'l.ncaa.org.mfoot-t.V63', entity_name: 'Salisbury Sea Gulls', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V63', entity_name: 'Salisbury Sea Gulls', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2663, import_key: 'l.ncaa.org.mfoot-t.X49', entity_name: 'Salve Regina Seahawks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X49', entity_name: 'Salve Regina Seahawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2664, import_key: 'l.ncaa.org.mfoot-t.803', entity_name: 'Sewanee Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.803', entity_name: 'Sewanee Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2665, import_key: 'l.ncaa.org.mfoot-t.W44', entity_name: 'Shenandoah Hornets', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W44', entity_name: 'Shenandoah Hornets', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2666, import_key: 'l.ncaa.org.mfoot-t.V68', entity_name: 'Simpson, Iowa Storm', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V68', entity_name: 'Simpson, Iowa Storm', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2667, import_key: 'l.ncaa.org.mfoot-t.Y80', entity_name: 'Sioux Falls', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y80', entity_name: 'Sioux Falls', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2668, import_key: 'l.ncaa.org.mfoot-t.Y46', entity_name: 'South Alabama', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y46', entity_name: 'South Alabama', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2669, import_key: 'l.ncaa.org.mfoot-t.V75', entity_name: 'Springfield Pride', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V75', entity_name: 'Springfield Pride', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2670, import_key: 'l.ncaa.org.mfoot-t.793 ', entity_name: 'St Francis-IN', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.793 ', entity_name: 'St Francis-IN', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2671, import_key: 'l.ncaa.org.mfoot-t.W08', entity_name: 'St. John Fisher Cardinals', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W08', entity_name: 'St. John Fisher Cardinals', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2672, import_key: 'l.ncaa.org.mfoot-t.X52', entity_name: 'St. John\'s, Minn. Johnnies', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X52', entity_name: 'St. John\'s, Minn. Johnnies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2673, import_key: 'l.ncaa.org.mfoot-t.W85', entity_name: 'St. Lawrence Saints', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W85', entity_name: 'St. Lawrence Saints', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2674, import_key: 'l.ncaa.org.mfoot-t.819', entity_name: 'St. Norbert Green Knights', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.819', entity_name: 'St. Norbert Green Knights', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2675, import_key: 'l.ncaa.org.mfoot-t.X57', entity_name: 'St. Olaf Oles', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X57', entity_name: 'St. Olaf Oles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2676, import_key: 'l.ncaa.org.mfoot-t.Y74', entity_name: 'St Scholastica', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y74', entity_name: 'St Scholastica', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2677, import_key: 'l.ncaa.org.mfoot-t.X55', entity_name: 'St. Thomas, Minn. Tommies', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X55', entity_name: 'St. Thomas, Minn. Tommies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2678, import_key: 'l.ncaa.org.mfoot-t.Y28', entity_name: 'St Xavier', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y28', entity_name: 'St Xavier', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2679, import_key: 'l.ncaa.org.mfoot-t.Y94 ', entity_name: 'Stevenson', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y94 ', entity_name: 'Stevenson', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2680, import_key: 'l.ncaa.org.mfoot-t.W56', entity_name: 'Sul Ross St. Lobos', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W56', entity_name: 'Sul Ross St. Lobos', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2681, import_key: 'l.ncaa.org.mfoot-t.W71', entity_name: 'Cortland St. Red Dragons', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W71', entity_name: 'Cortland St. Red Dragons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2682, import_key: 'l.ncaa.org.mfoot-t.Y58', entity_name: 'SUNY-Maritime', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y58', entity_name: 'SUNY-Maritime', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2683, import_key: 'l.ncaa.org.mfoot-t.V92', entity_name: 'Susquehanna Crusaders', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V92', entity_name: 'Susquehanna Crusaders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2684, import_key: 'l.ncaa.org.mfoot-t.Y53', entity_name: 'Tabor', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y53', entity_name: 'Tabor', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2685, import_key: 'l.ncaa.org.mfoot-t.Y31', entity_name: 'Taylor', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y31', entity_name: 'Taylor', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2686, import_key: 'l.ncaa.org.mfoot-t.Y34', entity_name: 'Team Mexico', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y34', entity_name: 'Team Mexico', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2687, import_key: 'l.ncaa.org.mfoot-t.Y33', entity_name: 'Team USA', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y33', entity_name: 'Team USA', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2688, import_key: 'l.ncaa.org.mfoot-t.W57', entity_name: 'Texas Lutheran Bulldogs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W57', entity_name: 'Texas Lutheran Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2689, import_key: 'l.ncaa.org.mfoot-t.X26', entity_name: 'Thiel Tomcats', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X26', entity_name: 'Thiel Tomcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2690, import_key: 'l.ncaa.org.mfoot-t.W21', entity_name: 'Thomas More Saints', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W21', entity_name: 'Thomas More Saints', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2691, import_key: 'l.ncaa.org.mfoot-t.797', entity_name: 'Tri-State Thunder', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.797', entity_name: 'Tri-State Thunder', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2692, import_key: 'l.ncaa.org.mfoot-t.X04', entity_name: 'Trinity, Conn. Bantams', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X04', entity_name: 'Trinity, Conn. Bantams', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2693, import_key: 'l.ncaa.org.mfoot-t.681', entity_name: 'Trinity, Texas Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.681', entity_name: 'Trinity, Texas Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2694, import_key: 'l.ncaa.org.mfoot-t.Y20', entity_name: 'Trinity Bible Lions', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y20', entity_name: 'Trinity Bible Lions', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2695, import_key: 'l.ncaa.org.mfoot-t.X09', entity_name: 'Tufts Jumbos', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X09', entity_name: 'Tufts Jumbos', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2696, import_key: 'l.ncaa.org.mfoot-t.Y24', entity_name: 'U of Dallas', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y24', entity_name: 'U of Dallas', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2697, import_key: 'l.ncaa.org.mfoot-t.X45', entity_name: 'Mass.-Dartmouth Corsairs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X45', entity_name: 'Mass.-Dartmouth Corsairs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2698, import_key: 'l.ncaa.org.mfoot-t.W88', entity_name: 'Union, N.Y. Dutchmen', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W88', entity_name: 'Union, N.Y. Dutchmen', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2699, import_key: 'l.ncaa.org.mfoot-t.V86', entity_name: 'Ursinus Bears', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V86', entity_name: 'Ursinus Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2700, import_key: 'l.ncaa.org.mfoot-t.W10', entity_name: 'Utica Pioneers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W10', entity_name: 'Utica Pioneers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2701, import_key: 'l.ncaa.org.mfoot-t.Y22', entity_name: 'Valley City St', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y22', entity_name: 'Valley City St', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2702, import_key: 'l.ncaa.org.mfoot-t.W74', entity_name: 'Wabash Little Giants', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W74', entity_name: 'Wabash Little Giants', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2703, import_key: 'l.ncaa.org.mfoot-t.V66', entity_name: 'Wartburg Knights', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V66', entity_name: 'Wartburg Knights', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2704, import_key: 'l.ncaa.org.mfoot-t.X27', entity_name: 'Washington & Jefferson Presidents', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X27', entity_name: 'Washington & Jefferson Presidents', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2705, import_key: 'l.ncaa.org.mfoot-t.W69', entity_name: 'Washington & Lee Generals', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W69', entity_name: 'Washington & Lee Generals', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2706, import_key: 'l.ncaa.org.mfoot-t.X22', entity_name: 'Washington, Mo. Bears', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X22', entity_name: 'Washington, Mo. Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2707, import_key: 'l.ncaa.org.mfoot-t.X29', entity_name: 'Waynesburg Yellow Jackets', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X29', entity_name: 'Waynesburg Yellow Jackets', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2708, import_key: 'l.ncaa.org.mfoot-t.X06', entity_name: 'Wesleyan, Conn. Cardinals', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X06', entity_name: 'Wesleyan, Conn. Cardinals', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2709, import_key: 'l.ncaa.org.mfoot-t.840', entity_name: 'Wesley Wolverines', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.840', entity_name: 'Wesley Wolverines', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2710, import_key: 'l.ncaa.org.mfoot-t.V76', entity_name: 'Western Connecticut Colonials', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V76', entity_name: 'Western Connecticut Colonials', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2711, import_key: 'l.ncaa.org.mfoot-t.X50', entity_name: 'Western New England Golden Bears', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X50', entity_name: 'Western New England Golden Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2712, import_key: 'l.ncaa.org.mfoot-t.X38', entity_name: 'Westfield St. Owls', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X38', entity_name: 'Westfield St. Owls', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2713, import_key: 'l.ncaa.org.mfoot-t.W19', entity_name: 'Westminster Mo. Blue Jays', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W19', entity_name: 'Westminster Mo. Blue Jays', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2714, import_key: 'l.ncaa.org.mfoot-t.X28', entity_name: 'Westminster, Pa. Titans', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X28', entity_name: 'Westminster, Pa. Titans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2715, import_key: 'l.ncaa.org.mfoot-t.W11', entity_name: 'Wheaton, Ill. Thunder', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W11', entity_name: 'Wheaton, Ill. Thunder', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2716, import_key: 'l.ncaa.org.mfoot-t.W66', entity_name: 'Whittier Poets', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W66', entity_name: 'Whittier Poets', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2717, import_key: 'l.ncaa.org.mfoot-t.X33', entity_name: 'Whitworth Pirates', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X33', entity_name: 'Whitworth Pirates', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2718, import_key: 'l.ncaa.org.mfoot-t.V88', entity_name: 'Widener Pioneers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V88', entity_name: 'Widener Pioneers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2719, import_key: 'l.ncaa.org.mfoot-t.V91', entity_name: 'Wilkes Colonels', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V91', entity_name: 'Wilkes Colonels', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2720, import_key: 'l.ncaa.org.mfoot-t.X34', entity_name: 'Willamette Bearcats', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X34', entity_name: 'Willamette Bearcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2721, import_key: 'l.ncaa.org.mfoot-t.W73', entity_name: 'William Paterson Pioneers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W73', entity_name: 'William Paterson Pioneers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2722, import_key: 'l.ncaa.org.mfoot-t.X03', entity_name: 'Williams Ephs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X03', entity_name: 'Williams Ephs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2723, import_key: 'l.ncaa.org.mfoot-t.W99', entity_name: 'Wilmington, Ohio Quakers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W99', entity_name: 'Wilmington, Ohio Quakers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2724, import_key: 'l.ncaa.org.mfoot-t.760', entity_name: 'Wis.-Eau Claire Blue Golds', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.760', entity_name: 'Wis.-Eau Claire Blue Golds', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2725, import_key: 'l.ncaa.org.mfoot-t.831', entity_name: 'Wis.-LaCrosse Eagles', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.831', entity_name: 'Wis.-LaCrosse Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2726, import_key: 'l.ncaa.org.mfoot-t.W61', entity_name: 'Wis.-Oshkosh Titans', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W61', entity_name: 'Wis.-Oshkosh Titans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2727, import_key: 'l.ncaa.org.mfoot-t.952', entity_name: 'Wis.-Platteville Pioneers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.952', entity_name: 'Wis.-Platteville Pioneers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2728, import_key: 'l.ncaa.org.mfoot-t.W62', entity_name: 'Wis.-River Falls Falcons', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W62', entity_name: 'Wis.-River Falls Falcons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2729, import_key: 'l.ncaa.org.mfoot-t.841', entity_name: 'Wis.-Stevens Point Pointers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.841', entity_name: 'Wis.-Stevens Point Pointers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2730, import_key: 'l.ncaa.org.mfoot-t.W59', entity_name: 'Wis.-Stout Blue Devils', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W59', entity_name: 'Wis.-Stout Blue Devils', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2731, import_key: 'l.ncaa.org.mfoot-t.W60', entity_name: 'Wis.-Whitewater Warhawks', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W60', entity_name: 'Wis.-Whitewater Warhawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2732, import_key: 'l.ncaa.org.mfoot-t.955', entity_name: 'Wisconsin Lutheran Warriors', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.955', entity_name: 'Wisconsin Lutheran Warriors', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2733, import_key: 'l.ncaa.org.mfoot-t.W75', entity_name: 'Wittenberg Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.W75', entity_name: 'Wittenberg Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2734, import_key: 'l.ncaa.org.mfoot-t.X39', entity_name: 'Worcester St. Lancers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.X39', entity_name: 'Worcester St. Lancers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2735, import_key: 'l.ncaa.org.mfoot-t.V77', entity_name: 'Worcester Polytechnic Engineers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.V77', entity_name: 'Worcester Polytechnic Engineers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2736, import_key: 'l.naia.org.mfoot-t.804', entity_name: 'Virginia Wise', status: 1, entity_type_id: 7
+    import_key: 'l.naia.org.mfoot-t.804', entity_name: 'Virginia Wise', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2737, import_key: 'l.ncaa.org.mfoot-t.842', entity_name: 'Webber Intl. Warriors', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.842', entity_name: 'Webber Intl. Warriors', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2738, import_key: 'l.ncaa.org.mfoot-t.962', entity_name: 'Bacone College', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.962', entity_name: 'Bacone College', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2739, import_key: 'l.ncaa.org.mfoot-t.954', entity_name: 'Bethel-TN Wildcats', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.954', entity_name: 'Bethel-TN Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2740, import_key: 'l.ncaa.org.mfoot-t.762', entity_name: 'Campbellsville', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.762', entity_name: 'Campbellsville', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2741, import_key: 'l.ncaa.org.mfoot-t.Y48', entity_name: 'Concordia (AL) Hornets', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y48', entity_name: 'Concordia (AL) Hornets', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2742, import_key: 'l.ncaa.org.mfoot-t.772', entity_name: 'Cumberland (TN) Bulldogs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.772', entity_name: 'Cumberland (TN) Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2743, import_key: 'l.ncaa.org.mfoot-t.844', entity_name: 'Cumberlands (KY) Patriots', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.844', entity_name: 'Cumberlands (KY) Patriots', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2744, import_key: 'l.ncaa.org.mfoot-t.832', entity_name: 'Edward Waters Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.832', entity_name: 'Edward Waters Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2745, import_key: 'l.ncaa.org.mfoot-t.Y09', entity_name: 'Geneva Golden Tornadoes', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y09', entity_name: 'Geneva Golden Tornadoes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2746, import_key: 'l.ncaa.org.mfoot-t.Y47', entity_name: 'Georgetown (KY)', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y47', entity_name: 'Georgetown (KY)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2747, import_key: 'l.ncaa.org.mfoot-t.798', entity_name: 'Lambuth Eagles', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.798', entity_name: 'Lambuth Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2748, import_key: 'l.ncaa.org.mfoot-t.754', entity_name: 'Langston', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.754', entity_name: 'Langston', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2749, import_key: 'l.ncaa.org.mfoot-t.Y65', entity_name: 'Marian (IN) Knights', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y65', entity_name: 'Marian (IN) Knights', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2750, import_key: 'l.ncaa.org.mfoot-t.Y14', entity_name: 'Minot State', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y14', entity_name: 'Minot State', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2751, import_key: 'l.ncaa.org.mfoot-t.752', entity_name: 'Montana Tech Orediggers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.752', entity_name: 'Montana Tech Orediggers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2752, import_key: 'l.ncaa.org.mfoot-t.825', entity_name: 'Montana-Western Bulldogs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.825', entity_name: 'Montana-Western Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2753, import_key: 'l.ncaa.org.mfoot-t.750', entity_name: 'Paul Quinn Tigers', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.750', entity_name: 'Paul Quinn Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2754, import_key: 'l.ncaa.org.mfoot-t.Y13', entity_name: 'Pikeville (KY) Bears', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y13', entity_name: 'Pikeville (KY) Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2755, import_key: 'l.ncaa.org.mfoot-t.731', entity_name: 'Quincy', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.731', entity_name: 'Quincy', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2756, import_key: 'l.ncaa.org.mfoot-t.838', entity_name: 'Southern Oregon Raiders', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.838', entity_name: 'Southern Oregon Raiders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2757, import_key: 'l.ncaa.org.mfoot-t.735', entity_name: 'St Ambrose', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.735', entity_name: 'St Ambrose', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2758, import_key: 'l.ncaa.org.mfoot-t.Y08', entity_name: 'St Francis (IL) Fighting Saints', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.Y08', entity_name: 'St Francis (IL) Fighting Saints', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2759, import_key: 'l.ncaa.org.mfoot-t.822', entity_name: 'SW Assemblies', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.822', entity_name: 'SW Assemblies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2760, import_key: 'l.ncaa.org.mfoot-t.852', entity_name: 'Texas College', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.852', entity_name: 'Texas College', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2761, import_key: 'l.ncaa.org.mfoot-t.823', entity_name: 'Trinity (IL) Trojans', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.823', entity_name: 'Trinity (IL) Trojans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2762, import_key: 'l.ncaa.org.mfoot-t.858', entity_name: 'Union (KY) Bulldogs', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.858', entity_name: 'Union (KY) Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2763, import_key: 'l.ncaa.org.mfoot-t.953', entity_name: 'Waldorf Warriors', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.953', entity_name: 'Waldorf Warriors', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2764, import_key: 'l.ncaa.org.mfoot-t.YB9', entity_name: 'Warner', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.YB9', entity_name: 'Warner', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2765, import_key: 'l.ncaa.org.mfoot-t.951', entity_name: 'William Penn Statesmen', status: 1, entity_type_id: 7
+    import_key: 'l.ncaa.org.mfoot-t.951', entity_name: 'William Penn Statesmen', status: 1, entity_type_id: entity_type_id
   }
 ])

--- a/db/seeds/008_ncaamb.rb
+++ b/db/seeds/008_ncaamb.rb
@@ -1,3390 +1,3391 @@
 # -*- coding: utf-8 -*-
+entity_type_id = EntityType.find_by_entity_type_abbreviation('NCAAMB').id
 Entity.create([
   {
-    id: 2766, import_key: 'l.ncaa.org.mbasket-t.A07', entity_name: 'Albany, N.Y. Great Danes', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A07', entity_name: 'Albany, N.Y. Great Danes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2767, import_key: 'l.ncaa.org.mbasket-t.A24', entity_name: 'Binghamton Bearcats', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A24', entity_name: 'Binghamton Bearcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2768, import_key: 'l.ncaa.org.mbasket-t.B09', entity_name: 'Hartford Hawks', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B09', entity_name: 'Hartford Hawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2769, import_key: 'l.ncaa.org.mbasket-t.B53', entity_name: 'Maine Black Bears', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B53', entity_name: 'Maine Black Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2770, import_key: 'l.ncaa.org.mbasket-t.B88', entity_name: 'New Hampshire Wildcats', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B88', entity_name: 'New Hampshire Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2771, import_key: 'l.ncaa.org.mbasket-t.C75', entity_name: 'Stony Brook Seawolves', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C75', entity_name: 'Stony Brook Seawolves', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2772, import_key: 'l.ncaa.org.mbasket-t.KH2', entity_name: 'UMass-Lowell River Hawks', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KH2', entity_name: 'UMass-Lowell River Hawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2773, import_key: 'l.ncaa.org.mbasket-t.B59', entity_name: 'UMBC Retrievers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B59', entity_name: 'UMBC Retrievers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2774, import_key: 'l.ncaa.org.mbasket-t.D03', entity_name: 'Vermont Catamounts', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D03', entity_name: 'Vermont Catamounts', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2775, import_key: 'l.ncaa.org.mbasket-t.A47', entity_name: 'Central Florida Knights', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A47', entity_name: 'Central Florida Knights', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2776, import_key: 'l.ncaa.org.mbasket-t.A54', entity_name: 'Cincinnati Bearcats', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A54', entity_name: 'Cincinnati Bearcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2777, import_key: 'l.ncaa.org.mbasket-t.A63', entity_name: 'Connecticut Huskies', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A63', entity_name: 'Connecticut Huskies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2778, import_key: 'l.ncaa.org.mbasket-t.B15', entity_name: 'Houston Cougars', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B15', entity_name: 'Houston Cougars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2779, import_key: 'l.ncaa.org.mbasket-t.B49', entity_name: 'Louisville Cardinals', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B49', entity_name: 'Louisville Cardinals', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2780, import_key: 'l.ncaa.org.mbasket-t.B63', entity_name: 'Memphis Tigers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B63', entity_name: 'Memphis Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2781, import_key: 'l.ncaa.org.mbasket-t.C37', entity_name: 'Rutgers Scarlet Knights', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C37', entity_name: 'Rutgers Scarlet Knights', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2782, import_key: 'l.ncaa.org.mbasket-t.C66', entity_name: 'SMU Mustangs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C66', entity_name: 'SMU Mustangs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2783, import_key: 'l.ncaa.org.mbasket-t.C61', entity_name: 'South Florida Bulls', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C61', entity_name: 'South Florida Bulls', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2784, import_key: 'l.ncaa.org.mbasket-t.C77', entity_name: 'Temple Owls', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C77', entity_name: 'Temple Owls', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2785, import_key: 'l.ncaa.org.mbasket-t.A69', entity_name: 'Dayton Flyers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A69', entity_name: 'Dayton Flyers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2786, import_key: 'l.ncaa.org.mbasket-t.A78', entity_name: 'Duquesne Dukes', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A78', entity_name: 'Duquesne Dukes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2787, import_key: 'l.ncaa.org.mbasket-t.A94', entity_name: 'Fordham Rams', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A94', entity_name: 'Fordham Rams', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2788, import_key: 'l.ncaa.org.mbasket-t.A98', entity_name: 'George Mason Patriots', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A98', entity_name: 'George Mason Patriots', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2789, import_key: 'l.ncaa.org.mbasket-t.A99', entity_name: 'George Washington Colonials', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A99', entity_name: 'George Washington Colonials', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2790, import_key: 'l.ncaa.org.mbasket-t.B37', entity_name: 'La Salle Explorers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B37', entity_name: 'La Salle Explorers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2791, import_key: 'l.ncaa.org.mbasket-t.C32', entity_name: 'Rhode Island Rams', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C32', entity_name: 'Rhode Island Rams', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2792, import_key: 'l.ncaa.org.mbasket-t.C34', entity_name: 'Richmond Spiders', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C34', entity_name: 'Richmond Spiders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2793, import_key: 'l.ncaa.org.mbasket-t.C45', entity_name: 'Saint Louis Billikens', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C45', entity_name: 'Saint Louis Billikens', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2794, import_key: 'l.ncaa.org.mbasket-t.C40', entity_name: 'St. Bonaventure Bonnies', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C40', entity_name: 'St. Bonaventure Bonnies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2795, import_key: 'l.ncaa.org.mbasket-t.C44', entity_name: 'St. Joseph\'s Hawks', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C44', entity_name: 'St. Joseph\'s Hawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2796, import_key: 'l.ncaa.org.mbasket-t.B61', entity_name: 'UMass Minutemen', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B61', entity_name: 'UMass Minutemen', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2797, import_key: 'l.ncaa.org.mbasket-t.D06', entity_name: 'Va. Commonwealth Rams', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D06', entity_name: 'Va. Commonwealth Rams', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2798, import_key: 'l.ncaa.org.mbasket-t.A27', entity_name: 'Boston College Eagles', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A27', entity_name: 'Boston College Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2799, import_key: 'l.ncaa.org.mbasket-t.A56', entity_name: 'Clemson Tigers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A56', entity_name: 'Clemson Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2800, import_key: 'l.ncaa.org.mbasket-t.A77', entity_name: 'Duke Blue Devils', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A77', entity_name: 'Duke Blue Devils', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2801, import_key: 'l.ncaa.org.mbasket-t.A93', entity_name: 'Florida St. Seminoles', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A93', entity_name: 'Florida St. Seminoles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2802, import_key: 'l.ncaa.org.mbasket-t.B05', entity_name: 'Georgia Tech Yellow Jackets', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B05', entity_name: 'Georgia Tech Yellow Jackets', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2803, import_key: 'l.ncaa.org.mbasket-t.B58', entity_name: 'Maryland Terrapins', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B58', entity_name: 'Maryland Terrapins', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2804, import_key: 'l.ncaa.org.mbasket-t.B65', entity_name: 'Miami Hurricanes', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B65', entity_name: 'Miami Hurricanes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2805, import_key: 'l.ncaa.org.mbasket-t.B99', entity_name: 'N.C. State Wolfpack', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B99', entity_name: 'N.C. State Wolfpack', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2806, import_key: 'l.ncaa.org.mbasket-t.B95', entity_name: 'North Carolina Tar Heels', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B95', entity_name: 'North Carolina Tar Heels', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2807, import_key: 'l.ncaa.org.mbasket-t.C09', entity_name: 'Notre Dame Fighting Irish', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C09', entity_name: 'Notre Dame Fighting Irish', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2808, import_key: 'l.ncaa.org.mbasket-t.C23', entity_name: 'Pittsburgh Panthers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C23', entity_name: 'Pittsburgh Panthers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2809, import_key: 'l.ncaa.org.mbasket-t.C76', entity_name: 'Syracuse Orange', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C76', entity_name: 'Syracuse Orange', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2810, import_key: 'l.ncaa.org.mbasket-t.D08', entity_name: 'Virginia Tech Hokies', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D08', entity_name: 'Virginia Tech Hokies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2811, import_key: 'l.ncaa.org.mbasket-t.D05', entity_name: 'Virginia Cavaliers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D05', entity_name: 'Virginia Cavaliers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2812, import_key: 'l.ncaa.org.mbasket-t.D10', entity_name: 'Wake Forest Demon Deacons', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D10', entity_name: 'Wake Forest Demon Deacons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2813, import_key: 'l.ncaa.org.mbasket-t.A80', entity_name: 'East Tennessee St. Buccaneers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A80', entity_name: 'East Tennessee St. Buccaneers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2814, import_key: 'l.ncaa.org.mbasket-t.F75', entity_name: 'Florida Gulf Coast Eagles', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F75', entity_name: 'Florida Gulf Coast Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2815, import_key: 'l.ncaa.org.mbasket-t.B30', entity_name: 'Jacksonville Dolphins', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B30', entity_name: 'Jacksonville Dolphins', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2816, import_key: 'l.ncaa.org.mbasket-t.E97', entity_name: 'Kennesaw St. Owls', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E97', entity_name: 'Kennesaw St. Owls', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2817, import_key: 'l.ncaa.org.mbasket-t.B42', entity_name: 'Lipscomb Bisons', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B42', entity_name: 'Lipscomb Bisons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2818, import_key: 'l.ncaa.org.mbasket-t.B64', entity_name: 'Mercer Bears', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B64', entity_name: 'Mercer Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2819, import_key: 'l.ncaa.org.mbasket-t.G22', entity_name: 'North Florida Ospreys', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G22', entity_name: 'North Florida Ospreys', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2820, import_key: 'l.ncaa.org.mbasket-t.I27', entity_name: 'Northern Kentucky Norse', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I27', entity_name: 'Northern Kentucky Norse', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2821, import_key: 'l.ncaa.org.mbasket-t.C74', entity_name: 'Stetson Hatters', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C74', entity_name: 'Stetson Hatters', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2822, import_key: 'l.ncaa.org.mbasket-t.E45', entity_name: 'USC Upstate Spartans', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E45', entity_name: 'USC Upstate Spartans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2823, import_key: 'l.ncaa.org.mbasket-t.A21', entity_name: 'Baylor Bears', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A21', entity_name: 'Baylor Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2824, import_key: 'l.ncaa.org.mbasket-t.B28', entity_name: 'Iowa St. Cyclones', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B28', entity_name: 'Iowa St. Cyclones', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2825, import_key: 'l.ncaa.org.mbasket-t.B34', entity_name: 'Kansas St. Wildcats', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B34', entity_name: 'Kansas St. Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2826, import_key: 'l.ncaa.org.mbasket-t.B33', entity_name: 'Kansas Jayhawks', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B33', entity_name: 'Kansas Jayhawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2827, import_key: 'l.ncaa.org.mbasket-t.C14', entity_name: 'Oklahoma St. Cowboys', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C14', entity_name: 'Oklahoma St. Cowboys', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2828, import_key: 'l.ncaa.org.mbasket-t.C13', entity_name: 'Oklahoma Sooners', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C13', entity_name: 'Oklahoma Sooners', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2829, import_key: 'l.ncaa.org.mbasket-t.C84', entity_name: 'TCU Horned Frogs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C84', entity_name: 'TCU Horned Frogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2830, import_key: 'l.ncaa.org.mbasket-t.C86', entity_name: 'Texas Tech Red Raiders', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C86', entity_name: 'Texas Tech Red Raiders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2831, import_key: 'l.ncaa.org.mbasket-t.C82', entity_name: 'Texas Longhorns', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C82', entity_name: 'Texas Longhorns', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2832, import_key: 'l.ncaa.org.mbasket-t.D14', entity_name: 'West Virginia Mountaineers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D14', entity_name: 'West Virginia Mountaineers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2833, import_key: 'l.ncaa.org.mbasket-t.A35', entity_name: 'Butler Bulldogs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A35', entity_name: 'Butler Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2834, import_key: 'l.ncaa.org.mbasket-t.A66', entity_name: 'Creighton Bluejays', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A66', entity_name: 'Creighton Bluejays', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2835, import_key: 'l.ncaa.org.mbasket-t.A73', entity_name: 'DePaul Blue Demons', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A73', entity_name: 'DePaul Blue Demons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2836, import_key: 'l.ncaa.org.mbasket-t.B01', entity_name: 'Georgetown Hoyas', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B01', entity_name: 'Georgetown Hoyas', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2837, import_key: 'l.ncaa.org.mbasket-t.B56', entity_name: 'Marquette Golden Eagles', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B56', entity_name: 'Marquette Golden Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2838, import_key: 'l.ncaa.org.mbasket-t.C28', entity_name: 'Providence Friars', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C28', entity_name: 'Providence Friars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2839, import_key: 'l.ncaa.org.mbasket-t.C56', entity_name: 'Seton Hall Pirates', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C56', entity_name: 'Seton Hall Pirates', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2840, import_key: 'l.ncaa.org.mbasket-t.C43', entity_name: 'St. John\'s Red Storm', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C43', entity_name: 'St. John\'s Red Storm', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2841, import_key: 'l.ncaa.org.mbasket-t.D04', entity_name: 'Villanova Wildcats', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D04', entity_name: 'Villanova Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2842, import_key: 'l.ncaa.org.mbasket-t.D28', entity_name: 'Xavier Musketeers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D28', entity_name: 'Xavier Musketeers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2843, import_key: 'l.ncaa.org.mbasket-t.A84', entity_name: 'Eastern Washington Eagles', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A84', entity_name: 'Eastern Washington Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2844, import_key: 'l.ncaa.org.mbasket-t.B18', entity_name: 'Idaho St. Bengals', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B18', entity_name: 'Idaho St. Bengals', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2845, import_key: 'l.ncaa.org.mbasket-t.B78', entity_name: 'Montana St. Bobcats', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B78', entity_name: 'Montana St. Bobcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2846, import_key: 'l.ncaa.org.mbasket-t.B77', entity_name: 'Montana Grizzlies', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B77', entity_name: 'Montana Grizzlies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2847, import_key: 'l.ncaa.org.mbasket-t.F01', entity_name: 'North Dakota', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F01', entity_name: 'North Dakota', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2848, import_key: 'l.ncaa.org.mbasket-t.C04', entity_name: 'Northern Arizona Lumberjacks', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C04', entity_name: 'Northern Arizona Lumberjacks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2849, import_key: 'l.ncaa.org.mbasket-t.E91', entity_name: 'Northern Colorado Bears', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E91', entity_name: 'Northern Colorado Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2850, import_key: 'l.ncaa.org.mbasket-t.C25', entity_name: 'Portland St. Vikings', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C25', entity_name: 'Portland St. Vikings', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2851, import_key: 'l.ncaa.org.mbasket-t.C38', entity_name: 'Sacramento St. Hornets', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C38', entity_name: 'Sacramento St. Hornets', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2852, import_key: 'l.ncaa.org.mbasket-t.C69', entity_name: 'Southern Utah Thunderbirds', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C69', entity_name: 'Southern Utah Thunderbirds', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2853, import_key: 'l.ncaa.org.mbasket-t.D13', entity_name: 'Weber St. Wildcats', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D13', entity_name: 'Weber St. Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2854, import_key: 'l.ncaa.org.mbasket-t.A43', entity_name: 'Campbell Fighting Camels', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A43', entity_name: 'Campbell Fighting Camels', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2855, import_key: 'l.ncaa.org.mbasket-t.B12', entity_name: 'High Point Panthers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B12', entity_name: 'High Point Panthers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2856, import_key: 'l.ncaa.org.mbasket-t.B41', entity_name: 'Liberty Flames', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B41', entity_name: 'Liberty Flames', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2857, import_key: 'l.ncaa.org.mbasket-t.G89', entity_name: 'Longwood Lancers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G89', entity_name: 'Longwood Lancers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2858, import_key: 'l.ncaa.org.mbasket-t.C31', entity_name: 'Radford Highlanders', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C31', entity_name: 'Radford Highlanders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2859, import_key: 'l.ncaa.org.mbasket-t.D07', entity_name: 'Virginia Military Keydets', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D07', entity_name: 'Virginia Military Keydets', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2860, import_key: 'l.ncaa.org.mbasket-t.A50', entity_name: 'Charleston Southern Buccaneers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A50', entity_name: 'Charleston Southern Buccaneers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2861, import_key: 'l.ncaa.org.mbasket-t.A58', entity_name: 'Coastal Carolina Chanticleers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A58', entity_name: 'Coastal Carolina Chanticleers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2862, import_key: 'l.ncaa.org.mbasket-t.A97', entity_name: 'Gardner-Webb Bulldogs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A97', entity_name: 'Gardner-Webb Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2863, import_key: 'l.ncaa.org.mbasket-t.I67', entity_name: 'Presbyterian Blue Hose', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I67', entity_name: 'Presbyterian Blue Hose', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2864, import_key: 'l.ncaa.org.mbasket-t.B97', entity_name: 'UNC-Asheville Bulldogs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B97', entity_name: 'UNC-Asheville Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2865, import_key: 'l.ncaa.org.mbasket-t.D21', entity_name: 'Winthrop Eagles', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D21', entity_name: 'Winthrop Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2866, import_key: 'l.ncaa.org.mbasket-t.B19', entity_name: 'Illinois Fighting Illini', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B19', entity_name: 'Illinois Fighting Illini', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2867, import_key: 'l.ncaa.org.mbasket-t.B22', entity_name: 'Indiana Hoosiers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B22', entity_name: 'Indiana Hoosiers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2868, import_key: 'l.ncaa.org.mbasket-t.B27', entity_name: 'Iowa Hawkeyes', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B27', entity_name: 'Iowa Hawkeyes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2869, import_key: 'l.ncaa.org.mbasket-t.B68', entity_name: 'Michigan St. Spartans', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B68', entity_name: 'Michigan St. Spartans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2870, import_key: 'l.ncaa.org.mbasket-t.B67', entity_name: 'Michigan Wolverines', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B67', entity_name: 'Michigan Wolverines', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2871, import_key: 'l.ncaa.org.mbasket-t.B70', entity_name: 'Minnesota Golden Gophers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B70', entity_name: 'Minnesota Golden Gophers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2872, import_key: 'l.ncaa.org.mbasket-t.B85', entity_name: 'Nebraska Cornhuskers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B85', entity_name: 'Nebraska Cornhuskers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2873, import_key: 'l.ncaa.org.mbasket-t.C07', entity_name: 'Northwestern Wildcats', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C07', entity_name: 'Northwestern Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2874, import_key: 'l.ncaa.org.mbasket-t.C12', entity_name: 'Ohio St. Buckeyes', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C12', entity_name: 'Ohio St. Buckeyes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2875, import_key: 'l.ncaa.org.mbasket-t.C21', entity_name: 'Penn St. Nittany Lions', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C21', entity_name: 'Penn St. Nittany Lions', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2876, import_key: 'l.ncaa.org.mbasket-t.C29', entity_name: 'Purdue Boilermakers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C29', entity_name: 'Purdue Boilermakers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2877, import_key: 'l.ncaa.org.mbasket-t.D22', entity_name: 'Wisconsin Badgers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D22', entity_name: 'Wisconsin Badgers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2878, import_key: 'l.ncaa.org.mbasket-t.A40', entity_name: 'Cal Poly-SLO Mustangs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A40', entity_name: 'Cal Poly-SLO Mustangs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2879, import_key: 'l.ncaa.org.mbasket-t.A41', entity_name: 'Cal. St.-Fullerton Titans', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A41', entity_name: 'Cal. St.-Fullerton Titans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2880, import_key: 'l.ncaa.org.mbasket-t.A42', entity_name: 'Cal. St.-Northridge Matadors', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A42', entity_name: 'Cal. St.-Northridge Matadors', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2881, import_key: 'l.ncaa.org.mbasket-t.B11', entity_name: 'Hawaii Warriors', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B11', entity_name: 'Hawaii Warriors', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2882, import_key: 'l.ncaa.org.mbasket-t.B43', entity_name: 'Long Beach St. 49ers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B43', entity_name: 'Long Beach St. 49ers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2883, import_key: 'l.ncaa.org.mbasket-t.E64', entity_name: 'UC Davis Aggies', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E64', entity_name: 'UC Davis Aggies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2884, import_key: 'l.ncaa.org.mbasket-t.A37', entity_name: 'UC Irvine Anteaters', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A37', entity_name: 'UC Irvine Anteaters', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2885, import_key: 'l.ncaa.org.mbasket-t.A38', entity_name: 'UC Riverside Highlanders', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A38', entity_name: 'UC Riverside Highlanders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2886, import_key: 'l.ncaa.org.mbasket-t.A39', entity_name: 'UC Santa Barbara Gauchos', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A39', entity_name: 'UC Santa Barbara Gauchos', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2887, import_key: 'l.ncaa.org.mbasket-t.A49', entity_name: 'Charleston Cougars', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A49', entity_name: 'Charleston Cougars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2888, import_key: 'l.ncaa.org.mbasket-t.A70', entity_name: 'Delaware Blue Hens', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A70', entity_name: 'Delaware Blue Hens', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2889, import_key: 'l.ncaa.org.mbasket-t.A76', entity_name: 'Drexel Dragons', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A76', entity_name: 'Drexel Dragons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2890, import_key: 'l.ncaa.org.mbasket-t.B13', entity_name: 'Hofstra Pride', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B13', entity_name: 'Hofstra Pride', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2891, import_key: 'l.ncaa.org.mbasket-t.B32', entity_name: 'James Madison Dukes', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B32', entity_name: 'James Madison Dukes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2892, import_key: 'l.ncaa.org.mbasket-t.C03', entity_name: 'Northeastern Huskies', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C03', entity_name: 'Northeastern Huskies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2893, import_key: 'l.ncaa.org.mbasket-t.C93', entity_name: 'Towson Tigers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C93', entity_name: 'Towson Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2894, import_key: 'l.ncaa.org.mbasket-t.C01', entity_name: 'UNC-Wilmington Seahawks', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C01', entity_name: 'UNC-Wilmington Seahawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2895, import_key: 'l.ncaa.org.mbasket-t.D20', entity_name: 'William & Mary Tribe', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D20', entity_name: 'William & Mary Tribe', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2896, import_key: 'l.ncaa.org.mbasket-t.A51', entity_name: 'Charlotte 49ers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A51', entity_name: 'Charlotte 49ers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2897, import_key: 'l.ncaa.org.mbasket-t.A79', entity_name: 'East Carolina Pirates', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A79', entity_name: 'East Carolina Pirates', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2898, import_key: 'l.ncaa.org.mbasket-t.A92', entity_name: 'Fla. International Golden Panthers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A92', entity_name: 'Fla. International Golden Panthers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2899, import_key: 'l.ncaa.org.mbasket-t.A91', entity_name: 'Florida Atlantic Owls', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A91', entity_name: 'Florida Atlantic Owls', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2900, import_key: 'l.ncaa.org.mbasket-t.B46', entity_name: 'Louisiana Tech Bulldogs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B46', entity_name: 'Louisiana Tech Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2901, import_key: 'l.ncaa.org.mbasket-t.B57', entity_name: 'Marshall Thundering Herd', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B57', entity_name: 'Marshall Thundering Herd', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2902, import_key: 'l.ncaa.org.mbasket-t.B69', entity_name: 'Middle Tenn. St. Blue Raiders', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B69', entity_name: 'Middle Tenn. St. Blue Raiders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2903, import_key: 'l.ncaa.org.mbasket-t.C02', entity_name: 'North Texas Mean Green', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C02', entity_name: 'North Texas Mean Green', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2904, import_key: 'l.ncaa.org.mbasket-t.C15', entity_name: 'Old Dominion Monarchs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C15', entity_name: 'Old Dominion Monarchs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2905, import_key: 'l.ncaa.org.mbasket-t.C33', entity_name: 'Rice Owls', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C33', entity_name: 'Rice Owls', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2906, import_key: 'l.ncaa.org.mbasket-t.C67', entity_name: 'Southern Miss. Golden Eagles', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C67', entity_name: 'Southern Miss. Golden Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2907, import_key: 'l.ncaa.org.mbasket-t.C91', entity_name: 'Texas-San Antonio Roadrunners', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C91', entity_name: 'Texas-San Antonio Roadrunners', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2908, import_key: 'l.ncaa.org.mbasket-t.C95', entity_name: 'Tulane Green Wave', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C95', entity_name: 'Tulane Green Wave', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2909, import_key: 'l.ncaa.org.mbasket-t.C96', entity_name: 'Tulsa Golden Hurricane', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C96', entity_name: 'Tulsa Golden Hurricane', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2910, import_key: 'l.ncaa.org.mbasket-t.A06', entity_name: 'UAB Blazers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A06', entity_name: 'UAB Blazers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2911, import_key: 'l.ncaa.org.mbasket-t.C89', entity_name: 'UTEP Miners', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C89', entity_name: 'UTEP Miners', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2912, import_key: 'l.ncaa.org.mbasket-t.I45', entity_name: 'NJIT Highlanders', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I45', entity_name: 'NJIT Highlanders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2913, import_key: 'l.ncaa.org.mbasket-t.A57', entity_name: 'Cleveland St. Vikings', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A57', entity_name: 'Cleveland St. Vikings', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2914, import_key: 'l.ncaa.org.mbasket-t.A74', entity_name: 'Detroit Titans', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A74', entity_name: 'Detroit Titans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2915, import_key: 'l.ncaa.org.mbasket-t.B21', entity_name: 'Ill.-Chicago Flames', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B21', entity_name: 'Ill.-Chicago Flames', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2916, import_key: 'l.ncaa.org.mbasket-t.C10', entity_name: 'Oakland, Mich. Golden Grizzlies', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C10', entity_name: 'Oakland, Mich. Golden Grizzlies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2917, import_key: 'l.ncaa.org.mbasket-t.D01', entity_name: 'Valparaiso Crusaders', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D01', entity_name: 'Valparaiso Crusaders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2918, import_key: 'l.ncaa.org.mbasket-t.D23', entity_name: 'Wis.-Green Bay Phoenix', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D23', entity_name: 'Wis.-Green Bay Phoenix', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2919, import_key: 'l.ncaa.org.mbasket-t.D24', entity_name: 'Wis.-Milwaukee Panthers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D24', entity_name: 'Wis.-Milwaukee Panthers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2920, import_key: 'l.ncaa.org.mbasket-t.D26', entity_name: 'Wright St. Raiders', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D26', entity_name: 'Wright St. Raiders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2921, import_key: 'l.ncaa.org.mbasket-t.D30', entity_name: 'Youngstown St. Penguins', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D30', entity_name: 'Youngstown St. Penguins', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2922, import_key: 'l.ncaa.org.mbasket-t.A32', entity_name: 'Brown Bears', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A32', entity_name: 'Brown Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2923, import_key: 'l.ncaa.org.mbasket-t.A62', entity_name: 'Columbia Lions', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A62', entity_name: 'Columbia Lions', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2924, import_key: 'l.ncaa.org.mbasket-t.A65', entity_name: 'Cornell Big Red', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A65', entity_name: 'Cornell Big Red', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2925, import_key: 'l.ncaa.org.mbasket-t.A67', entity_name: 'Dartmouth Big Green', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A67', entity_name: 'Dartmouth Big Green', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2926, import_key: 'l.ncaa.org.mbasket-t.B10', entity_name: 'Harvard Crimson', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B10', entity_name: 'Harvard Crimson', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2927, import_key: 'l.ncaa.org.mbasket-t.C20', entity_name: 'Penn Quakers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C20', entity_name: 'Penn Quakers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2928, import_key: 'l.ncaa.org.mbasket-t.C27', entity_name: 'Princeton Tigers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C27', entity_name: 'Princeton Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2929, import_key: 'l.ncaa.org.mbasket-t.D29', entity_name: 'Yale Bulldogs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D29', entity_name: 'Yale Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2930, import_key: 'l.ncaa.org.mbasket-t.A44', entity_name: 'Canisius Golden Griffins', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A44', entity_name: 'Canisius Golden Griffins', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2931, import_key: 'l.ncaa.org.mbasket-t.A87', entity_name: 'Fairfield Stags', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A87', entity_name: 'Fairfield Stags', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2932, import_key: 'l.ncaa.org.mbasket-t.B26', entity_name: 'Iona Gaels', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B26', entity_name: 'Iona Gaels', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2933, import_key: 'l.ncaa.org.mbasket-t.B54', entity_name: 'Manhattan Jaspers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B54', entity_name: 'Manhattan Jaspers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2934, import_key: 'l.ncaa.org.mbasket-t.B55', entity_name: 'Marist Red Foxes', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B55', entity_name: 'Marist Red Foxes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2935, import_key: 'l.ncaa.org.mbasket-t.B76', entity_name: 'Monmouth Hawks', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B76', entity_name: 'Monmouth Hawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2936, import_key: 'l.ncaa.org.mbasket-t.B92', entity_name: 'Niagara Purple Eagles', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B92', entity_name: 'Niagara Purple Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2937, import_key: 'l.ncaa.org.mbasket-t.C30', entity_name: 'Quinnipiac Bobcats', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C30', entity_name: 'Quinnipiac Bobcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2938, import_key: 'l.ncaa.org.mbasket-t.C35', entity_name: 'Rider Broncs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C35', entity_name: 'Rider Broncs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2939, import_key: 'l.ncaa.org.mbasket-t.C57', entity_name: 'Siena Saints', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C57', entity_name: 'Siena Saints', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2940, import_key: 'l.ncaa.org.mbasket-t.C47', entity_name: 'St. Peter\'s Peacocks', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C47', entity_name: 'St. Peter\'s Peacocks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2941, import_key: 'l.ncaa.org.mbasket-t.A02', entity_name: 'Akron Zips', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A02', entity_name: 'Akron Zips', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2942, import_key: 'l.ncaa.org.mbasket-t.A29', entity_name: 'Bowling Green Falcons', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A29', entity_name: 'Bowling Green Falcons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2943, import_key: 'l.ncaa.org.mbasket-t.A34', entity_name: 'Buffalo Bulls', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A34', entity_name: 'Buffalo Bulls', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2944, import_key: 'l.ncaa.org.mbasket-t.B35', entity_name: 'Kent St. Golden Flashes', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B35', entity_name: 'Kent St. Golden Flashes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2945, import_key: 'l.ncaa.org.mbasket-t.B66', entity_name: 'Miami (Ohio) RedHawks', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B66', entity_name: 'Miami (Ohio) RedHawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2946, import_key: 'l.ncaa.org.mbasket-t.C11', entity_name: 'Ohio Bobcats', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C11', entity_name: 'Ohio Bobcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2947, import_key: 'l.ncaa.org.mbasket-t.A20', entity_name: 'Ball St. Cardinals', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A20', entity_name: 'Ball St. Cardinals', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2948, import_key: 'l.ncaa.org.mbasket-t.A48', entity_name: 'Central Michigan Chippewas', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A48', entity_name: 'Central Michigan Chippewas', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2949, import_key: 'l.ncaa.org.mbasket-t.A83', entity_name: 'Eastern Michigan Eagles', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A83', entity_name: 'Eastern Michigan Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2950, import_key: 'l.ncaa.org.mbasket-t.C05', entity_name: 'Northern Illinois Huskies', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C05', entity_name: 'Northern Illinois Huskies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2951, import_key: 'l.ncaa.org.mbasket-t.C92', entity_name: 'Toledo Rockets', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C92', entity_name: 'Toledo Rockets', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2952, import_key: 'l.ncaa.org.mbasket-t.D18', entity_name: 'Western Michigan Broncos', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D18', entity_name: 'Western Michigan Broncos', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2953, import_key: 'l.ncaa.org.mbasket-t.A23', entity_name: 'Bethune-Cookman Wildcats', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A23', entity_name: 'Bethune-Cookman Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2954, import_key: 'l.ncaa.org.mbasket-t.A64', entity_name: 'Coppin St. Eagles', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A64', entity_name: 'Coppin St. Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2955, import_key: 'l.ncaa.org.mbasket-t.A71', entity_name: 'Delaware St. Hornets', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A71', entity_name: 'Delaware St. Hornets', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2956, import_key: 'l.ncaa.org.mbasket-t.A90', entity_name: 'Florida A&M Rattlers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A90', entity_name: 'Florida A&M Rattlers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2957, import_key: 'l.ncaa.org.mbasket-t.B08', entity_name: 'Hampton Pirates', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B08', entity_name: 'Hampton Pirates', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2958, import_key: 'l.ncaa.org.mbasket-t.B16', entity_name: 'Howard Bisons', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B16', entity_name: 'Howard Bisons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2959, import_key: 'l.ncaa.org.mbasket-t.B60', entity_name: 'Md.-Eastern Shore Hawks', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B60', entity_name: 'Md.-Eastern Shore Hawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2960, import_key: 'l.ncaa.org.mbasket-t.B80', entity_name: 'Morgan St. Bears', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B80', entity_name: 'Morgan St. Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2961, import_key: 'l.ncaa.org.mbasket-t.B96', entity_name: 'N.C. A&T Aggies', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B96', entity_name: 'N.C. A&T Aggies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2962, import_key: 'l.ncaa.org.mbasket-t.E17', entity_name: 'N.C. Central Eagles', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E17', entity_name: 'N.C. Central Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2963, import_key: 'l.ncaa.org.mbasket-t.B94', entity_name: 'Norfolk St. Spartans', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B94', entity_name: 'Norfolk St. Spartans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2964, import_key: 'l.ncaa.org.mbasket-t.C60', entity_name: 'S. Carolina St. Bulldogs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C60', entity_name: 'S. Carolina St. Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2965, import_key: 'l.ncaa.org.mbasket-t.C55', entity_name: 'Savannah St. Tigers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C55', entity_name: 'Savannah St. Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2966, import_key: 'l.ncaa.org.mbasket-t.A30', entity_name: 'Bradley Braves', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A30', entity_name: 'Bradley Braves', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2967, import_key: 'l.ncaa.org.mbasket-t.A75', entity_name: 'Drake Bulldogs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A75', entity_name: 'Drake Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2968, import_key: 'l.ncaa.org.mbasket-t.A86', entity_name: 'Evansville Aces', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A86', entity_name: 'Evansville Aces', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2969, import_key: 'l.ncaa.org.mbasket-t.B20', entity_name: 'Illinois St. Redbirds', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B20', entity_name: 'Illinois St. Redbirds', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2970, import_key: 'l.ncaa.org.mbasket-t.B23', entity_name: 'Indiana St. Sycamores', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B23', entity_name: 'Indiana St. Sycamores', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2971, import_key: 'l.ncaa.org.mbasket-t.B51', entity_name: 'Loyola of Chicago Rambers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B51', entity_name: 'Loyola of Chicago Rambers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2972, import_key: 'l.ncaa.org.mbasket-t.C70', entity_name: 'Missouri St Bears', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C70', entity_name: 'Missouri St Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2973, import_key: 'l.ncaa.org.mbasket-t.C06', entity_name: 'Northern Iowa Panthers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C06', entity_name: 'Northern Iowa Panthers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2974, import_key: 'l.ncaa.org.mbasket-t.C65', entity_name: 'Southern Illinois Salukis', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C65', entity_name: 'Southern Illinois Salukis', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2975, import_key: 'l.ncaa.org.mbasket-t.D19', entity_name: 'Wichita St. Shockers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D19', entity_name: 'Wichita St. Shockers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2976, import_key: 'l.ncaa.org.mbasket-t.A01', entity_name: 'Air Force Falcons', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A01', entity_name: 'Air Force Falcons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2977, import_key: 'l.ncaa.org.mbasket-t.A26', entity_name: 'Boise St. Broncos', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A26', entity_name: 'Boise St. Broncos', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2978, import_key: 'l.ncaa.org.mbasket-t.A61', entity_name: 'Colorado St. Rams', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A61', entity_name: 'Colorado St. Rams', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2979, import_key: 'l.ncaa.org.mbasket-t.A95', entity_name: 'Fresno St. Bulldogs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A95', entity_name: 'Fresno St. Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2980, import_key: 'l.ncaa.org.mbasket-t.B86', entity_name: 'Nevada Wolf Pack', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B86', entity_name: 'Nevada Wolf Pack', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2981, import_key: 'l.ncaa.org.mbasket-t.B89', entity_name: 'New Mexico Lobos', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B89', entity_name: 'New Mexico Lobos', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2982, import_key: 'l.ncaa.org.mbasket-t.C51', entity_name: 'San Diego St. Aztecs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C51', entity_name: 'San Diego St. Aztecs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2983, import_key: 'l.ncaa.org.mbasket-t.C53', entity_name: 'San Jose St. Spartans', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C53', entity_name: 'San Jose St. Spartans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2984, import_key: 'l.ncaa.org.mbasket-t.B87', entity_name: 'UNLV Runnin\' Rebels', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B87', entity_name: 'UNLV Runnin\' Rebels', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2985, import_key: 'l.ncaa.org.mbasket-t.C99', entity_name: 'Utah State Aggies', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C99', entity_name: 'Utah State Aggies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2986, import_key: 'l.ncaa.org.mbasket-t.D27', entity_name: 'Wyoming Cowboys', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D27', entity_name: 'Wyoming Cowboys', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2987, import_key: 'l.ncaa.org.mbasket-t.JL9', entity_name: 'Bryant Bulldogs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JL9', entity_name: 'Bryant Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2988, import_key: 'l.ncaa.org.mbasket-t.A46', entity_name: 'Cent. Connecticut St. Blue Devils', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A46', entity_name: 'Cent. Connecticut St. Blue Devils', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2989, import_key: 'l.ncaa.org.mbasket-t.A88', entity_name: 'Fairleigh Dickinson Knights', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A88', entity_name: 'Fairleigh Dickinson Knights', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2990, import_key: 'l.ncaa.org.mbasket-t.B44', entity_name: 'Long Island U. Blackbirds', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B44', entity_name: 'Long Island U. Blackbirds', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2991, import_key: 'l.ncaa.org.mbasket-t.B82', entity_name: 'Mount St. Mary\'s, Md. Mountaineers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B82', entity_name: 'Mount St. Mary\'s, Md. Mountaineers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2992, import_key: 'l.ncaa.org.mbasket-t.C36', entity_name: 'Robert Morris Colonials', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C36', entity_name: 'Robert Morris Colonials', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2993, import_key: 'l.ncaa.org.mbasket-t.C39', entity_name: 'Sacred Heart Pioneers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C39', entity_name: 'Sacred Heart Pioneers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2994, import_key: 'l.ncaa.org.mbasket-t.C41', entity_name: 'St. Francis, NY Terriers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C41', entity_name: 'St. Francis, NY Terriers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2995, import_key: 'l.ncaa.org.mbasket-t.C42', entity_name: 'St. Francis, Pa. Red Flash', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C42', entity_name: 'St. Francis, Pa. Red Flash', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2996, import_key: 'l.ncaa.org.mbasket-t.D09', entity_name: 'Wagner Seahawks', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D09', entity_name: 'Wagner Seahawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2997, import_key: 'l.ncaa.org.mbasket-t.A22', entity_name: 'Belmont Bruins', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A22', entity_name: 'Belmont Bruins', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2998, import_key: 'l.ncaa.org.mbasket-t.A82', entity_name: 'Eastern Kentucky Colonels', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A82', entity_name: 'Eastern Kentucky Colonels', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 2999, import_key: 'l.ncaa.org.mbasket-t.B31', entity_name: 'Jacksonville St. Gamecocks', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B31', entity_name: 'Jacksonville St. Gamecocks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3000, import_key: 'l.ncaa.org.mbasket-t.B79', entity_name: 'Morehead St. Eagles', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B79', entity_name: 'Morehead St. Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3001, import_key: 'l.ncaa.org.mbasket-t.C80', entity_name: 'Tennessee St. Tigers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C80', entity_name: 'Tennessee St. Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3002, import_key: 'l.ncaa.org.mbasket-t.C81', entity_name: 'Tennessee Tech Golden Eagles', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C81', entity_name: 'Tennessee Tech Golden Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3003, import_key: 'l.ncaa.org.mbasket-t.A19', entity_name: 'Austin Peay Governors', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A19', entity_name: 'Austin Peay Governors', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3004, import_key: 'l.ncaa.org.mbasket-t.A81', entity_name: 'Eastern Illinois Panthers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A81', entity_name: 'Eastern Illinois Panthers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3005, import_key: 'l.ncaa.org.mbasket-t.B83', entity_name: 'Murray St. Racers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B83', entity_name: 'Murray St. Racers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3006, import_key: 'l.ncaa.org.mbasket-t.C62', entity_name: 'SE Missouri St. Indians', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C62', entity_name: 'SE Missouri St. Indians', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3007, import_key: 'l.ncaa.org.mbasket-t.G01', entity_name: 'SIU-Edwardsville Cougars', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G01', entity_name: 'SIU-Edwardsville Cougars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3008, import_key: 'l.ncaa.org.mbasket-t.C79', entity_name: 'Tennessee-Martin Skyhawks', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C79', entity_name: 'Tennessee-Martin Skyhawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3009, import_key: 'l.ncaa.org.mbasket-t.A12', entity_name: 'Arizona St. Sun Devils', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A12', entity_name: 'Arizona St. Sun Devils', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3010, import_key: 'l.ncaa.org.mbasket-t.A11', entity_name: 'Arizona Wildcats', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A11', entity_name: 'Arizona Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3011, import_key: 'l.ncaa.org.mbasket-t.A36', entity_name: 'California Golden Bears', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A36', entity_name: 'California Golden Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3012, import_key: 'l.ncaa.org.mbasket-t.A60', entity_name: 'Colorado Buffaloes', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A60', entity_name: 'Colorado Buffaloes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3013, import_key: 'l.ncaa.org.mbasket-t.C18', entity_name: 'Oregon St. Beavers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C18', entity_name: 'Oregon St. Beavers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3014, import_key: 'l.ncaa.org.mbasket-t.C17', entity_name: 'Oregon Ducks', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C17', entity_name: 'Oregon Ducks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3015, import_key: 'l.ncaa.org.mbasket-t.C72', entity_name: 'Stanford Cardinal', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C72', entity_name: 'Stanford Cardinal', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3016, import_key: 'l.ncaa.org.mbasket-t.C97', entity_name: 'UCLA Bruins', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C97', entity_name: 'UCLA Bruins', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3017, import_key: 'l.ncaa.org.mbasket-t.C64', entity_name: 'USC Trojans', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C64', entity_name: 'USC Trojans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3018, import_key: 'l.ncaa.org.mbasket-t.C98', entity_name: 'Utah Utes', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C98', entity_name: 'Utah Utes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3019, import_key: 'l.ncaa.org.mbasket-t.D12', entity_name: 'Washington St. Cougars', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D12', entity_name: 'Washington St. Cougars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3020, import_key: 'l.ncaa.org.mbasket-t.D11', entity_name: 'Washington Huskies', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D11', entity_name: 'Washington Huskies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3021, import_key: 'l.ncaa.org.mbasket-t.A09', entity_name: 'American U. Eagles', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A09', entity_name: 'American U. Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3022, import_key: 'l.ncaa.org.mbasket-t.A17', entity_name: 'Army Black Knights', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A17', entity_name: 'Army Black Knights', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3023, import_key: 'l.ncaa.org.mbasket-t.A28', entity_name: 'Boston U. Terriers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A28', entity_name: 'Boston U. Terriers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3024, import_key: 'l.ncaa.org.mbasket-t.A33', entity_name: 'Bucknell Bison', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A33', entity_name: 'Bucknell Bison', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3025, import_key: 'l.ncaa.org.mbasket-t.A59', entity_name: 'Colgate Red Raiders', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A59', entity_name: 'Colgate Red Raiders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3026, import_key: 'l.ncaa.org.mbasket-t.B14', entity_name: 'Holy Cross Crusaders', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B14', entity_name: 'Holy Cross Crusaders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3027, import_key: 'l.ncaa.org.mbasket-t.B38', entity_name: 'Lafayette Leopards', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B38', entity_name: 'Lafayette Leopards', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3028, import_key: 'l.ncaa.org.mbasket-t.B40', entity_name: 'Lehigh Mountain Hawks', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B40', entity_name: 'Lehigh Mountain Hawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3029, import_key: 'l.ncaa.org.mbasket-t.B52', entity_name: 'Loyola, Md. Greyhounds', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B52', entity_name: 'Loyola, Md. Greyhounds', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3030, import_key: 'l.ncaa.org.mbasket-t.B84', entity_name: 'Navy Midshipmen', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B84', entity_name: 'Navy Midshipmen', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3031, import_key: 'l.ncaa.org.mbasket-t.A03', entity_name: 'Alabama Crimson Tide', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A03', entity_name: 'Alabama Crimson Tide', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3032, import_key: 'l.ncaa.org.mbasket-t.A13', entity_name: 'Arkansas Razorbacks', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A13', entity_name: 'Arkansas Razorbacks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3033, import_key: 'l.ncaa.org.mbasket-t.A18', entity_name: 'Auburn Tigers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A18', entity_name: 'Auburn Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3034, import_key: 'l.ncaa.org.mbasket-t.A89', entity_name: 'Florida Gators', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A89', entity_name: 'Florida Gators', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3035, import_key: 'l.ncaa.org.mbasket-t.B02', entity_name: 'Georgia Bulldogs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B02', entity_name: 'Georgia Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3036, import_key: 'l.ncaa.org.mbasket-t.B36', entity_name: 'Kentucky Wildcats', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B36', entity_name: 'Kentucky Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3037, import_key: 'l.ncaa.org.mbasket-t.B45', entity_name: 'LSU Tigers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B45', entity_name: 'LSU Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3038, import_key: 'l.ncaa.org.mbasket-t.B72', entity_name: 'Mississippi St. Bulldogs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B72', entity_name: 'Mississippi St. Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3039, import_key: 'l.ncaa.org.mbasket-t.B71', entity_name: 'Mississippi Rebels', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B71', entity_name: 'Mississippi Rebels', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3040, import_key: 'l.ncaa.org.mbasket-t.B74', entity_name: 'Missouri Tigers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B74', entity_name: 'Missouri Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3041, import_key: 'l.ncaa.org.mbasket-t.C59', entity_name: 'South Carolina Gamecocks', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C59', entity_name: 'South Carolina Gamecocks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3042, import_key: 'l.ncaa.org.mbasket-t.C78', entity_name: 'Tennessee Volunteers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C78', entity_name: 'Tennessee Volunteers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3043, import_key: 'l.ncaa.org.mbasket-t.C83', entity_name: 'Texas A&M Aggies', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C83', entity_name: 'Texas A&M Aggies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3044, import_key: 'l.ncaa.org.mbasket-t.D02', entity_name: 'Vanderbilt Commodores', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D02', entity_name: 'Vanderbilt Commodores', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3045, import_key: 'l.ncaa.org.mbasket-t.A10', entity_name: 'Appalachian St. Mountaineers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A10', entity_name: 'Appalachian St. Mountaineers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3046, import_key: 'l.ncaa.org.mbasket-t.A52', entity_name: 'Chattanooga Mocs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A52', entity_name: 'Chattanooga Mocs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3047, import_key: 'l.ncaa.org.mbasket-t.A85', entity_name: 'Elon Phoenix', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A85', entity_name: 'Elon Phoenix', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3048, import_key: 'l.ncaa.org.mbasket-t.C49', entity_name: 'Samford Bulldogs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C49', entity_name: 'Samford Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3049, import_key: 'l.ncaa.org.mbasket-t.B98', entity_name: 'UNC Greensboro Spartans', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B98', entity_name: 'UNC Greensboro Spartans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3050, import_key: 'l.ncaa.org.mbasket-t.D15', entity_name: 'Western Carolina Catamounts', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D15', entity_name: 'Western Carolina Catamounts', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3051, import_key: 'l.ncaa.org.mbasket-t.A68', entity_name: 'Davidson Wildcats', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A68', entity_name: 'Davidson Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3052, import_key: 'l.ncaa.org.mbasket-t.A96', entity_name: 'Furman Paladins', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A96', entity_name: 'Furman Paladins', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3053, import_key: 'l.ncaa.org.mbasket-t.B03', entity_name: 'Georgia Southern Eagles', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B03', entity_name: 'Georgia Southern Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3054, import_key: 'l.ncaa.org.mbasket-t.A55', entity_name: 'The Citadel Bulldogs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A55', entity_name: 'The Citadel Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3055, import_key: 'l.ncaa.org.mbasket-t.D25', entity_name: 'Wofford Terriers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D25', entity_name: 'Wofford Terriers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3056, import_key: 'l.ncaa.org.mbasket-t.G81', entity_name: 'Abilene Christian Wildcats', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G81', entity_name: 'Abilene Christian Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3057, import_key: 'l.ncaa.org.mbasket-t.D56', entity_name: 'Central Arkansas Bears', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D56', entity_name: 'Central Arkansas Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3058, import_key: 'l.ncaa.org.mbasket-t.G79', entity_name: 'Houston Baptist Huskies', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G79', entity_name: 'Houston Baptist Huskies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3059, import_key: 'l.ncaa.org.mbasket-t.I72', entity_name: 'Incarnate Word Cardinals', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I72', entity_name: 'Incarnate Word Cardinals', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3060, import_key: 'l.ncaa.org.mbasket-t.B39', entity_name: 'Lamar Cardinals', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B39', entity_name: 'Lamar Cardinals', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3061, import_key: 'l.ncaa.org.mbasket-t.B62', entity_name: 'McNeese St. Cowboys', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B62', entity_name: 'McNeese St. Cowboys', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3062, import_key: 'l.ncaa.org.mbasket-t.B91', entity_name: 'New Orleans Privateers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B91', entity_name: 'New Orleans Privateers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3063, import_key: 'l.ncaa.org.mbasket-t.B93', entity_name: 'Nicholls Colonels', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B93', entity_name: 'Nicholls Colonels', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3064, import_key: 'l.ncaa.org.mbasket-t.C08', entity_name: 'Northwestern St. Demons', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C08', entity_name: 'Northwestern St. Demons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3065, import_key: 'l.ncaa.org.mbasket-t.C16', entity_name: 'Oral Roberts Golden Eagles', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C16', entity_name: 'Oral Roberts Golden Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3066, import_key: 'l.ncaa.org.mbasket-t.C48', entity_name: 'Sam Houston St. Bearkats', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C48', entity_name: 'Sam Houston St. Bearkats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3067, import_key: 'l.ncaa.org.mbasket-t.C63', entity_name: 'SE Louisiana Lions', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C63', entity_name: 'SE Louisiana Lions', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3068, import_key: 'l.ncaa.org.mbasket-t.C73', entity_name: 'Stephen F. Austin Lumberjacks', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C73', entity_name: 'Stephen F. Austin Lumberjacks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3069, import_key: 'l.ncaa.org.mbasket-t.C88', entity_name: 'Texas A&M-Corpus Christi Islanders', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C88', entity_name: 'Texas A&M-Corpus Christi Islanders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3070, import_key: 'l.ncaa.org.mbasket-t.A04', entity_name: 'Alabama A&M Bulldogs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A04', entity_name: 'Alabama A&M Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3071, import_key: 'l.ncaa.org.mbasket-t.A05', entity_name: 'Alabama St. Hornets', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A05', entity_name: 'Alabama St. Hornets', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3072, import_key: 'l.ncaa.org.mbasket-t.A08', entity_name: 'Alcorn St. Braves', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A08', entity_name: 'Alcorn St. Braves', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3073, import_key: 'l.ncaa.org.mbasket-t.A16', entity_name: 'Ark.-Pine Bluff Golden Lions', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A16', entity_name: 'Ark.-Pine Bluff Golden Lions', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3074, import_key: 'l.ncaa.org.mbasket-t.B07', entity_name: 'Grambling St. Tigers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B07', entity_name: 'Grambling St. Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3075, import_key: 'l.ncaa.org.mbasket-t.B29', entity_name: 'Jackson St. Tigers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B29', entity_name: 'Jackson St. Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3076, import_key: 'l.ncaa.org.mbasket-t.B73', entity_name: 'Miss Valley St Delta Devils', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B73', entity_name: 'Miss Valley St Delta Devils', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3077, import_key: 'l.ncaa.org.mbasket-t.C26', entity_name: 'Prairie View Panthers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C26', entity_name: 'Prairie View Panthers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3078, import_key: 'l.ncaa.org.mbasket-t.C68', entity_name: 'Southern U. Jaguars', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C68', entity_name: 'Southern U. Jaguars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3079, import_key: 'l.ncaa.org.mbasket-t.C85', entity_name: 'Texas Southern Tigers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C85', entity_name: 'Texas Southern Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3080, import_key: 'l.ncaa.org.mbasket-t.A72', entity_name: 'Denver Pioneers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A72', entity_name: 'Denver Pioneers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3081, import_key: 'l.ncaa.org.mbasket-t.B25', entity_name: 'IPFW Mastodons', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B25', entity_name: 'IPFW Mastodons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3082, import_key: 'l.ncaa.org.mbasket-t.B24', entity_name: 'IUPU-Indianapolis Jaguars', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B24', entity_name: 'IUPU-Indianapolis Jaguars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3083, import_key: 'l.ncaa.org.mbasket-t.E88', entity_name: 'Nebraska-Omaha Mavericks', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E88', entity_name: 'Nebraska-Omaha Mavericks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3084, import_key: 'l.ncaa.org.mbasket-t.H20', entity_name: 'North Dakota St. Bison', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H20', entity_name: 'North Dakota St. Bison', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3085, import_key: 'l.ncaa.org.mbasket-t.H21', entity_name: 'South Dakota St. Jackrabbits', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H21', entity_name: 'South Dakota St. Jackrabbits', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3086, import_key: 'l.ncaa.org.mbasket-t.JM1', entity_name: 'South Dakota Coyotes', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JM1', entity_name: 'South Dakota Coyotes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3087, import_key: 'l.ncaa.org.mbasket-t.D16', entity_name: 'Western Illinois Leathernecks', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D16', entity_name: 'Western Illinois Leathernecks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3088, import_key: 'l.ncaa.org.mbasket-t.A15', entity_name: 'Ark.-Little Rock Trojans', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A15', entity_name: 'Ark.-Little Rock Trojans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3089, import_key: 'l.ncaa.org.mbasket-t.A14', entity_name: 'Arkansas St. Red Wolves', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A14', entity_name: 'Arkansas St. Red Wolves', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3090, import_key: 'l.ncaa.org.mbasket-t.B04', entity_name: 'Georgia St. Panthers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B04', entity_name: 'Georgia St. Panthers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3091, import_key: 'l.ncaa.org.mbasket-t.B47', entity_name: 'Louisiana Ragin Cajuns', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B47', entity_name: 'Louisiana Ragin Cajuns', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3092, import_key: 'l.ncaa.org.mbasket-t.C58', entity_name: 'South Alabama Jaguars', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C58', entity_name: 'South Alabama Jaguars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3093, import_key: 'l.ncaa.org.mbasket-t.C71', entity_name: 'Texas State Bobcats', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C71', entity_name: 'Texas State Bobcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3094, import_key: 'l.ncaa.org.mbasket-t.C87', entity_name: 'Texas-Arlington Mavericks', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C87', entity_name: 'Texas-Arlington Mavericks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3095, import_key: 'l.ncaa.org.mbasket-t.C94', entity_name: 'Troy Trojans', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C94', entity_name: 'Troy Trojans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3096, import_key: 'l.ncaa.org.mbasket-t.B48', entity_name: 'ULM Warhawks', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B48', entity_name: 'ULM Warhawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3097, import_key: 'l.ncaa.org.mbasket-t.D17', entity_name: 'Western Kentucky Hilltoppers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D17', entity_name: 'Western Kentucky Hilltoppers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3098, import_key: 'l.ncaa.org.mbasket-t.A31', entity_name: 'BYU Cougars', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A31', entity_name: 'BYU Cougars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3099, import_key: 'l.ncaa.org.mbasket-t.B06', entity_name: 'Gonzaga Bulldogs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B06', entity_name: 'Gonzaga Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3100, import_key: 'l.ncaa.org.mbasket-t.B50', entity_name: 'Loyola Marymount Lions', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B50', entity_name: 'Loyola Marymount Lions', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3101, import_key: 'l.ncaa.org.mbasket-t.C19', entity_name: 'Pacific Tigers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C19', entity_name: 'Pacific Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3102, import_key: 'l.ncaa.org.mbasket-t.C22', entity_name: 'Pepperdine Waves', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C22', entity_name: 'Pepperdine Waves', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3103, import_key: 'l.ncaa.org.mbasket-t.C24', entity_name: 'Portland Pilots', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C24', entity_name: 'Portland Pilots', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3104, import_key: 'l.ncaa.org.mbasket-t.C50', entity_name: 'San Diego Toreros', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C50', entity_name: 'San Diego Toreros', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3105, import_key: 'l.ncaa.org.mbasket-t.C52', entity_name: 'San Francisco Dons', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C52', entity_name: 'San Francisco Dons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3106, import_key: 'l.ncaa.org.mbasket-t.C54', entity_name: 'Santa Clara Broncos', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C54', entity_name: 'Santa Clara Broncos', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3107, import_key: 'l.ncaa.org.mbasket-t.C46', entity_name: 'St. Mary\'s, Calif. Gaels', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C46', entity_name: 'St. Mary\'s, Calif. Gaels', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3108, import_key: 'l.ncaa.org.mbasket-t.G97', entity_name: 'Cal State Bakersfield Roadrunners', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G97', entity_name: 'Cal State Bakersfield Roadrunners', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3109, import_key: 'l.ncaa.org.mbasket-t.A53', entity_name: 'Chicago St. Cougars', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A53', entity_name: 'Chicago St. Cougars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3110, import_key: 'l.ncaa.org.mbasket-t.H03', entity_name: 'Grand Canyon Antelopes', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H03', entity_name: 'Grand Canyon Antelopes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3111, import_key: 'l.ncaa.org.mbasket-t.B17', entity_name: 'Idaho Vandals', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B17', entity_name: 'Idaho Vandals', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3112, import_key: 'l.ncaa.org.mbasket-t.B90', entity_name: 'New Mexico St. Aggies', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B90', entity_name: 'New Mexico St. Aggies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3113, import_key: 'l.ncaa.org.mbasket-t.H02', entity_name: 'Seattle Redhawks', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H02', entity_name: 'Seattle Redhawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3114, import_key: 'l.ncaa.org.mbasket-t.C90', entity_name: 'Texas-Pan American Broncos', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.C90', entity_name: 'Texas-Pan American Broncos', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3115, import_key: 'l.ncaa.org.mbasket-t.B75', entity_name: 'UMKC Kangaroos', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B75', entity_name: 'UMKC Kangaroos', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3116, import_key: 'l.ncaa.org.mbasket-t.G35', entity_name: 'Utah Valley St. Wolverines', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G35', entity_name: 'Utah Valley St. Wolverines', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3117, import_key: 'l.ncaa.org.mbasket-t.D59', entity_name: 'Cal State Chico Wildcats', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D59', entity_name: 'Cal State Chico Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3118, import_key: 'l.ncaa.org.mbasket-t.D50', entity_name: 'Cal State Dominguez Hills Toros', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D50', entity_name: 'Cal State Dominguez Hills Toros', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3119, import_key: 'l.ncaa.org.mbasket-t.G99', entity_name: 'Cal State LA Golden Eagles', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G99', entity_name: 'Cal State LA Golden Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3120, import_key: 'l.ncaa.org.mbasket-t.H12', entity_name: 'Cal State Poly-Pomona Broncos', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H12', entity_name: 'Cal State Poly-Pomona Broncos', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3121, import_key: 'l.ncaa.org.mbasket-t.G98', entity_name: 'Cal State San Bernardino Coyotes', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G98', entity_name: 'Cal State San Bernardino Coyotes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3122, import_key: 'l.ncaa.org.mbasket-t.D53', entity_name: 'Cal State Stanislaus Warriors', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D53', entity_name: 'Cal State Stanislaus Warriors', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3123, import_key: 'l.ncaa.org.mbasket-t.G44', entity_name: 'San Francisco St. Gators', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G44', entity_name: 'San Francisco St. Gators', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3124, import_key: 'l.ncaa.org.mbasket-t.F84', entity_name: 'Sonoma St. Cossacks', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F84', entity_name: 'Sonoma St. Cossacks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3125, import_key: 'l.ncaa.org.mbasket-t.E98', entity_name: 'UC San Diego Tritons', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E98', entity_name: 'UC San Diego Tritons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3126, import_key: 'l.ncaa.org.mbasket-t.D35', entity_name: 'Anderson, S.C. Trojans', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D35', entity_name: 'Anderson, S.C. Trojans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3127, import_key: 'l.ncaa.org.mbasket-t.D42', entity_name: 'Barton Bulldogs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D42', entity_name: 'Barton Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3128, import_key: 'l.ncaa.org.mbasket-t.D43', entity_name: 'Belmont Abbey Crusaders', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D43', entity_name: 'Belmont Abbey Crusaders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3129, import_key: 'l.ncaa.org.mbasket-t.G55', entity_name: 'Coker Cobras', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G55', entity_name: 'Coker Cobras', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3130, import_key: 'l.ncaa.org.mbasket-t.G26', entity_name: 'Erskine Flying Fleet', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G26', entity_name: 'Erskine Flying Fleet', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3131, import_key: 'l.ncaa.org.mbasket-t.D97', entity_name: 'Lees-McRae Bobcats', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D97', entity_name: 'Lees-McRae Bobcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3132, import_key: 'l.ncaa.org.mbasket-t.G90', entity_name: 'Limestone Saints', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G90', entity_name: 'Limestone Saints', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3133, import_key: 'l.ncaa.org.mbasket-t.F51', entity_name: 'Mount Olive Trojans', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F51', entity_name: 'Mount Olive Trojans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3134, import_key: 'l.ncaa.org.mbasket-t.JL5', entity_name: 'Queens Royals', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JL5', entity_name: 'Queens Royals', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3135, import_key: 'l.ncaa.org.mbasket-t.F33', entity_name: 'St. Andrews Knights', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F33', entity_name: 'St. Andrews Knights', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3136, import_key: 'l.ncaa.org.mbasket-t.D70', entity_name: 'Dominican, N.Y. Chargers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D70', entity_name: 'Dominican, N.Y. Chargers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3137, import_key: 'l.ncaa.org.mbasket-t.F32', entity_name: 'Nyack The Purple Pride', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F32', entity_name: 'Nyack The Purple Pride', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3138, import_key: 'l.ncaa.org.mbasket-t.F50', entity_name: 'Philadelphia Rams', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F50', entity_name: 'Philadelphia Rams', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3139, import_key: 'l.ncaa.org.mbasket-t.E93', entity_name: 'Wilmington, Del. Wildcats', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E93', entity_name: 'Wilmington, Del. Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3140, import_key: 'l.ncaa.org.mbasket-t.I26', entity_name: 'Bowie St. Bulldogs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I26', entity_name: 'Bowie St. Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3141, import_key: 'l.ncaa.org.mbasket-t.I12', entity_name: 'St. Paul\'s Tigers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I12', entity_name: 'St. Paul\'s Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3142, import_key: 'l.ncaa.org.mbasket-t.G91', entity_name: 'Virginia Union Panthers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G91', entity_name: 'Virginia Union Panthers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3143, import_key: 'l.ncaa.org.mbasket-t.G45', entity_name: 'Central St., Ohio', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G45', entity_name: 'Central St., Ohio', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3144, import_key: 'l.ncaa.org.mbasket-t.D61', entity_name: 'Claflin', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D61', entity_name: 'Claflin', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3145, import_key: 'l.ncaa.org.mbasket-t.I44', entity_name: 'Columbia Union', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I44', entity_name: 'Columbia Union', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3146, import_key: 'l.ncaa.org.mbasket-t.D52', entity_name: 'CS Monterey Bay', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D52', entity_name: 'CS Monterey Bay', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3147, import_key: 'l.ncaa.org.mbasket-t.I41', entity_name: 'Monterrey Tech Borregos', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I41', entity_name: 'Monterrey Tech Borregos', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3148, import_key: 'l.ncaa.org.mbasket-t.E24', entity_name: 'North Greenville', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E24', entity_name: 'North Greenville', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3149, import_key: 'l.ncaa.org.mbasket-t.G06', entity_name: 'Oakland City', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G06', entity_name: 'Oakland City', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3150, import_key: 'l.ncaa.org.mbasket-t.I13', entity_name: 'Palm Beach Atlantic', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I13', entity_name: 'Palm Beach Atlantic', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3151, import_key: 'l.ncaa.org.mbasket-t.E32', entity_name: 'Puerto Rico-Mayaguez', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E32', entity_name: 'Puerto Rico-Mayaguez', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3152, import_key: 'l.ncaa.org.mbasket-t.H86', entity_name: 'Puerto Rico-Rio Piedras', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H86', entity_name: 'Puerto Rico-Rio Piedras', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3153, import_key: 'l.ncaa.org.mbasket-t.F52', entity_name: 'Tiffin', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F52', entity_name: 'Tiffin', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3154, import_key: 'l.ncaa.org.mbasket-t.I37', entity_name: 'Ferris St. Bulldogs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I37', entity_name: 'Ferris St. Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3155, import_key: 'l.ncaa.org.mbasket-t.G66', entity_name: 'Findlay Oilers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G66', entity_name: 'Findlay Oilers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3156, import_key: 'l.ncaa.org.mbasket-t.H43', entity_name: 'Gannon Golden Knights', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H43', entity_name: 'Gannon Golden Knights', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3157, import_key: 'l.ncaa.org.mbasket-t.H68', entity_name: 'Grand Valley St. Lakers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H68', entity_name: 'Grand Valley St. Lakers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3158, import_key: 'l.ncaa.org.mbasket-t.F58', entity_name: 'Hillsdale Chargers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F58', entity_name: 'Hillsdale Chargers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3159, import_key: 'l.ncaa.org.mbasket-t.H66', entity_name: 'Lake Superior St. Lakers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H66', entity_name: 'Lake Superior St. Lakers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3160, import_key: 'l.ncaa.org.mbasket-t.E95', entity_name: 'Mercyhurst Lakers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E95', entity_name: 'Mercyhurst Lakers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3161, import_key: 'l.ncaa.org.mbasket-t.H78', entity_name: 'Michigan Tech Huskies', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H78', entity_name: 'Michigan Tech Huskies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3162, import_key: 'l.ncaa.org.mbasket-t.E12', entity_name: 'Missouri-Rolla Miners', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E12', entity_name: 'Missouri-Rolla Miners', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3163, import_key: 'l.ncaa.org.mbasket-t.F59', entity_name: 'Northern Michigan Wildcats', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F59', entity_name: 'Northern Michigan Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3164, import_key: 'l.ncaa.org.mbasket-t.I04', entity_name: 'Northwood, Mich.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I04', entity_name: 'Northwood, Mich.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3165, import_key: 'l.ncaa.org.mbasket-t.G43', entity_name: 'Rockhurst Hawks', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G43', entity_name: 'Rockhurst Hawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3166, import_key: 'l.ncaa.org.mbasket-t.G36', entity_name: 'Saginaw Valley St.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G36', entity_name: 'Saginaw Valley St.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3167, import_key: 'l.ncaa.org.mbasket-t.F57', entity_name: 'Wayne St. Warriors', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F57', entity_name: 'Wayne St. Warriors', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3168, import_key: 'l.ncaa.org.mbasket-t.G37', entity_name: 'Bellarmine Knights', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G37', entity_name: 'Bellarmine Knights', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3169, import_key: 'l.ncaa.org.mbasket-t.I06', entity_name: 'Indianapolis Greyhounds', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I06', entity_name: 'Indianapolis Greyhounds', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3170, import_key: 'l.ncaa.org.mbasket-t.I10', entity_name: 'Lewis Flyers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I10', entity_name: 'Lewis Flyers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3171, import_key: 'l.ncaa.org.mbasket-t.JK7', entity_name: 'Missouri-St. Louis Rivermen', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JK7', entity_name: 'Missouri-St. Louis Rivermen', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3172, import_key: 'l.ncaa.org.mbasket-t.G42', entity_name: 'Quincy Hawks', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G42', entity_name: 'Quincy Hawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3173, import_key: 'l.ncaa.org.mbasket-t.E49', entity_name: 'St. Joseph\'s, Ind. Pumas', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E49', entity_name: 'St. Joseph\'s, Ind. Pumas', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3174, import_key: 'l.ncaa.org.mbasket-t.E84', entity_name: 'Wis.-Parkside Rangers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E84', entity_name: 'Wis.-Parkside Rangers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3175, import_key: 'l.ncaa.org.mbasket-t.D32', entity_name: 'Alaska-Anchorage Seawolfs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D32', entity_name: 'Alaska-Anchorage Seawolfs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3176, import_key: 'l.ncaa.org.mbasket-t.D33', entity_name: 'Alaska-Fairbanks Nanooks', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D33', entity_name: 'Alaska-Fairbanks Nanooks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3177, import_key: 'l.ncaa.org.mbasket-t.JJ5', entity_name: 'NW Nazarene', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JJ5', entity_name: 'NW Nazarene', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3178, import_key: 'l.ncaa.org.mbasket-t.G15', entity_name: 'Seattle Pacific', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G15', entity_name: 'Seattle Pacific', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3179, import_key: 'l.ncaa.org.mbasket-t.E50', entity_name: 'St. Martin\'s', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E50', entity_name: 'St. Martin\'s', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3180, import_key: 'l.ncaa.org.mbasket-t.G41', entity_name: 'W. Oregon', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G41', entity_name: 'W. Oregon', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3181, import_key: 'l.ncaa.org.mbasket-t.G96', entity_name: 'W. Washington', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G96', entity_name: 'W. Washington', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3182, import_key: 'l.ncaa.org.mbasket-t.E67', entity_name: 'Montevallo Falcons', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E67', entity_name: 'Montevallo Falcons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3183, import_key: 'l.ncaa.org.mbasket-t.E22', entity_name: 'North Alabama Lions', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E22', entity_name: 'North Alabama Lions', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3184, import_key: 'l.ncaa.org.mbasket-t.E69', entity_name: 'Valdosta St. Blazers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E69', entity_name: 'Valdosta St. Blazers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3185, import_key: 'l.ncaa.org.mbasket-t.E79', entity_name: 'West Alabama Tigers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E79', entity_name: 'West Alabama Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3186, import_key: 'l.ncaa.org.mbasket-t.E68', entity_name: 'West Florida Argonauts', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E68', entity_name: 'West Florida Argonauts', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3187, import_key: 'l.ncaa.org.mbasket-t.D38', entity_name: 'Ark.-Monticello Boll Weevils', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D38', entity_name: 'Ark.-Monticello Boll Weevils', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3188, import_key: 'l.ncaa.org.mbasket-t.D36', entity_name: 'Arkansas Tech Wonder Boys', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D36', entity_name: 'Arkansas Tech Wonder Boys', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3189, import_key: 'l.ncaa.org.mbasket-t.D60', entity_name: 'Christian Brothers Buccaneers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D60', entity_name: 'Christian Brothers Buccaneers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3190, import_key: 'l.ncaa.org.mbasket-t.D69', entity_name: 'Delta St. Statesmen', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D69', entity_name: 'Delta St. Statesmen', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3191, import_key: 'l.ncaa.org.mbasket-t.D88', entity_name: 'Harding Bisons', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D88', entity_name: 'Harding Bisons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3192, import_key: 'l.ncaa.org.mbasket-t.H56', entity_name: 'Henderson St. Reddies', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H56', entity_name: 'Henderson St. Reddies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3193, import_key: 'l.ncaa.org.mbasket-t.G83', entity_name: 'Ouachita Tigers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G83', entity_name: 'Ouachita Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3194, import_key: 'l.ncaa.org.mbasket-t.G27', entity_name: 'S. Arkansas Muleriders', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G27', entity_name: 'S. Arkansas Muleriders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3195, import_key: 'l.ncaa.org.mbasket-t.G85', entity_name: 'Cameron Aggies', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G85', entity_name: 'Cameron Aggies', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3196, import_key: 'l.ncaa.org.mbasket-t.JK6', entity_name: 'East Central Tigers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JK6', entity_name: 'East Central Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3197, import_key: 'l.ncaa.org.mbasket-t.G73', entity_name: 'Midwestern St. Mustangs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G73', entity_name: 'Midwestern St. Mustangs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3198, import_key: 'l.ncaa.org.mbasket-t.G57', entity_name: 'SE Oklahoma', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G57', entity_name: 'SE Oklahoma', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3199, import_key: 'l.ncaa.org.mbasket-t.H58', entity_name: 'Angelo St. Rams', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H58', entity_name: 'Angelo St. Rams', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3200, import_key: 'l.ncaa.org.mbasket-t.F16', entity_name: 'E. New Mexico Greyhounds', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F16', entity_name: 'E. New Mexico Greyhounds', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3201, import_key: 'l.ncaa.org.mbasket-t.I34', entity_name: 'Tarleton St. Texans', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I34', entity_name: 'Tarleton St. Texans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3202, import_key: 'l.ncaa.org.mbasket-t.F85', entity_name: 'Texas A&M Commerce Lions', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F85', entity_name: 'Texas A&M Commerce Lions', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3203, import_key: 'l.ncaa.org.mbasket-t.E54', entity_name: 'Texas A&M-Kingsville Javelines', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E54', entity_name: 'Texas A&M-Kingsville Javelines', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3204, import_key: 'l.ncaa.org.mbasket-t.F98', entity_name: 'Cent. Missouri Mules', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F98', entity_name: 'Cent. Missouri Mules', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3205, import_key: 'l.ncaa.org.mbasket-t.G12', entity_name: 'Emporia', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G12', entity_name: 'Emporia', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3206, import_key: 'l.ncaa.org.mbasket-t.E30', entity_name: 'Pittsburg St. Gorillas', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E30', entity_name: 'Pittsburg St. Gorillas', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3207, import_key: 'l.ncaa.org.mbasket-t.H67', entity_name: 'Truman St. Bulldogs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H67', entity_name: 'Truman St. Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3208, import_key: 'l.ncaa.org.mbasket-t.D66', entity_name: 'Concordia, N.Y. Clippers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D66', entity_name: 'Concordia, N.Y. Clippers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3209, import_key: 'l.ncaa.org.mbasket-t.F71', entity_name: 'Dowling Golden Lions', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F71', entity_name: 'Dowling Golden Lions', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3210, import_key: 'l.ncaa.org.mbasket-t.I38', entity_name: 'Molloy Lions', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I38', entity_name: 'Molloy Lions', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3211, import_key: 'l.ncaa.org.mbasket-t.G49', entity_name: 'N.Y. Tech Bears', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G49', entity_name: 'N.Y. Tech Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3212, import_key: 'l.ncaa.org.mbasket-t.H83', entity_name: 'St. Thomas Aquinas Spartans', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H83', entity_name: 'St. Thomas Aquinas Spartans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3213, import_key: 'l.ncaa.org.mbasket-t.G50', entity_name: 'Minn.-Duluth Bulldogs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G50', entity_name: 'Minn.-Duluth Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3214, import_key: 'l.ncaa.org.mbasket-t.H72', entity_name: 'Minn.-Mankato', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H72', entity_name: 'Minn.-Mankato', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3215, import_key: 'l.ncaa.org.mbasket-t.JK3', entity_name: 'LeMoyne', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JK3', entity_name: 'LeMoyne', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3216, import_key: 'l.ncaa.org.mbasket-t.F24', entity_name: 'St. Michael\'s Knights', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F24', entity_name: 'St. Michael\'s Knights', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3217, import_key: 'l.ncaa.org.mbasket-t.G46', entity_name: 'Minn.-Crookston Golden Eagles', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G46', entity_name: 'Minn.-Crookston Golden Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3218, import_key: 'l.ncaa.org.mbasket-t.H70', entity_name: 'Northern St., S.D. Redmen', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H70', entity_name: 'Northern St., S.D. Redmen', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3219, import_key: 'l.ncaa.org.mbasket-t.H71', entity_name: 'Southwest St., Minn. Mustangs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H71', entity_name: 'Southwest St., Minn. Mustangs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3220, import_key: 'l.ncaa.org.mbasket-t.F44', entity_name: 'Wayne, Neb. Wildcats', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F44', entity_name: 'Wayne, Neb. Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3221, import_key: 'l.ncaa.org.mbasket-t.H82', entity_name: 'Winona St. Warriors', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H82', entity_name: 'Winona St. Warriors', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3222, import_key: 'l.ncaa.org.mbasket-t.E86', entity_name: 'BYU-Hawaii Seasiders', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E86', entity_name: 'BYU-Hawaii Seasiders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3223, import_key: 'l.ncaa.org.mbasket-t.D58', entity_name: 'Chaminade Silverswords', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D58', entity_name: 'Chaminade Silverswords', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3224, import_key: 'l.ncaa.org.mbasket-t.F19', entity_name: 'Hawaii Pacific Sea Warriors', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F19', entity_name: 'Hawaii Pacific Sea Warriors', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3225, import_key: 'l.ncaa.org.mbasket-t.D90', entity_name: 'Hawaii-Hilo Vulcans', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D90', entity_name: 'Hawaii-Hilo Vulcans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3226, import_key: 'l.ncaa.org.mbasket-t.H45', entity_name: 'Augusta St. Jaguars', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H45', entity_name: 'Augusta St. Jaguars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3227, import_key: 'l.ncaa.org.mbasket-t.D82', entity_name: 'Francis Marion Patriots', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D82', entity_name: 'Francis Marion Patriots', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3228, import_key: 'l.ncaa.org.mbasket-t.D96', entity_name: 'Lander Senators', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D96', entity_name: 'Lander Senators', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3229, import_key: 'l.ncaa.org.mbasket-t.E18', entity_name: 'N.C.-Pembroke Braves', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E18', entity_name: 'N.C.-Pembroke Braves', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3230, import_key: 'l.ncaa.org.mbasket-t.F64', entity_name: 'S.C.-Aiken Pacers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F64', entity_name: 'S.C.-Aiken Pacers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3231, import_key: 'l.ncaa.org.mbasket-t.H32', entity_name: 'Georgia College Bobcats', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H32', entity_name: 'Georgia College Bobcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3232, import_key: 'l.ncaa.org.mbasket-t.G80', entity_name: 'UNC-Pembroke', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G80', entity_name: 'UNC-Pembroke', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3233, import_key: 'l.ncaa.org.mbasket-t.KE7 ', entity_name: 'Young Harris Mountan Lions', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KE7 ', entity_name: 'Young Harris Mountan Lions', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3234, import_key: 'l.ncaa.org.mbasket-t.JN9', entity_name: 'California, Pa. Vulcans', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JN9', entity_name: 'California, Pa. Vulcans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3235, import_key: 'l.ncaa.org.mbasket-t.F15', entity_name: 'Clarion Golden Eagles', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F15', entity_name: 'Clarion Golden Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3236, import_key: 'l.ncaa.org.mbasket-t.H31', entity_name: 'Lock Haven Eagles', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H31', entity_name: 'Lock Haven Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3237, import_key: 'l.ncaa.org.mbasket-t.I03', entity_name: 'Shippensburg Raiders', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I03', entity_name: 'Shippensburg Raiders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3238, import_key: 'l.ncaa.org.mbasket-t.E44', entity_name: 'Slippery Rock Rock Pride', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E44', entity_name: 'Slippery Rock Rock Pride', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3239, import_key: 'l.ncaa.org.mbasket-t.JJ9', entity_name: 'Chadron St. Eagles', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JJ9', entity_name: 'Chadron St. Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3240, import_key: 'l.ncaa.org.mbasket-t.H06', entity_name: 'Colorado Christian Cougars', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H06', entity_name: 'Colorado Christian Cougars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3241, import_key: 'l.ncaa.org.mbasket-t.H05', entity_name: 'Colorado Mines Orediggers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H05', entity_name: 'Colorado Mines Orediggers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3242, import_key: 'l.ncaa.org.mbasket-t.G78', entity_name: 'Fort Hays St. Tigers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G78', entity_name: 'Fort Hays St. Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3243, import_key: 'l.ncaa.org.mbasket-t.E35', entity_name: 'Regis Rangers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E35', entity_name: 'Regis Rangers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3244, import_key: 'l.ncaa.org.mbasket-t.H04', entity_name: 'Adams St. Cougars', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H04', entity_name: 'Adams St. Cougars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3245, import_key: 'l.ncaa.org.mbasket-t.D65', entity_name: 'Colo.-Colo. Springs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D65', entity_name: 'Colo.-Colo. Springs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3246, import_key: 'l.ncaa.org.mbasket-t.H16', entity_name: 'CSU-Pueblo Thunderwolves', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H16', entity_name: 'CSU-Pueblo Thunderwolves', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3247, import_key: 'l.ncaa.org.mbasket-t.D80', entity_name: 'Fort Lewis Skyhawk', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D80', entity_name: 'Fort Lewis Skyhawk', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3248, import_key: 'l.ncaa.org.mbasket-t.H09', entity_name: 'Mesa St. Mavericks', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H09', entity_name: 'Mesa St. Mavericks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3249, import_key: 'l.ncaa.org.mbasket-t.E20', entity_name: 'N.M. Highlands Cowboys', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E20', entity_name: 'N.M. Highlands Cowboys', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3250, import_key: 'l.ncaa.org.mbasket-t.G07', entity_name: 'Western St., Colo. Mountaineers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G07', entity_name: 'Western St., Colo. Mountaineers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3251, import_key: 'l.ncaa.org.mbasket-t.F11', entity_name: 'Lenoir-Rhyne Bears', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F11', entity_name: 'Lenoir-Rhyne Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3252, import_key: 'l.ncaa.org.mbasket-t.F61', entity_name: 'Mars Hill Lions', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F61', entity_name: 'Mars Hill Lions', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3253, import_key: 'l.ncaa.org.mbasket-t.F27', entity_name: 'Newberry Indians', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F27', entity_name: 'Newberry Indians', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3254, import_key: 'l.ncaa.org.mbasket-t.E62', entity_name: 'Tusculum Pioneers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E62', entity_name: 'Tusculum Pioneers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3255, import_key: 'l.ncaa.org.mbasket-t.H22', entity_name: 'Albany State, Ga. Golden Rams', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H22', entity_name: 'Albany State, Ga. Golden Rams', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3256, import_key: 'l.ncaa.org.mbasket-t.D62', entity_name: 'Clark Atlanta Panthers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D62', entity_name: 'Clark Atlanta Panthers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3257, import_key: 'l.ncaa.org.mbasket-t.D81', entity_name: 'Fort Valley St. Wildcats', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D81', entity_name: 'Fort Valley St. Wildcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3258, import_key: 'l.ncaa.org.mbasket-t.F07', entity_name: 'Kentucky St. Thorobred', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F07', entity_name: 'Kentucky St. Thorobred', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3259, import_key: 'l.ncaa.org.mbasket-t.JK9', entity_name: 'LeMoyne-Owen Dolphins', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JK9', entity_name: 'LeMoyne-Owen Dolphins', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3260, import_key: 'l.ncaa.org.mbasket-t.I43', entity_name: 'Miles', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I43', entity_name: 'Miles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3261, import_key: 'l.ncaa.org.mbasket-t.E63', entity_name: 'Tuskegee Golden Tigers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E63', entity_name: 'Tuskegee Golden Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3262, import_key: 'l.ncaa.org.mbasket-t.G69', entity_name: 'Barry Buccaneers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G69', entity_name: 'Barry Buccaneers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3263, import_key: 'l.ncaa.org.mbasket-t.H23', entity_name: 'Eckerd', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H23', entity_name: 'Eckerd', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3264, import_key: 'l.ncaa.org.mbasket-t.D78', entity_name: 'Florida Tech', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D78', entity_name: 'Florida Tech', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3265, import_key: 'l.ncaa.org.mbasket-t.F94', entity_name: 'Nova Southeastern', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F94', entity_name: 'Nova Southeastern', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3266, import_key: 'l.ncaa.org.mbasket-t.E37', entity_name: 'Rollins', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E37', entity_name: 'Rollins', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3267, import_key: 'l.ncaa.org.mbasket-t.F77', entity_name: 'St. Leo', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F77', entity_name: 'St. Leo', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3268, import_key: 'l.ncaa.org.mbasket-t.KH3', entity_name: 'Tampa', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KH3', entity_name: 'Tampa', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3269, import_key: 'l.ncaa.org.mbasket-t.E01', entity_name: 'Lincoln, Mo. Blue Tigers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E01', entity_name: 'Lincoln, Mo. Blue Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3270, import_key: 'l.ncaa.org.mbasket-t.H52', entity_name: 'Montana St.-Billings Yellowjackets', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H52', entity_name: 'Montana St.-Billings Yellowjackets', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3271, import_key: 'l.ncaa.org.mbasket-t.G84', entity_name: 'Panhandle St.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G84', entity_name: 'Panhandle St.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3272, import_key: 'l.ncaa.org.mbasket-t.E48', entity_name: 'St. Edward\'s Hilltoppers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E48', entity_name: 'St. Edward\'s Hilltoppers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3273, import_key: 'l.ncaa.org.mbasket-t.F87', entity_name: 'St. Mary\'s, Texas Rattlers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F87', entity_name: 'St. Mary\'s, Texas Rattlers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3274, import_key: 'l.ncaa.org.mbasket-t.F17', entity_name: 'W. New Mexico Mustangs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F17', entity_name: 'W. New Mexico Mustangs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3275, import_key: 'l.ncaa.org.mbasket-t.D46', entity_name: 'Bluefield St. Big Blues', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D46', entity_name: 'Bluefield St. Big Blues', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3276, import_key: 'l.ncaa.org.mbasket-t.H91', entity_name: 'Ohio Valley Fighting Scots', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H91', entity_name: 'Ohio Valley Fighting Scots', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3277, import_key: 'l.ncaa.org.mbasket-t.E42', entity_name: 'Shepherd Rams', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E42', entity_name: 'Shepherd Rams', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3278, import_key: 'l.ncaa.org.mbasket-t.H98', entity_name: 'W. Va. Wesleyan Bobcats', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H98', entity_name: 'W. Va. Wesleyan Bobcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3279, import_key: 'l.ncaa.org.mbasket-t.JL8', entity_name: 'Concord (WV) Lions', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JL8', entity_name: 'Concord (WV) Lions', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3280, import_key: 'l.ncaa.org.mbasket-t.JP2', entity_name: 'Academy of Art', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JP2', entity_name: 'Academy of Art', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3281, import_key: 'l.ncaa.org.mbasket-t.I98', entity_name: 'Adrian', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I98', entity_name: 'Adrian', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3282, import_key: 'l.ncaa.org.mbasket.div2-t.KG5', entity_name: 'Alabama-Huntsville', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket.div2-t.KG5', entity_name: 'Alabama-Huntsville', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3283, import_key: 'l.ncaa.org.mbasket-t.JW1', entity_name: 'Albertus Magnus', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JW1', entity_name: 'Albertus Magnus', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3284, import_key: 'l.ncaa.org.mbasket-t.JS9', entity_name: 'Alma', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JS9', entity_name: 'Alma', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3285, import_key: 'l.ncaa.org.mbasket-t.E33', entity_name: 'American-PR', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E33', entity_name: 'American-PR', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3286, import_key: 'l.ncaa.org.mbasket-t.I99', entity_name: 'Apprentice School', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I99', entity_name: 'Apprentice School', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3287, import_key: 'l.ncaa.org.mbasket-t.JU1', entity_name: 'Arkansas-Fort Smith', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JU1', entity_name: 'Arkansas-Fort Smith', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3288, import_key: 'l.ncaa.org.mbasket-t.JR4', entity_name: 'Bacone', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JR4', entity_name: 'Bacone', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3289, import_key: 'l.ncaa.org.mbasket-t.JQ7', entity_name: 'Bemidji State', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JQ7', entity_name: 'Bemidji State', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3290, import_key: 'l.ncaa.org.mbasket-t.KH8', entity_name: 'Bethesda, CA', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KH8', entity_name: 'Bethesda, CA', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3291, import_key: 'l.ncaa.org.mbasket-t.A25', entity_name: 'Birmingham So', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A25', entity_name: 'Birmingham So', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3292, import_key: 'l.ncaa.org.mbasket-t.E14', entity_name: 'Blackburn', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E14', entity_name: 'Blackburn', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3293, import_key: 'l.ncaa.org.mbasket-t.JT8', entity_name: 'Bloomsburg', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JT8', entity_name: 'Bloomsburg', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3294, import_key: 'l.ncaa.org.mbasket-t.JN8', entity_name: 'Brescia', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JN8', entity_name: 'Brescia', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3295, import_key: 'l.ncaa.org.mbasket-t.JM4', entity_name: 'Cal Lutheran', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JM4', entity_name: 'Cal Lutheran', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3296, import_key: 'l.ncaa.org.mbasket-t.JP1', entity_name: 'Cal Maritime', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JP1', entity_name: 'Cal Maritime', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3297, import_key: 'l.ncaa.org.mbasket-t.JW8', entity_name: 'Carson-Newman', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JW8', entity_name: 'Carson-Newman', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3298, import_key: 'l.ncaa.org.mbasket-t.I89', entity_name: 'Carver Bible', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I89', entity_name: 'Carver Bible', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3299, import_key: 'l.ncaa.org.mbasket-t.JM7', entity_name: 'Catawba', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JM7', entity_name: 'Catawba', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3300, import_key: 'l.ncaa.org.mbasket-t.H85', entity_name: 'Central Oklahoma', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H85', entity_name: 'Central Oklahoma', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3301, import_key: 'l.ncaa.org.mbasket-t.JP7', entity_name: 'Cheyney', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JP7', entity_name: 'Cheyney', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3302, import_key: 'l.ncaa.org.mbasket-t.D64', entity_name: 'Coll of Idaho', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D64', entity_name: 'Coll of Idaho', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3303, import_key: 'l.ncaa.org.mbasket-t.JS8', entity_name: 'Coll of New Jersey', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JS8', entity_name: 'Coll of New Jersey', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3304, import_key: 'l.ncaa.org.mbasket-t.JT7', entity_name: 'Columbus State', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JT7', entity_name: 'Columbus State', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3305, import_key: 'l.ncaa.org.mbasket-t.JV5', entity_name: 'Concordia (WI)', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JV5', entity_name: 'Concordia (WI)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3306, import_key: 'l.ncaa.org.mbasket-t.JU7', entity_name: 'Concordia-Chicago', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JU7', entity_name: 'Concordia-Chicago', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3307, import_key: 'l.ncaa.org.mbasket-t.E94', entity_name: 'Concordia-St Paul', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E94', entity_name: 'Concordia-St Paul', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3308, import_key: 'l.ncaa.org.mbasket.div2-t.KF2', entity_name: 'Crown College', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket.div2-t.KF2', entity_name: 'Crown College', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3309, import_key: 'l.ncaa.org.mbasket-t.JX2', entity_name: 'Dakota State', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JX2', entity_name: 'Dakota State', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3310, import_key: 'l.ncaa.org.mbasket-t.I92', entity_name: 'Dallas Christian', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I92', entity_name: 'Dallas Christian', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3311, import_key: 'l.ncaa.org.mbasket-t.JQ2', entity_name: 'Dana College', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JQ2', entity_name: 'Dana College', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3312, import_key: 'l.ncaa.org.mbasket-t.I95', entity_name: 'Daniel Webster', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I95', entity_name: 'Daniel Webster', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3313, import_key: 'l.ncaa.org.mbasket-t.JW7', entity_name: 'Davis & Elkins', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JW7', entity_name: 'Davis & Elkins', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3314, import_key: 'l.ncaa.org.mbasket-t.H14', entity_name: 'Eugene College', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H14', entity_name: 'Eugene College', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3315, import_key: 'l.ncaa.org.mbasket.div2-t.KF8', entity_name: 'Fairmont State', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket.div2-t.KF8', entity_name: 'Fairmont State', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3316, import_key: 'l.ncaa.org.mbasket-t.JU6', entity_name: 'Farmingdale St', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JU6', entity_name: 'Farmingdale St', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3317, import_key: 'l.ncaa.org.mbasket-t.I94', entity_name: 'Fla Southern', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I94', entity_name: 'Fla Southern', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3318, import_key: 'l.ncaa.org.mbasket-t.KH6', entity_name: 'Florida College', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KH6', entity_name: 'Florida College', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3319, import_key: 'l.ncaa.org.mbasket-t.D79', entity_name: 'Fort Campbell', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D79', entity_name: 'Fort Campbell', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3320, import_key: 'l.ncaa.org.mbasket-t.JT2', entity_name: 'Franklin', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JT2', entity_name: 'Franklin', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3321, import_key: 'l.ncaa.org.mbasket-t.JS6', entity_name: 'Fredonia State', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JS6', entity_name: 'Fredonia State', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3322, import_key: 'l.ncaa.org.mbasket-t.JW6', entity_name: 'Fresno Pacific', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JW6', entity_name: 'Fresno Pacific', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3323, import_key: 'l.ncaa.org.mbasket-t.JN5', entity_name: 'Grace Bible', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JN5', entity_name: 'Grace Bible', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3324, import_key: 'l.ncaa.org.mbasket-t.JQ1', entity_name: 'Graceland', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JQ1', entity_name: 'Graceland', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3325, import_key: 'l.ncaa.org.mbasket-t.I20', entity_name: 'Hamline', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I20', entity_name: 'Hamline', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3326, import_key: 'l.ncaa.org.mbasket-t.JT4', entity_name: 'Hannibal-LaGrange', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JT4', entity_name: 'Hannibal-LaGrange', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3327, import_key: 'l.ncaa.org.mbasket-t.JX1', entity_name: 'Hendrix', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JX1', entity_name: 'Hendrix', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3328, import_key: 'l.ncaa.org.mbasket-t.JW2', entity_name: 'Hiram', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JW2', entity_name: 'Hiram', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3329, import_key: 'l.ncaa.org.mbasket-t.JW5', entity_name: 'Holy Family', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JW5', entity_name: 'Holy Family', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3330, import_key: 'l.ncaa.org.mbasket-t.JS2', entity_name: 'Illinois Tech', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JS2', entity_name: 'Illinois Tech', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3331, import_key: 'l.ncaa.org.mbasket-t.H90', entity_name: 'Illinois-Springfield', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H90', entity_name: 'Illinois-Springfield', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3332, import_key: 'l.ncaa.org.mbasket-t.JM3', entity_name: 'Indiana (PA)', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JM3', entity_name: 'Indiana (PA)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3333, import_key: 'l.ncaa.org.mbasket-t.KH4', entity_name: 'Iowa Wesleyan', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KH4', entity_name: 'Iowa Wesleyan', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3334, import_key: 'l.ncaa.org.mbasket-t.JN4', entity_name: 'IU East', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JN4', entity_name: 'IU East', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3335, import_key: 'l.ncaa.org.mbasket-t.I90', entity_name: 'J&W-North Miami', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I90', entity_name: 'J&W-North Miami', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3336, import_key: 'l.ncaa.org.mbasket-t.JV7', entity_name: 'Kean', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JV7', entity_name: 'Kean', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3337, import_key: 'l.ncaa.org.mbasket-t.JM5', entity_name: 'La Roche', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JM5', entity_name: 'La Roche', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3338, import_key: 'l.ncaa.org.mbasket-t.JQ6', entity_name: 'Lake Erie', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JQ6', entity_name: 'Lake Erie', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3339, import_key: 'l.ncaa.org.mbasket-t.KB3', entity_name: 'Langston', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KB3', entity_name: 'Langston', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3340, import_key: 'l.ncaa.org.mbasket-t.JS1', entity_name: 'Lethbridge', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JS1', entity_name: 'Lethbridge', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3341, import_key: 'l.ncaa.org.mbasket-t.H15', entity_name: 'Life-Pacific', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H15', entity_name: 'Life-Pacific', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3342, import_key: 'l.ncaa.org.mbasket-t.JV9', entity_name: 'Lyndon State', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JV9', entity_name: 'Lyndon State', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3343, import_key: 'l.ncaa.org.mbasket-t.JS3', entity_name: 'Madonna', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JS3', entity_name: 'Madonna', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3344, import_key: 'l.ncaa.org.mbasket-t.JR7', entity_name: 'Maine-Presque Isle', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JR7', entity_name: 'Maine-Presque Isle', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3345, import_key: 'l.ncaa.org.mbasket-t.JW3', entity_name: 'Malone', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JW3', entity_name: 'Malone', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3346, import_key: 'l.ncaa.org.mbasket-t.JN3', entity_name: 'Mansfield', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JN3', entity_name: 'Mansfield', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3347, import_key: 'l.ncaa.org.mbasket-t.JT6', entity_name: 'Martin Methodist', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JT6', entity_name: 'Martin Methodist', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3348, import_key: 'l.ncaa.org.mbasket-t.JM8', entity_name: 'Maryland Bible Coll', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JM8', entity_name: 'Maryland Bible Coll', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3349, import_key: 'l.ncaa.org.mbasket-t.JQ8', entity_name: 'Maury', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JQ8', entity_name: 'Maury', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3350, import_key: 'l.ncaa.org.mbasket-t.JW9', entity_name: 'Michigan-Dearborn', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JW9', entity_name: 'Michigan-Dearborn', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3351, import_key: 'l.ncaa.org.mbasket-t.JS7', entity_name: 'Mid-America Christian', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JS7', entity_name: 'Mid-America Christian', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3352, import_key: 'l.ncaa.org.mbasket-t.JQ3', entity_name: 'Midland Lutheran', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JQ3', entity_name: 'Midland Lutheran', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3353, import_key: 'l.ncaa.org.mbasket-t.JP3', entity_name: 'MIT', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JP3', entity_name: 'MIT', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3354, import_key: 'l.ncaa.org.mbasket-t.B81', entity_name: 'Morris Brown', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.B81', entity_name: 'Morris Brown', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3355, import_key: 'l.ncaa.org.mbasket-t.JR8', entity_name: 'Morris College', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JR8', entity_name: 'Morris College', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3356, import_key: 'l.ncaa.org.mbasket-t.JR9', entity_name: 'Mount Ida', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JR9', entity_name: 'Mount Ida', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3357, import_key: 'l.ncaa.org.mbasket-t.JQ5', entity_name: 'Mount Marty Coll', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JQ5', entity_name: 'Mount Marty Coll', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3358, import_key: 'l.ncaa.org.mbasket-t.JT3', entity_name: 'Mt St Vincent', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JT3', entity_name: 'Mt St Vincent', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3359, import_key: 'l.ncaa.org.mbasket-t.JN1', entity_name: 'NE Oklahoma', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JN1', entity_name: 'NE Oklahoma', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3360, import_key: 'l.ncaa.org.mbasket-t.JW4', entity_name: 'Neb-Kearney', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JW4', entity_name: 'Neb-Kearney', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3361, import_key: 'l.ncaa.org.mbasket-t.JP4', entity_name: 'Northern New Mexico', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JP4', entity_name: 'Northern New Mexico', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3362, import_key: 'l.ncaa.org.mbasket-t.KH7', entity_name: 'Northwood, TX', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KH7', entity_name: 'Northwood, TX', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3363, import_key: 'l.ncaa.org.mbasket-t.JP8', entity_name: 'NW Christian', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JP8', entity_name: 'NW Christian', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3364, import_key: 'l.ncaa.org.mbasket-t.JV2', entity_name: 'NYU Poly', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JV2', entity_name: 'NYU Poly', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3365, import_key: 'l.ncaa.org.mbasket-t.G77', entity_name: 'Oakwood', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G77', entity_name: 'Oakwood', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3366, import_key: 'l.ncaa.org.mbasket-t.I96', entity_name: 'Oberlin', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I96', entity_name: 'Oberlin', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3367, import_key: 'l.ncaa.org.mbasket-t.I93', entity_name: 'Ohio Christian', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I93', entity_name: 'Ohio Christian', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3368, import_key: 'l.ncaa.org.mbasket.div2-t.KH1', entity_name: 'Paine College', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket.div2-t.KH1', entity_name: 'Paine College', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3369, import_key: 'l.ncaa.org.mbasket-t.JS5', entity_name: 'Peru State (NE)', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JS5', entity_name: 'Peru State (NE)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3370, import_key: 'l.ncaa.org.mbasket-t.JP6', entity_name: 'Plymouth State', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JP6', entity_name: 'Plymouth State', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3371, import_key: 'l.ncaa.org.mbasket-t.JP9', entity_name: 'Post University', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JP9', entity_name: 'Post University', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3372, import_key: 'l.ncaa.org.mbasket-t.H87', entity_name: 'PR-Bayamon', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H87', entity_name: 'PR-Bayamon', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3373, import_key: 'l.ncaa.org.mbasket-t.JV8', entity_name: 'PSU-Behrend', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JV8', entity_name: 'PSU-Behrend', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3374, import_key: 'l.ncaa.org.mbasket-t.JR2', entity_name: 'Purdue Calumet', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JR2', entity_name: 'Purdue Calumet', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3375, import_key: 'l.ncaa.org.mbasket-t.JS4', entity_name: 'Purdue-North Central', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JS4', entity_name: 'Purdue-North Central', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3376, import_key: 'l.ncaa.org.mbasket-t.JT9', entity_name: 'Randolph College', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JT9', entity_name: 'Randolph College', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3377, import_key: 'l.ncaa.org.mbasket-t.JR3', entity_name: 'Robert Morris-IL', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JR3', entity_name: 'Robert Morris-IL', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3378, import_key: 'l.ncaa.org.mbasket-t.H11', entity_name: 'Robert Morris-IN', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H11', entity_name: 'Robert Morris-IN', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3379, import_key: 'l.ncaa.org.mbasket-t.JU5', entity_name: 'Salem Int', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JU5', entity_name: 'Salem Int', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3380, import_key: 'l.ncaa.org.mbasket-t.JT5', entity_name: 'Science & Arts (OK)', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JT5', entity_name: 'Science & Arts (OK)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3381, import_key: 'l.ncaa.org.mbasket-t.F72', entity_name: 'SE College', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F72', entity_name: 'SE College', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3382, import_key: 'l.ncaa.org.mbasket-t.H77', entity_name: 'Si Tanka', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H77', entity_name: 'Si Tanka', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3383, import_key: 'l.ncaa.org.mbasket-t.E43', entity_name: 'Simon Fraser', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E43', entity_name: 'Simon Fraser', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3384, import_key: 'l.ncaa.org.mbasket-t.G39', entity_name: 'Simpson', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G39', entity_name: 'Simpson', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3385, import_key: 'l.ncaa.org.mbasket-t.F38', entity_name: 'SJ Christian', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F38', entity_name: 'SJ Christian', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3386, import_key: 'l.ncaa.org.mbasket-t.H13', entity_name: 'So College-Phoenix', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H13', entity_name: 'So College-Phoenix', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3387, import_key: 'l.ncaa.org.mbasket-t.JN2', entity_name: 'Southern Poly', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JN2', entity_name: 'Southern Poly', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3388, import_key: 'l.ncaa.org.mbasket-t.JU4', entity_name: 'Southwestern (AZ)', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JU4', entity_name: 'Southwestern (AZ)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3389, import_key: 'l.ncaa.org.mbasket-t.JN6', entity_name: 'St Catharine', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JN6', entity_name: 'St Catharine', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3390, import_key: 'l.ncaa.org.mbasket-t.JU9', entity_name: 'St Joseph (NY)', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JU9', entity_name: 'St Joseph (NY)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3391, import_key: 'l.ncaa.org.mbasket-t.F13', entity_name: 'St Marys-MI', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F13', entity_name: 'St Marys-MI', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3392, import_key: 'l.ncaa.org.mbasket-t.JQ4', entity_name: 'St Olaf', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JQ4', entity_name: 'St Olaf', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3393, import_key: 'l.ncaa.org.mbasket-t.KH5', entity_name: 'St. Katherine', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KH5', entity_name: 'St. Katherine', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3394, import_key: 'l.ncaa.org.mbasket-t.JV1', entity_name: 'SUNY-Cobleskill', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JV1', entity_name: 'SUNY-Cobleskill', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3395, import_key: 'l.ncaa.org.mbasket-t.JP5', entity_name: 'SW Baptist', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JP5', entity_name: 'SW Baptist', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3396, import_key: 'l.ncaa.org.mbasket-t.G14', entity_name: 'SW Univ-TX', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G14', entity_name: 'SW Univ-TX', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3397, import_key: 'l.ncaa.org.mbasket-t.KH9', entity_name: 'Thomas, GA', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KH9', entity_name: 'Thomas, GA', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3398, import_key: 'l.ncaa.org.mbasket-t.JU8', entity_name: 'Trinity International', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JU8', entity_name: 'Trinity International', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3399, import_key: 'l.ncaa.org.mbasket-t.JV6', entity_name: 'U of Sciences (PA)', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JV6', entity_name: 'U of Sciences (PA)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3400, import_key: 'l.ncaa.org.mbasket-t.JT1', entity_name: 'Univ of the Southwest', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JT1', entity_name: 'Univ of the Southwest', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3401, import_key: 'l.ncaa.org.mbasket-t.JV3', entity_name: 'Vassar', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JV3', entity_name: 'Vassar', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3402, import_key: 'l.ncaa.org.mbasket-t.JU2', entity_name: 'Walla Walla', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JU2', entity_name: 'Walla Walla', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3403, import_key: 'l.ncaa.org.mbasket-t.JR1', entity_name: 'West Georgia', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JR1', entity_name: 'West Georgia', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3404, import_key: 'l.ncaa.org.mbasket-t.JR5', entity_name: 'West Texas A&M', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JR5', entity_name: 'West Texas A&M', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3405, import_key: 'l.ncaa.org.mbasket-t.E80', entity_name: 'Western Colorado', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E80', entity_name: 'Western Colorado', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3406, import_key: 'l.ncaa.org.mbasket-t.F18', entity_name: 'Western Maryland', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F18', entity_name: 'Western Maryland', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3407, import_key: 'l.ncaa.org.mbasket-t.JU3', entity_name: 'Whittier', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JU3', entity_name: 'Whittier', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3408, import_key: 'l.ncaa.org.mbasket.div2-t.KE9', entity_name: 'William Jewell', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket.div2-t.KE9', entity_name: 'William Jewell', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3409, import_key: 'l.ncaa.org.mbasket-t.JR6', entity_name: 'William Woods', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JR6', entity_name: 'William Woods', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3410, import_key: 'l.ncaa.org.mbasket-t.JV4', entity_name: 'Wilmington (OH)', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JV4', entity_name: 'Wilmington (OH)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3411, import_key: 'l.ncaa.org.mbasket-t.JM2', entity_name: 'Wingate', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JM2', entity_name: 'Wingate', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3412, import_key: 'l.ncaa.org.mbasket-t.KG8', entity_name: 'Lincoln (PA) Lions', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KG8', entity_name: 'Lincoln (PA) Lions', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3413, import_key: 'l.ncaa.org.mbasket-t.JX5', entity_name: 'American International', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JX5', entity_name: 'American International', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3414, import_key: 'l.ncaa.org.mbasket-t.JX3', entity_name: 'Georgia Southwestern', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JX3', entity_name: 'Georgia Southwestern', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3415, import_key: 'l.ncaa.org.mbasket-t.KA6', entity_name: 'Northwest Univ (WA) Eagles', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KA6', entity_name: 'Northwest Univ (WA) Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3416, import_key: 'l.ncaa.org.mbasket-t.I42', entity_name: 'Winston-Salem Rams', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I42', entity_name: 'Winston-Salem Rams', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3417, import_key: 'l.ncaa.org.mbasket-t.I17', entity_name: 'Medaille', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I17', entity_name: 'Medaille', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3418, import_key: 'l.ncaa.org.mbasket-t.F92', entity_name: 'Austin Kangaroos', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F92', entity_name: 'Austin Kangaroos', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3419, import_key: 'l.ncaa.org.mbasket-t.D71', entity_name: 'E. Texas Baptist', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D71', entity_name: 'E. Texas Baptist', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3420, import_key: 'l.ncaa.org.mbasket-t.D98', entity_name: 'LeTourneau', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D98', entity_name: 'LeTourneau', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3421, import_key: 'l.ncaa.org.mbasket-t.E02', entity_name: 'Louisiana College', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E02', entity_name: 'Louisiana College', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3422, import_key: 'l.ncaa.org.mbasket-t.F80', entity_name: 'Texas-Dallas', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F80', entity_name: 'Texas-Dallas', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3423, import_key: 'l.ncaa.org.mbasket-t.H60', entity_name: 'Concordia-Austin', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H60', entity_name: 'Concordia-Austin', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3424, import_key: 'l.ncaa.org.mbasket-t.D87', entity_name: 'Hardin-Simmons', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D87', entity_name: 'Hardin-Simmons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3425, import_key: 'l.ncaa.org.mbasket-t.F83', entity_name: 'Howard Payne', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F83', entity_name: 'Howard Payne', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3426, import_key: 'l.ncaa.org.mbasket-t.F88', entity_name: 'Mary Hardin-Baylor', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F88', entity_name: 'Mary Hardin-Baylor', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3427, import_key: 'l.ncaa.org.mbasket-t.G52', entity_name: 'McMurry', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G52', entity_name: 'McMurry', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3428, import_key: 'l.ncaa.org.mbasket-t.E38', entity_name: 'Schreiner', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E38', entity_name: 'Schreiner', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3429, import_key: 'l.ncaa.org.mbasket-t.E51', entity_name: 'Sul Ross St.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E51', entity_name: 'Sul Ross St.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3430, import_key: 'l.ncaa.org.mbasket-t.E56', entity_name: 'Texas Lutheran', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E56', entity_name: 'Texas Lutheran', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3431, import_key: 'l.ncaa.org.mbasket-t.I15', entity_name: 'Catholic', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I15', entity_name: 'Catholic', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3432, import_key: 'l.ncaa.org.mbasket-t.E08', entity_name: 'Mary Washington', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E08', entity_name: 'Mary Washington', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3433, import_key: 'l.ncaa.org.mbasket-t.E87', entity_name: 'Marymount, Va.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E87', entity_name: 'Marymount, Va.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3434, import_key: 'l.ncaa.org.mbasket-t.F03', entity_name: 'St. Mary\'s, Md.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F03', entity_name: 'St. Mary\'s, Md.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3435, import_key: 'l.ncaa.org.mbasket-t.D89', entity_name: 'Haverford', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D89', entity_name: 'Haverford', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3436, import_key: 'l.ncaa.org.mbasket-t.I29', entity_name: 'Muhlenberg', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I29', entity_name: 'Muhlenberg', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3437, import_key: 'l.ncaa.org.mbasket-t.E52', entity_name: 'Swarthmore', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E52', entity_name: 'Swarthmore', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3438, import_key: 'l.ncaa.org.mbasket-t.F41', entity_name: 'Ursinus', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F41', entity_name: 'Ursinus', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3439, import_key: 'l.ncaa.org.mbasket-t.F65', entity_name: 'Washington, Md.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F65', entity_name: 'Washington, Md.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3440, import_key: 'l.ncaa.org.mbasket-t.G53', entity_name: 'Dickinson', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G53', entity_name: 'Dickinson', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3441, import_key: 'l.ncaa.org.mbasket-t.D83', entity_name: 'Gettysburg', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D83', entity_name: 'Gettysburg', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3442, import_key: 'l.ncaa.org.mbasket-t.F73', entity_name: 'Johns Hopkins', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F73', entity_name: 'Johns Hopkins', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3443, import_key: 'l.ncaa.org.mbasket-t.D41', entity_name: 'Augustana,Ill. Vikings', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D41', entity_name: 'Augustana,Ill. Vikings', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3444, import_key: 'l.ncaa.org.mbasket-t.G93', entity_name: 'Elmhurst', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G93', entity_name: 'Elmhurst', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3445, import_key: 'l.ncaa.org.mbasket-t.F12', entity_name: 'North Central', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F12', entity_name: 'North Central', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3446, import_key: 'l.ncaa.org.mbasket-t.JM9', entity_name: 'North Park Vikings', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JM9', entity_name: 'North Park Vikings', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3447, import_key: 'l.ncaa.org.mbasket-t.F23', entity_name: 'Curry', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F23', entity_name: 'Curry', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3448, import_key: 'l.ncaa.org.mbasket-t.E19', entity_name: 'New England', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E19', entity_name: 'New England', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3449, import_key: 'l.ncaa.org.mbasket-t.F66', entity_name: 'Juniata', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F66', entity_name: 'Juniata', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3450, import_key: 'l.ncaa.org.mbasket-t.H35', entity_name: 'Moravian', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H35', entity_name: 'Moravian', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3451, import_key: 'l.ncaa.org.mbasket-t.I33', entity_name: 'Susquehanna', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I33', entity_name: 'Susquehanna', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3452, import_key: 'l.ncaa.org.mbasket-t.I16', entity_name: 'CCNY', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I16', entity_name: 'CCNY', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3453, import_key: 'l.ncaa.org.mbasket-t.F69', entity_name: 'John Jay', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F69', entity_name: 'John Jay', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3454, import_key: 'l.ncaa.org.mbasket-t.F63', entity_name: 'NY City Tech', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F63', entity_name: 'NY City Tech', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3455, import_key: 'l.ncaa.org.mbasket-t.D51', entity_name: 'Cal St.-East Bay', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D51', entity_name: 'Cal St.-East Bay', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3456, import_key: 'l.ncaa.org.mbasket-t.G24', entity_name: 'Chowan', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G24', entity_name: 'Chowan', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3457, import_key: 'l.ncaa.org.mbasket-t.H07', entity_name: 'Colorado College', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H07', entity_name: 'Colorado College', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3458, import_key: 'l.ncaa.org.mbasket-t.G33', entity_name: 'Dallas', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G33', entity_name: 'Dallas', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3459, import_key: 'l.ncaa.org.mbasket-t.H92', entity_name: 'Martin Luther', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H92', entity_name: 'Martin Luther', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3460, import_key: 'l.ncaa.org.mbasket-t.E09', entity_name: 'Menlo', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E09', entity_name: 'Menlo', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3461, import_key: 'l.ncaa.org.mbasket-t.H25', entity_name: 'Rust', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H25', entity_name: 'Rust', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3462, import_key: 'l.ncaa.org.mbasket-t.H65', entity_name: 'Stillman', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H65', entity_name: 'Stillman', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3463, import_key: 'l.ncaa.org.mbasket-t.G92', entity_name: 'Texas-Tyler Patriots', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G92', entity_name: 'Texas-Tyler Patriots', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3464, import_key: 'l.ncaa.org.mbasket-t.JL4', entity_name: 'Thomas More', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JL4', entity_name: 'Thomas More', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3465, import_key: 'l.ncaa.org.mbasket-t.E61', entity_name: 'Tri-State', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E61', entity_name: 'Tri-State', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3466, import_key: 'l.ncaa.org.mbasket-t.E65', entity_name: 'UC Santa Cruz', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E65', entity_name: 'UC Santa Cruz', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3467, import_key: 'l.ncaa.org.mbasket-t.H76', entity_name: 'Upper Iowa', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H76', entity_name: 'Upper Iowa', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3468, import_key: 'l.ncaa.org.mbasket-t.F68', entity_name: 'Hartwick', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F68', entity_name: 'Hartwick', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3469, import_key: 'l.ncaa.org.mbasket-t.D93', entity_name: 'Ithaca', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D93', entity_name: 'Ithaca', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3470, import_key: 'l.ncaa.org.mbasket-t.G61', entity_name: 'Delaware Valley', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G61', entity_name: 'Delaware Valley', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3471, import_key: 'l.ncaa.org.mbasket-t.G10', entity_name: 'FDU-Madison', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G10', entity_name: 'FDU-Madison', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3472, import_key: 'l.ncaa.org.mbasket-t.G60', entity_name: 'Lycoming', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G60', entity_name: 'Lycoming', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3473, import_key: 'l.ncaa.org.mbasket-t.E39', entity_name: 'Scranton', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E39', entity_name: 'Scranton', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3474, import_key: 'l.ncaa.org.mbasket-t.D73', entity_name: 'Emmanuel', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D73', entity_name: 'Emmanuel', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3475, import_key: 'l.ncaa.org.mbasket-t.G48', entity_name: 'S. Vermont', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G48', entity_name: 'S. Vermont', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3476, import_key: 'l.ncaa.org.mbasket-t.F22', entity_name: 'Suffolk', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F22', entity_name: 'Suffolk', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3477, import_key: 'l.ncaa.org.mbasket-t.D76', entity_name: 'Fisk', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D76', entity_name: 'Fisk', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3478, import_key: 'l.ncaa.org.mbasket-t.G76', entity_name: 'LaGrange', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G76', entity_name: 'LaGrange', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3479, import_key: 'l.ncaa.org.mbasket-t.G63', entity_name: 'Maryville, Tenn.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G63', entity_name: 'Maryville, Tenn.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3480, import_key: 'l.ncaa.org.mbasket-t.G23', entity_name: 'Piedmont', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G23', entity_name: 'Piedmont', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3481, import_key: 'l.ncaa.org.mbasket-t.H51', entity_name: 'Bluffton', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H51', entity_name: 'Bluffton', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3482, import_key: 'l.ncaa.org.mbasket-t.D68', entity_name: 'Defiance', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D68', entity_name: 'Defiance', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3483, import_key: 'l.ncaa.org.mbasket-t.JK8', entity_name: 'Hanover', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JK8', entity_name: 'Hanover', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3484, import_key: 'l.ncaa.org.mbasket-t.JJ2', entity_name: 'Manchester', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JJ2', entity_name: 'Manchester', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3485, import_key: 'l.ncaa.org.mbasket-t.G03', entity_name: 'Mount St. Joseph', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G03', entity_name: 'Mount St. Joseph', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3486, import_key: 'l.ncaa.org.mbasket-t.E59', entity_name: 'Transylvania', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E59', entity_name: 'Transylvania', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3487, import_key: 'l.ncaa.org.mbasket-t.H79', entity_name: 'Buena Vista', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H79', entity_name: 'Buena Vista', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3488, import_key: 'l.ncaa.org.mbasket-t.F99', entity_name: 'Coe', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F99', entity_name: 'Coe', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3489, import_key: 'l.ncaa.org.mbasket-t.G67', entity_name: 'Cornell, Iowa', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G67', entity_name: 'Cornell, Iowa', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3490, import_key: 'l.ncaa.org.mbasket-t.D95', entity_name: 'Lakeland', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D95', entity_name: 'Lakeland', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3491, import_key: 'l.ncaa.org.mbasket-t.H19', entity_name: 'Clarkson', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H19', entity_name: 'Clarkson', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3492, import_key: 'l.ncaa.org.mbasket-t.D86', entity_name: 'Hamilton', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D86', entity_name: 'Hamilton', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3493, import_key: 'l.ncaa.org.mbasket-t.D91', entity_name: 'Hobart', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D91', entity_name: 'Hobart', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3494, import_key: 'l.ncaa.org.mbasket-t.F42', entity_name: 'RPI', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F42', entity_name: 'RPI', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3495, import_key: 'l.ncaa.org.mbasket-t.H28', entity_name: 'Keene St.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H28', entity_name: 'Keene St.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3496, import_key: 'l.ncaa.org.mbasket-t.G04', entity_name: 'Rhode Island Coll.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G04', entity_name: 'Rhode Island Coll.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3497, import_key: 'l.ncaa.org.mbasket-t.G59', entity_name: 'Albion Briton', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G59', entity_name: 'Albion Briton', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3498, import_key: 'l.ncaa.org.mbasket-t.H48', entity_name: 'Hope', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H48', entity_name: 'Hope', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3499, import_key: 'l.ncaa.org.mbasket-t.F28', entity_name: 'Ripon', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F28', entity_name: 'Ripon', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3500, import_key: 'l.ncaa.org.mbasket-t.G11', entity_name: 'Grinnell', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G11', entity_name: 'Grinnell', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3501, import_key: 'l.ncaa.org.mbasket-t.H17', entity_name: 'Illinois College', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H17', entity_name: 'Illinois College', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3502, import_key: 'l.ncaa.org.mbasket-t.H93', entity_name: 'Lake Forest', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H93', entity_name: 'Lake Forest', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3503, import_key: 'l.ncaa.org.mbasket-t.H74', entity_name: 'Concordia, Moor.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H74', entity_name: 'Concordia, Moor.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3504, import_key: 'l.ncaa.org.mbasket-tI20', entity_name: 'Hamline', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-tI20', entity_name: 'Hamline', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3505, import_key: 'l.ncaa.org.mbasket-t.E05', entity_name: 'Macalester', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E05', entity_name: 'Macalester', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3506, import_key: 'l.ncaa.org.mbasket-t.G20', entity_name: 'Colby', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G20', entity_name: 'Colby', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3507, import_key: 'l.ncaa.org.mbasket-t.F25', entity_name: 'Middlebury', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F25', entity_name: 'Middlebury', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3508, import_key: 'l.ncaa.org.mbasket-t.G47', entity_name: 'Tufts', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G47', entity_name: 'Tufts', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3509, import_key: 'l.ncaa.org.mbasket-t.G54', entity_name: 'Williams', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G54', entity_name: 'Williams', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3510, import_key: 'l.ncaa.org.mbasket-t.I40', entity_name: 'Clark U.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I40', entity_name: 'Clark U.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3511, import_key: 'l.ncaa.org.mbasket-t.D63', entity_name: 'Coast Guard', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D63', entity_name: 'Coast Guard', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3512, import_key: 'l.ncaa.org.mbasket-t.F39', entity_name: 'Worcester Tech', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F39', entity_name: 'Worcester Tech', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3513, import_key: 'l.ncaa.org.mbasket-t.D55', entity_name: 'Castleton St.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D55', entity_name: 'Castleton St.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3514, import_key: 'l.ncaa.org.mbasket-t.F21', entity_name: 'Husson', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F21', entity_name: 'Husson', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3515, import_key: 'l.ncaa.org.mbasket-t.I32', entity_name: 'Lasell', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I32', entity_name: 'Lasell', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3516, import_key: 'l.ncaa.org.mbasket-t.H27', entity_name: 'Maine-Farmington', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H27', entity_name: 'Maine-Farmington', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3517, import_key: 'l.ncaa.org.mbasket-t.I01', entity_name: 'Denison', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I01', entity_name: 'Denison', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3518, import_key: 'l.ncaa.org.mbasket-t.H24', entity_name: 'Kenyon', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H24', entity_name: 'Kenyon', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3519, import_key: 'l.ncaa.org.mbasket-t.G13', entity_name: 'Ohio Weslyn', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G13', entity_name: 'Ohio Weslyn', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3520, import_key: 'l.ncaa.org.mbasket-t.KG7', entity_name: 'Wabash Little Giants', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KG7', entity_name: 'Wabash Little Giants', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3521, import_key: 'l.ncaa.org.mbasket-t.I24', entity_name: 'Keuka', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I24', entity_name: 'Keuka', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3522, import_key: 'l.ncaa.org.mbasket-t.H37', entity_name: 'N.Y. Polytechnic', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H37', entity_name: 'N.Y. Polytechnic', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3523, import_key: 'l.ncaa.org.mbasket-t.H26', entity_name: 'Villa Julie', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H26', entity_name: 'Villa Julie', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3524, import_key: 'l.ncaa.org.mbasket-t.G19', entity_name: 'Aurora Spartans', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G19', entity_name: 'Aurora Spartans', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3525, import_key: 'l.ncaa.org.mbasket-t.D44', entity_name: 'Benedictine,Ill. Eagles', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D44', entity_name: 'Benedictine,Ill. Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3526, import_key: 'l.ncaa.org.mbasket-t.D99', entity_name: 'Lewis & Clark', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D99', entity_name: 'Lewis & Clark', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3527, import_key: 'l.ncaa.org.mbasket-t.F37', entity_name: 'Linfield', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F37', entity_name: 'Linfield', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3528, import_key: 'l.ncaa.org.mbasket-t.I31', entity_name: 'Pacific Lutheran', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I31', entity_name: 'Pacific Lutheran', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3529, import_key: 'l.ncaa.org.mbasket-t.F95', entity_name: 'Pacific, Ore. Boxers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F95', entity_name: 'Pacific, Ore. Boxers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3530, import_key: 'l.ncaa.org.mbasket-t.I35', entity_name: 'Puget Sound', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I35', entity_name: 'Puget Sound', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3531, import_key: 'l.ncaa.org.mbasket-t.F55', entity_name: 'Whitman', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F55', entity_name: 'Whitman', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3532, import_key: 'l.ncaa.org.mbasket-t.E82', entity_name: 'Whitworth', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E82', entity_name: 'Whitworth', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3533, import_key: 'l.ncaa.org.mbasket-t.E83', entity_name: 'Willamette', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E83', entity_name: 'Willamette', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3534, import_key: 'l.ncaa.org.mbasket-t.F49', entity_name: 'Capital', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F49', entity_name: 'Capital', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3535, import_key: 'l.ncaa.org.mbasket-t.H95', entity_name: 'John Carroll', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H95', entity_name: 'John Carroll', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3536, import_key: 'l.ncaa.org.mbasket-t.E07', entity_name: 'Marietta', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E07', entity_name: 'Marietta', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3537, import_key: 'l.ncaa.org.mbasket-t.E16', entity_name: 'Mount Union', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E16', entity_name: 'Mount Union', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3538, import_key: 'l.ncaa.org.mbasket-t.H30', entity_name: 'Ohio Northern', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H30', entity_name: 'Ohio Northern', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3539, import_key: 'l.ncaa.org.mbasket-t.H41', entity_name: 'Bridgewater, Va.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H41', entity_name: 'Bridgewater, Va.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3540, import_key: 'l.ncaa.org.mbasket-t.D72', entity_name: 'E. Mennonite', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D72', entity_name: 'E. Mennonite', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3541, import_key: 'l.ncaa.org.mbasket-t.JJ1', entity_name: 'Emory & Henry', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JJ1', entity_name: 'Emory & Henry', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3542, import_key: 'l.ncaa.org.mbasket-t.D85', entity_name: 'Guilford', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D85', entity_name: 'Guilford', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3543, import_key: 'l.ncaa.org.mbasket-t.H69', entity_name: 'Hampden-Sydney', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H69', entity_name: 'Hampden-Sydney', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3544, import_key: 'l.ncaa.org.mbasket-t.F09', entity_name: 'Lynchburg', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F09', entity_name: 'Lynchburg', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3545, import_key: 'l.ncaa.org.mbasket-t.E34', entity_name: 'Randolph-Macon', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E34', entity_name: 'Randolph-Macon', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3546, import_key: 'l.ncaa.org.mbasket-t.F40', entity_name: 'Roanoke', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F40', entity_name: 'Roanoke', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3547, import_key: 'l.ncaa.org.mbasket-t.E75', entity_name: 'Washington & Lee', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E75', entity_name: 'Washington & Lee', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3548, import_key: 'l.ncaa.org.mbasket-t.I28', entity_name: 'Alvernia Crusaders', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I28', entity_name: 'Alvernia Crusaders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3549, import_key: 'l.ncaa.org.mbasket-t.G62', entity_name: 'Cabrini', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G62', entity_name: 'Cabrini', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3550, import_key: 'l.ncaa.org.mbasket-t.H34', entity_name: 'Eastern, Pa.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H34', entity_name: 'Eastern, Pa.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3551, import_key: 'l.ncaa.org.mbasket-t.H50', entity_name: 'Thiel', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H50', entity_name: 'Thiel', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3552, import_key: 'l.ncaa.org.mbasket-t.E74', entity_name: 'Washington & Jefferson', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E74', entity_name: 'Washington & Jefferson', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3553, import_key: 'l.ncaa.org.mbasket-t.G18', entity_name: 'Westminster (MO)', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G18', entity_name: 'Westminster (MO)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3554, import_key: 'l.ncaa.org.mbasket-t.G17', entity_name: 'Centenary, N.J.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G17', entity_name: 'Centenary, N.J.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3555, import_key: 'l.ncaa.org.mbasket-t.F45', entity_name: 'Manhattanville', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F45', entity_name: 'Manhattanville', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3556, import_key: 'l.ncaa.org.mbasket-t.H33', entity_name: 'Merchant Marine', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H33', entity_name: 'Merchant Marine', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3557, import_key: 'l.ncaa.org.mbasket-t.H36', entity_name: 'N.Y. Maritime', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H36', entity_name: 'N.Y. Maritime', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3558, import_key: 'l.ncaa.org.mbasket-t.H47', entity_name: 'Old Westbury', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H47', entity_name: 'Old Westbury', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3559, import_key: 'l.ncaa.org.mbasket-t.E21', entity_name: 'SUNY-Maritime Privateers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E21', entity_name: 'SUNY-Maritime Privateers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3560, import_key: 'l.ncaa.org.mbasket-t.JJ8', entity_name: 'LaVerne', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JJ8', entity_name: 'LaVerne', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3561, import_key: 'l.ncaa.org.mbasket-t.E26', entity_name: 'Occidental', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E26', entity_name: 'Occidental', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3562, import_key: 'l.ncaa.org.mbasket-t.F53', entity_name: 'Pomona-Pitzer', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F53', entity_name: 'Pomona-Pitzer', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3563, import_key: 'l.ncaa.org.mbasket-t.G29', entity_name: 'Redlands', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G29', entity_name: 'Redlands', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3564, import_key: 'l.ncaa.org.mbasket-t.G68', entity_name: 'Centre', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G68', entity_name: 'Centre', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3565, import_key: 'l.ncaa.org.mbasket-t.I07', entity_name: 'DePauw', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I07', entity_name: 'DePauw', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3566, import_key: 'l.ncaa.org.mbasket-t.E11', entity_name: 'Millsaps', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E11', entity_name: 'Millsaps', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3567, import_key: 'l.ncaa.org.mbasket-t.E27', entity_name: 'Oglethorpe', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E27', entity_name: 'Oglethorpe', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3568, import_key: 'l.ncaa.org.mbasket-t.F67', entity_name: 'Sewanee', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F67', entity_name: 'Sewanee', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3569, import_key: 'l.ncaa.org.mbasket-t.F46', entity_name: 'Trinity, Texas', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F46', entity_name: 'Trinity, Texas', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3570, import_key: 'l.ncaa.org.mbasket-t.JN7', entity_name: 'Eureka Red Devils', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JN7', entity_name: 'Eureka Red Devils', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3571, import_key: 'l.ncaa.org.mbasket-t.G71', entity_name: 'Greenville', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G71', entity_name: 'Greenville', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3572, import_key: 'l.ncaa.org.mbasket-t.E78', entity_name: 'Webster', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E78', entity_name: 'Webster', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3573, import_key: 'l.ncaa.org.mbasket-t.I36', entity_name: 'Buffalo St.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I36', entity_name: 'Buffalo St.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3574, import_key: 'l.ncaa.org.mbasket-t.H39', entity_name: 'Brandeis', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H39', entity_name: 'Brandeis', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3575, import_key: 'l.ncaa.org.mbasket-t.F47', entity_name: 'Carnegie-Mellon', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F47', entity_name: 'Carnegie-Mellon', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3576, import_key: 'l.ncaa.org.mbasket-t.D74', entity_name: 'Emory', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D74', entity_name: 'Emory', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3577, import_key: 'l.ncaa.org.mbasket-t.F29', entity_name: 'Averett Cougars', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F29', entity_name: 'Averett Cougars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3578, import_key: 'l.ncaa.org.mbasket-t.G34', entity_name: 'Ferrum', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G34', entity_name: 'Ferrum', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3579, import_key: 'l.ncaa.org.mbasket-t.F62', entity_name: 'Greensboro', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F62', entity_name: 'Greensboro', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3580, import_key: 'l.ncaa.org.mbasket-t.E10', entity_name: 'Methodist', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E10', entity_name: 'Methodist', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3581, import_key: 'l.ncaa.org.mbasket-t.JJ6', entity_name: 'N.C. Wesleyan', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JJ6', entity_name: 'N.C. Wesleyan', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3582, import_key: 'l.ncaa.org.mbasket-t.E41', entity_name: 'Shenandoah', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E41', entity_name: 'Shenandoah', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3583, import_key: 'l.ncaa.org.mbasket-t.KC8', entity_name: 'Albright', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KC8', entity_name: 'Albright', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3584, import_key: 'l.ncaa.org.mbasket-t.I69', entity_name: 'Allegheny', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I69', entity_name: 'Allegheny', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3585, import_key: 'l.ncaa.org.mbasket-t.KC9', entity_name: 'Arcadia', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KC9', entity_name: 'Arcadia', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3586, import_key: 'l.ncaa.org.mbasket-t.KC1', entity_name: 'Arizona Christian', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KC1', entity_name: 'Arizona Christian', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3587, import_key: 'l.ncaa.org.mbasket-t.KB4', entity_name: 'Ave Maria', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KB4', entity_name: 'Ave Maria', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3588, import_key: 'l.ncaa.org.mbasket-t.I78', entity_name: 'Baker', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I78', entity_name: 'Baker', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3589, import_key: 'l.ncaa.org.mbasket-t.KB7', entity_name: 'Barber-Scotia', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KB7', entity_name: 'Barber-Scotia', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3590, import_key: 'l.ncaa.org.mbasket-t.I75', entity_name: 'Berea', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I75', entity_name: 'Berea', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3591, import_key: 'l.ncaa.org.mbasket-t.JY7', entity_name: 'Black Hills State', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JY7', entity_name: 'Black Hills State', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3592, import_key: 'l.ncaa.org.mbasket-t.KG9', entity_name: 'Cairn Highlanders', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KG9', entity_name: 'Cairn Highlanders', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3593, import_key: 'l.ncaa.org.mbasket-t.I65', entity_name: 'Caldwell', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I65', entity_name: 'Caldwell', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3594, import_key: 'l.ncaa.org.mbasket-t.I79', entity_name: 'Calumet', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I79', entity_name: 'Calumet', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3595, import_key: 'l.ncaa.org.mbasket-t.A45', entity_name: 'Centenary Gentlemen', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.A45', entity_name: 'Centenary Gentlemen', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3596, import_key: 'l.ncaa.org.mbasket-t.JY8', entity_name: 'Central Penn College', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JY8', entity_name: 'Central Penn College', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3597, import_key: 'l.ncaa.org.mbasket-t.KD8', entity_name: 'Chapman', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KD8', entity_name: 'Chapman', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3598, import_key: 'l.ncaa.org.mbasket-t.KJ4', entity_name: 'Chestnut Hill', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KJ4', entity_name: 'Chestnut Hill', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3599, import_key: 'l.ncaa.org.mbasket-t.KD6', entity_name: 'Coastal Georgia', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KD6', entity_name: 'Coastal Georgia', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3600, import_key: 'l.ncaa.org.mbasket.div3-t.KF9', entity_name: 'Colby-Sawyer', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket.div3-t.KF9', entity_name: 'Colby-Sawyer', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3601, import_key: 'l.ncaa.org.mbasket-t.KJ3', entity_name: 'Columbia International', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KJ3', entity_name: 'Columbia International', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3602, import_key: 'l.ncaa.org.mbasket-t.KE1', entity_name: 'Concordia (AL)', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KE1', entity_name: 'Concordia (AL)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3603, import_key: 'l.ncaa.org.mbasket-t.JX9', entity_name: 'Cornerstone', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JX9', entity_name: 'Cornerstone', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3604, import_key: 'l.ncaa.org.mbasket-t.KB1', entity_name: 'CS-San Marcos', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KB1', entity_name: 'CS-San Marcos', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3605, import_key: 'l.ncaa.org.mbasket-t.I82', entity_name: 'Culver-Stockton', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I82', entity_name: 'Culver-Stockton', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3606, import_key: 'l.ncaa.org.mbasket-t.I61', entity_name: 'Dallas Baptist', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I61', entity_name: 'Dallas Baptist', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3607, import_key: 'l.ncaa.org.mbasket-t.KE6', entity_name: 'District of Columbia', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KE6', entity_name: 'District of Columbia', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3608, import_key: 'l.ncaa.org.mbasket-t.JZ5', entity_name: 'Doane College', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JZ5', entity_name: 'Doane College', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3609, import_key: 'l.ncaa.org.mbasket-t.KI3', entity_name: 'Earlham College', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KI3', entity_name: 'Earlham College', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3610, import_key: 'l.ncaa.org.mbasket-t.I59', entity_name: 'East-West', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I59', entity_name: 'East-West', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3611, import_key: 'l.ncaa.org.mbasket.div3-t.KF1', entity_name: 'Eastern Nazarene', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket.div3-t.KF1', entity_name: 'Eastern Nazarene', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3612, import_key: 'l.ncaa.org.mbasket-t.I48', entity_name: 'Edward Waters', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I48', entity_name: 'Edward Waters', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3613, import_key: 'l.ncaa.org.mbasket-t.KD7', entity_name: 'Elizabeth City State', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KD7', entity_name: 'Elizabeth City State', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3614, import_key: 'l.ncaa.org.mbasket-t.I71', entity_name: 'Elmira', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I71', entity_name: 'Elmira', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3615, import_key: 'l.ncaa.org.mbasket-t.JZ2', entity_name: 'Fayetteville State', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JZ2', entity_name: 'Fayetteville State', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3616, import_key: 'l.ncaa.org.mbasket-t.I81', entity_name: 'Florida Memorial', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I81', entity_name: 'Florida Memorial', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3617, import_key: 'l.ncaa.org.mbasket.div3-t.KK8', entity_name: 'Florida National', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket.div3-t.KK8', entity_name: 'Florida National', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3618, import_key: 'l.ncaa.org.mbasket-t.JX8', entity_name: 'Fontbonne', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JX8', entity_name: 'Fontbonne', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3619, import_key: 'l.ncaa.org.mbasket-t.I66', entity_name: 'Franklin Pierce', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I66', entity_name: 'Franklin Pierce', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3620, import_key: 'l.ncaa.org.mbasket-t.JY9', entity_name: 'George Fox Univ', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JY9', entity_name: 'George Fox Univ', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3621, import_key: 'l.ncaa.org.mbasket-t.JZ3', entity_name: 'Glenville State', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JZ3', entity_name: 'Glenville State', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3622, import_key: 'l.ncaa.org.mbasket-t.I50', entity_name: 'Goucher', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I50', entity_name: 'Goucher', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3623, import_key: 'l.ncaa.org.mbasket-t.JY3', entity_name: 'Gwynedd-Mercy', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JY3', entity_name: 'Gwynedd-Mercy', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3624, import_key: 'l.ncaa.org.mbasket-t.I49', entity_name: 'Haskell', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I49', entity_name: 'Haskell', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3625, import_key: 'l.ncaa.org.mbasket-t.KC2', entity_name: 'Holy Cross (IN)', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KC2', entity_name: 'Holy Cross (IN)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3626, import_key: 'l.ncaa.org.mbasket-t.KC3', entity_name: 'Indiana-Kokomo', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KC3', entity_name: 'Indiana-Kokomo', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3627, import_key: 'l.ncaa.org.mbasket-t.KC4', entity_name: 'J&W-Providence', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KC4', entity_name: 'J&W-Providence', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3628, import_key: 'l.ncaa.org.mbasket-t.KK5', entity_name: 'Johnson (TN)', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KK5', entity_name: 'Johnson (TN)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3629, import_key: 'l.ncaa.org.mbasket-t.JX6', entity_name: 'Johnson C. Smith', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JX6', entity_name: 'Johnson C. Smith', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3630, import_key: 'l.ncaa.org.mbasket-t.I77', entity_name: 'Kentucky Wesleyan', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I77', entity_name: 'Kentucky Wesleyan', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3631, import_key: 'l.ncaa.org.mbasket-t.I73', entity_name: 'King\'s College (PA)', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I73', entity_name: 'King\'s College (PA)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3632, import_key: 'l.ncaa.org.mbasket-t.JZ6', entity_name: 'La Sierra', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JZ6', entity_name: 'La Sierra', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3633, import_key: 'l.ncaa.org.mbasket-t.KA2', entity_name: 'Lesley University', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KA2', entity_name: 'Lesley University', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3634, import_key: 'l.ncaa.org.mbasket-t.I62', entity_name: 'Lewis-Clark State', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I62', entity_name: 'Lewis-Clark State', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3635, import_key: 'l.ncaa.org.mbasket-t.KD5', entity_name: 'Lindsey Wilson', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KD5', entity_name: 'Lindsey Wilson', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3636, import_key: 'l.ncaa.org.mbasket-t.KC7', entity_name: 'Loras', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KC7', entity_name: 'Loras', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3637, import_key: 'l.ncaa.org.mbasket-t.JL1', entity_name: 'MacMurray College', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JL1', entity_name: 'MacMurray College', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3638, import_key: 'l.ncaa.org.mbasket-t.JZ8', entity_name: 'Maryville (MO)', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JZ8', entity_name: 'Maryville (MO)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3639, import_key: 'l.ncaa.org.mbasket-t.I68', entity_name: 'Marywood', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I68', entity_name: 'Marywood', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3640, import_key: 'l.ncaa.org.mbasket-t.I64', entity_name: 'Master\'s College', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I64', entity_name: 'Master\'s College', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3641, import_key: 'l.ncaa.org.mbasket-t.I53', entity_name: 'Mercy', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I53', entity_name: 'Mercy', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3642, import_key: 'l.ncaa.org.mbasket-t.KB5', entity_name: 'Mid-Continent', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KB5', entity_name: 'Mid-Continent', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3643, import_key: 'l.ncaa.org.mbasket-t.KI8', entity_name: 'Minnesota Morris', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KI8', entity_name: 'Minnesota Morris', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3644, import_key: 'l.ncaa.org.mbasket-t.KE5', entity_name: 'Mississippi College', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KE5', entity_name: 'Mississippi College', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3645, import_key: 'l.ncaa.org.mbasket-t.KK1', entity_name: 'Morehouse', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KK1', entity_name: 'Morehouse', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3646, import_key: 'l.ncaa.org.mbasket-t.I87', entity_name: 'Mt. St. Mary (NY)', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I87', entity_name: 'Mt. St. Mary (NY)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3647, import_key: 'l.ncaa.org.mbasket-t.JZ7', entity_name: 'Neumann', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JZ7', entity_name: 'Neumann', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3648, import_key: 'l.ncaa.org.mbasket-t.JY2', entity_name: 'New Hope Christian', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JY2', entity_name: 'New Hope Christian', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3649, import_key: 'l.ncaa.org.mbasket-t.KC6', entity_name: 'Newman', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KC6', entity_name: 'Newman', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3650, import_key: 'l.ncaa.org.mbasket-t.KJ1', entity_name: 'Northwestern Ohio', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KJ1', entity_name: 'Northwestern Ohio', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3651, import_key: 'l.ncaa.org.mbasket-t.KB8', entity_name: 'NW Missouri State', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KB8', entity_name: 'NW Missouri State', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3652, import_key: 'l.ncaa.org.mbasket.div3-t.KF3', entity_name: 'Olivet College', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket.div3-t.KF3', entity_name: 'Olivet College', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3653, import_key: 'l.ncaa.org.mbasket-t.KA3', entity_name: 'Our Lady of the Lake', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KA3', entity_name: 'Our Lady of the Lake', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3654, import_key: 'l.ncaa.org.mbasket-t.I57', entity_name: 'Ozarks (AR)', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I57', entity_name: 'Ozarks (AR)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3655, import_key: 'l.ncaa.org.mbasket-t.KB6', entity_name: 'Pacific Union', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KB6', entity_name: 'Pacific Union', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3656, import_key: 'l.ncaa.org.mbasket-t.KB2', entity_name: 'Pacifica', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KB2', entity_name: 'Pacifica', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3657, import_key: 'l.ncaa.org.mbasket.div3-t.KF7', entity_name: 'Presentation College', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket.div3-t.KF7', entity_name: 'Presentation College', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3658, import_key: 'l.ncaa.org.mbasket-t.KE3', entity_name: 'PSU-Abington', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KE3', entity_name: 'PSU-Abington', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3659, import_key: 'l.ncaa.org.mbasket-t.KE2', entity_name: 'PSU-Altoona', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KE2', entity_name: 'PSU-Altoona', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3660, import_key: 'l.ncaa.org.mbasket-t.I56', entity_name: 'Rhema', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I56', entity_name: 'Rhema', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3661, import_key: 'l.ncaa.org.mbasket-t.JY4', entity_name: 'Roosevelt', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JY4', entity_name: 'Roosevelt', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3662, import_key: 'l.ncaa.org.mbasket.div3-t.KG4', entity_name: 'Rosemont College', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket.div3-t.KG4', entity_name: 'Rosemont College', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3663, import_key: 'l.ncaa.org.mbasket-t.KD4', entity_name: 'Rutgers-Camden', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KD4', entity_name: 'Rutgers-Camden', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3664, import_key: 'l.ncaa.org.mbasket.div3-t.KG6', entity_name: 'Salisbury', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket.div3-t.KG6', entity_name: 'Salisbury', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3665, import_key: 'l.ncaa.org.mbasket-t.I55', entity_name: 'Savannah CAD', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I55', entity_name: 'Savannah CAD', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3666, import_key: 'l.ncaa.org.mbasket-t.KC5', entity_name: 'Sioux Falls', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KC5', entity_name: 'Sioux Falls', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3667, import_key: 'l.ncaa.org.mbasket-t.I88', entity_name: 'Skidmore', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I88', entity_name: 'Skidmore', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3668, import_key: 'l.naia.org.mbasket-t.G14', entity_name: 'Southwestern University Pirates', status: 1, entity_type_id: 8
+    import_key: 'l.naia.org.mbasket-t.G14', entity_name: 'Southwestern University Pirates', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3669, import_key: 'l.ncaa.org.mbasket-t.I63', entity_name: 'St Joseph (VT)', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I63', entity_name: 'St Joseph (VT)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3670, import_key: 'l.ncaa.org.mbasket-t.JY6', entity_name: 'St Josephs (ME)', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JY6', entity_name: 'St Josephs (ME)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3671, import_key: 'l.ncaa.org.mbasket-t.I85', entity_name: 'St Mary\'s (MN)', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I85', entity_name: 'St Mary\'s (MN)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3672, import_key: 'l.ncaa.org.mbasket-t.KD3', entity_name: 'St Mary\'s-KS', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KD3', entity_name: 'St Mary\'s-KS', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3673, import_key: 'l.ncaa.org.mbasket-t.JZ4', entity_name: 'St Thomas (TX)', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JZ4', entity_name: 'St Thomas (TX)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3674, import_key: 'l.ncaa.org.mbasket-t.KD9', entity_name: 'St. Thomas (FL)', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KD9', entity_name: 'St. Thomas (FL)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3675, import_key: 'l.ncaa.org.mbasket-t.I46', entity_name: 'Stonehill', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I46', entity_name: 'Stonehill', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3676, import_key: 'l.ncaa.org.mbasket-t.KD2', entity_name: 'Suny-Oswego', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KD2', entity_name: 'Suny-Oswego', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3677, import_key: 'l.ncaa.org.mbasket-t.I58', entity_name: 'SUNY-Purchase', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I58', entity_name: 'SUNY-Purchase', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3678, import_key: 'l.ncaa.org.mbasket-t.I51', entity_name: 'SW Oklahoma St.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I51', entity_name: 'SW Oklahoma St.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3679, import_key: 'l.ncaa.org.mbasket-t.JY5', entity_name: 'Tabor College', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JY5', entity_name: 'Tabor College', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3680, import_key: 'l.ncaa.org.mbasket-t.JY1', entity_name: 'Trinity Baptist', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JY1', entity_name: 'Trinity Baptist', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3681, import_key: 'l.ncaa.org.mbasket-t.KB9', entity_name: 'UC Merced', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KB9', entity_name: 'UC Merced', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3682, import_key: 'l.ncaa.org.mbasket-t.G05', entity_name: 'Union (KY) Bulldogs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G05', entity_name: 'Union (KY) Bulldogs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3683, import_key: 'l.ncaa.org.mbasket-t.I60', entity_name: 'Union (NY)', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I60', entity_name: 'Union (NY)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3684, import_key: 'l.ncaa.org.mbasket-t.I54', entity_name: 'Valley City State', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I54', entity_name: 'Valley City State', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3685, import_key: 'l.ncaa.org.mbasket-t.KA1', entity_name: 'Victory University', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KA1', entity_name: 'Victory University', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3686, import_key: 'l.ncaa.org.mbasket-t.KJ7', entity_name: 'Viterbo', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KJ7', entity_name: 'Viterbo', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3687, import_key: 'l.ncaa.org.mbasket-t.I76', entity_name: 'Waldorf', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I76', entity_name: 'Waldorf', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3688, import_key: 'l.ncaa.org.mbasket-t.I47', entity_name: 'Warner Southern', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I47', entity_name: 'Warner Southern', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3689, import_key: 'l.ncaa.org.mbasket-t.I84', entity_name: 'Wartburg', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I84', entity_name: 'Wartburg', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3690, import_key: 'l.ncaa.org.mbasket-t.I74', entity_name: 'Washburn', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I74', entity_name: 'Washburn', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3691, import_key: 'l.ncaa.org.mbasket-t.I86', entity_name: 'Washington (MO)', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I86', entity_name: 'Washington (MO)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3692, import_key: 'l.ncaa.org.mbasket-t.KD1', entity_name: 'Wentworth', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KD1', entity_name: 'Wentworth', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3693, import_key: 'l.ncaa.org.mbasket-t.I80', entity_name: 'Wesley', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I80', entity_name: 'Wesley', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3694, import_key: 'l.ncaa.org.mbasket-t.KE4', entity_name: 'Westminster (UT)', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KE4', entity_name: 'Westminster (UT)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3695, import_key: 'l.ncaa.org.mbasket-t.I52', entity_name: 'Wheaton', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I52', entity_name: 'Wheaton', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3696, import_key: 'l.ncaa.org.mbasket-t.KK6', entity_name: 'Wittenberg', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KK6', entity_name: 'Wittenberg', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3697, import_key: 'l.ncaa.org.mbasket-t.I70', entity_name: 'Xavier (LA)', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I70', entity_name: 'Xavier (LA)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3698, import_key: 'l.ncaa.org.mbasket-t.JX4', entity_name: 'Baruch College', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JX4', entity_name: 'Baruch College', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3699, import_key: 'l.ncaa.org.mbasket-t.KA4', entity_name: 'Arlington Baptist', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KA4', entity_name: 'Arlington Baptist', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3700, import_key: 'l.ncaa.org.mbasket-t.JX7', entity_name: 'Crowley\'s Ridge', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JX7', entity_name: 'Crowley\'s Ridge', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3701, import_key: 'l.ncaa.org.mbasket-t.KA9', entity_name: 'Hiwassee', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KA9', entity_name: 'Hiwassee', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3702, import_key: 'l.ncaa.org.mbasket-t.KA5', entity_name: 'J&W-Charlotte', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KA5', entity_name: 'J&W-Charlotte', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3703, import_key: 'l.ncaa.org.mbasket-t.KA7', entity_name: 'Judson', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KA7', entity_name: 'Judson', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3704, import_key: 'l.ncaa.org.mbasket-t.F48', entity_name: 'Millikin', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F48', entity_name: 'Millikin', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3705, import_key: 'l.ncaa.org.mbasket-t.KA8', entity_name: 'Philadelphia Bible', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.KA8', entity_name: 'Philadelphia Bible', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3706, import_key: 'l.ncaa.org.mbasket-t.JZ9', entity_name: 'SD Mines & Tech', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JZ9', entity_name: 'SD Mines & Tech', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3707, import_key: 'l.ncaa.org.mbasket-t.H49', entity_name: 'Harris-Stowe', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H49', entity_name: 'Harris-Stowe', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3708, import_key: 'l.ncaa.org.mbasket-t.G28', entity_name: 'Williams Baptist', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G28', entity_name: 'Williams Baptist', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3709, import_key: 'l.naia.org.mbasket-t.H90', entity_name: 'Illinois-Springfield Prairie Stars', status: 1, entity_type_id: 8
+    import_key: 'l.naia.org.mbasket-t.H90', entity_name: 'Illinois-Springfield Prairie Stars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3710, import_key: 'l.ncaa.org.mbasket-t.H89', entity_name: 'Ind.-South Bend', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H89', entity_name: 'Ind.-South Bend', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3711, import_key: 'l.ncaa.org.mbasket-t.E28', entity_name: 'Olivet Nazarene', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E28', entity_name: 'Olivet Nazarene', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3712, import_key: 'l.ncaa.org.mbasket-t.E89', entity_name: 'St. Francis, Ill.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E89', entity_name: 'St. Francis, Ill.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3713, import_key: 'l.ncaa.org.mbasket-t.H94', entity_name: 'St. Xavier', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H94', entity_name: 'St. Xavier', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3714, import_key: 'l.ncaa.org.mbasket-t.G95', entity_name: 'Allen', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G95', entity_name: 'Allen', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3715, import_key: 'l.ncaa.org.mbasket-t.F26', entity_name: 'Voorhees', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F26', entity_name: 'Voorhees', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3716, import_key: 'l.ncaa.org.mbasket-t.I21', entity_name: 'Carroll, Mont.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I21', entity_name: 'Carroll, Mont.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3717, import_key: 'l.ncaa.org.mbasket-t.F93', entity_name: 'Great Falls', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F93', entity_name: 'Great Falls', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3718, import_key: 'l.ncaa.org.mbasket-t.F02', entity_name: 'Montana St.-Northern', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F02', entity_name: 'Montana St.-Northern', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3719, import_key: 'l.ncaa.org.mbasket-t.E13', entity_name: 'Montana Tech', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E13', entity_name: 'Montana Tech', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3720, import_key: 'l.ncaa.org.mbasket-t.E90', entity_name: 'Montana-Western', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E90', entity_name: 'Montana-Western', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3721, import_key: 'l.ncaa.org.mbasket-t.G74', entity_name: 'Rocky Mountain', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G74', entity_name: 'Rocky Mountain', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3722, import_key: 'l.ncaa.org.mbasket-t.H29', entity_name: 'Azusa Pacific Cougars', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H29', entity_name: 'Azusa Pacific Cougars', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3723, import_key: 'l.ncaa.org.mbasket-t.H46', entity_name: 'Cal Baptist', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H46', entity_name: 'Cal Baptist', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3724, import_key: 'l.ncaa.org.mbasket-t.I02', entity_name: 'Concordia, Calif.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I02', entity_name: 'Concordia, Calif.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3725, import_key: 'l.ncaa.org.mbasket-t.I08', entity_name: 'Hope International', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I08', entity_name: 'Hope International', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3726, import_key: 'l.ncaa.org.mbasket-t.E31', entity_name: 'Point Loma', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E31', entity_name: 'Point Loma', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3727, import_key: 'l.ncaa.org.mbasket-t.I23', entity_name: 'San Diego Christian', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I23', entity_name: 'San Diego Christian', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3728, import_key: 'l.ncaa.org.mbasket-t.E70', entity_name: 'Vanguard', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E70', entity_name: 'Vanguard', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3729, import_key: 'l.ncaa.org.mbasket-t.E81', entity_name: 'Westmont', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E81', entity_name: 'Westmont', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3730, import_key: 'l.ncaa.org.mbasket-t.G87', entity_name: 'Dillard', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G87', entity_name: 'Dillard', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3731, import_key: 'l.ncaa.org.mbasket-t.E03', entity_name: 'Loyola, La.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E03', entity_name: 'Loyola, La.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3732, import_key: 'l.ncaa.org.mbasket-t.G94', entity_name: 'LSU-Shreveport', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G94', entity_name: 'LSU-Shreveport', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3733, import_key: 'l.ncaa.org.mbasket-t.E66', entity_name: 'Mobile', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E66', entity_name: 'Mobile', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3734, import_key: 'l.ncaa.org.mbasket-t.H64', entity_name: 'Southern, New Orleans Error', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H64', entity_name: 'Southern, New Orleans Error', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3735, import_key: 'l.ncaa.org.mbasket-t.F70', entity_name: 'Spring Hill', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F70', entity_name: 'Spring Hill', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3736, import_key: 'l.ncaa.org.mbasket-t.E58', entity_name: 'Tougaloo', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E58', entity_name: 'Tougaloo', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3737, import_key: 'l.ncaa.org.mbasket-t.F78', entity_name: 'William Carey', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F78', entity_name: 'William Carey', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3738, import_key: 'l.ncaa.org.mbasket-t.H97', entity_name: 'Campbellsville', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H97', entity_name: 'Campbellsville', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3739, import_key: 'l.ncaa.org.mbasket-t.F43', entity_name: 'Cumberland, Tenn.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F43', entity_name: 'Cumberland, Tenn.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3740, import_key: 'l.ncaa.org.mbasket-t.G75', entity_name: 'Georgetown, Ky.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G75', entity_name: 'Georgetown, Ky.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3741, import_key: 'l.ncaa.org.mbasket-t.H57', entity_name: 'Lambuth', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H57', entity_name: 'Lambuth', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3742, import_key: 'l.ncaa.org.mbasket-t.H84', entity_name: 'Pikeville', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H84', entity_name: 'Pikeville', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3743, import_key: 'l.ncaa.org.mbasket-t.D40', entity_name: 'Athens St. Bears', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D40', entity_name: 'Athens St. Bears', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3744, import_key: 'l.ncaa.org.mbasket-t.H99', entity_name: 'Mountain St. (WV)', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H99', entity_name: 'Mountain St. (WV)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3745, import_key: 'l.ncaa.org.mbasket-t.H96', entity_name: 'Spalding', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H96', entity_name: 'Spalding', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3746, import_key: 'l.ncaa.org.mbasket-t.JM6', entity_name: 'Talladega Tornadoes', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JM6', entity_name: 'Talladega Tornadoes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3747, import_key: 'l.ncaa.org.mbasket-t.I11', entity_name: 'Wilberforce', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I11', entity_name: 'Wilberforce', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3748, import_key: 'l.ncaa.org.mbasket-t.G86', entity_name: 'Huston-Tillotson', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G86', entity_name: 'Huston-Tillotson', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3749, import_key: 'l.ncaa.org.mbasket-t.F79', entity_name: 'Jarvis Christian', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F79', entity_name: 'Jarvis Christian', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3750, import_key: 'l.ncaa.org.mbasket-t.G21', entity_name: 'NW Oklahoma', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G21', entity_name: 'NW Oklahoma', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3751, import_key: 'l.ncaa.org.mbasket-t.F10', entity_name: 'Paul Quinn', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F10', entity_name: 'Paul Quinn', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3752, import_key: 'l.ncaa.org.mbasket-t.F81', entity_name: 'SW Assemblies of God', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F81', entity_name: 'SW Assemblies of God', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3753, import_key: 'l.ncaa.org.mbasket-t.E55', entity_name: 'Texas Coll.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E55', entity_name: 'Texas Coll.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3754, import_key: 'l.ncaa.org.mbasket-t.G82', entity_name: 'Texas Permian Basin', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G82', entity_name: 'Texas Permian Basin', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3755, import_key: 'l.ncaa.org.mbasket-t.F86', entity_name: 'Texas Wesleyan', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F86', entity_name: 'Texas Wesleyan', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3756, import_key: 'l.ncaa.org.mbasket-t.G51', entity_name: 'TX A&M-Int', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G51', entity_name: 'TX A&M-Int', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3757, import_key: 'l.ncaa.org.mbasket-t.E92', entity_name: 'Wiley', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E92', entity_name: 'Wiley', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3758, import_key: 'l.ncaa.org.mbasket-t.I30', entity_name: 'John Brown', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I30', entity_name: 'John Brown', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3759, import_key: 'l.ncaa.org.mbasket-t.G31', entity_name: 'Lubbock Christian', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G31', entity_name: 'Lubbock Christian', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3760, import_key: 'l.ncaa.org.mbasket-t.I18', entity_name: 'Oklahoma City', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I18', entity_name: 'Oklahoma City', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3761, import_key: 'l.ncaa.org.mbasket-t.G38', entity_name: 'St. Gregorys', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G38', entity_name: 'St. Gregorys', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3762, import_key: 'l.ncaa.org.mbasket-t.E76', entity_name: 'Wayland Baptist', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E76', entity_name: 'Wayland Baptist', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3763, import_key: 'l.ncaa.org.mbasket-t.H59', entity_name: 'Auburn-Montgomery Senators', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H59', entity_name: 'Auburn-Montgomery Senators', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3764, import_key: 'l.ncaa.org.mbasket-t.H44', entity_name: 'Brewton Parker', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H44', entity_name: 'Brewton Parker', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3765, import_key: 'l.ncaa.org.mbasket-t.E23', entity_name: 'North Georgia', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E23', entity_name: 'North Georgia', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3766, import_key: 'l.ncaa.org.mbasket-t.E36', entity_name: 'Reinhardt', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E36', entity_name: 'Reinhardt', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3767, import_key: 'l.ncaa.org.mbasket-t.G70', entity_name: 'Shorter', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G70', entity_name: 'Shorter', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3768, import_key: 'l.ncaa.org.mbasket-t.G25', entity_name: 'Southern Wesleyan', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G25', entity_name: 'Southern Wesleyan', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3769, import_key: 'l.ncaa.org.mbasket-t.JJ7', entity_name: 'Lee University Flames', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JJ7', entity_name: 'Lee University Flames', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3770, import_key: 'l.naia.org.mbasket-t.JN2', entity_name: 'Southern Polytechnic State Hornets', status: 1, entity_type_id: 8
+    import_key: 'l.naia.org.mbasket-t.JN2', entity_name: 'Southern Polytechnic State Hornets', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3771, import_key: 'l.ncaa.org.mbasket-t.F05', entity_name: 'Berry', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F05', entity_name: 'Berry', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3772, import_key: 'l.ncaa.org.mbasket-t.I05', entity_name: 'Freed-Hardeman', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I05', entity_name: 'Freed-Hardeman', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3773, import_key: 'l.ncaa.org.mbasket-t.F76', entity_name: 'Lyon', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F76', entity_name: 'Lyon', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3774, import_key: 'l.ncaa.org.mbasket-t.E60', entity_name: 'Trevecca Nazarene', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E60', entity_name: 'Trevecca Nazarene', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3775, import_key: 'l.naia.org.mbasket-t.I98', entity_name: 'Adrian', status: 1, entity_type_id: 8
+    import_key: 'l.naia.org.mbasket-t.I98', entity_name: 'Adrian', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3776, import_key: 'l.naia.org.mbasket-t.I99', entity_name: 'Apprentice School', status: 1, entity_type_id: 8
+    import_key: 'l.naia.org.mbasket-t.I99', entity_name: 'Apprentice School', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3777, import_key: 'l.naia.org.mbasket-t.KF4', entity_name: 'Benedictine-Springfield', status: 1, entity_type_id: 8
+    import_key: 'l.naia.org.mbasket-t.KF4', entity_name: 'Benedictine-Springfield', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3778, import_key: 'l.ncaa.org.mbasket-t.JK4', entity_name: 'Blue Mountain', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JK4', entity_name: 'Blue Mountain', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3779, import_key: 'l.naia.org.mbasket-t.I89', entity_name: 'Carver Bible', status: 1, entity_type_id: 8
+    import_key: 'l.naia.org.mbasket-t.I89', entity_name: 'Carver Bible', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3780, import_key: 'l.ncaa.org.mbasket-t.F90', entity_name: 'Concordia (MI)', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F90', entity_name: 'Concordia (MI)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3781, import_key: 'l.naia.org.mbasket-t.KE8', entity_name: 'Corban', status: 1, entity_type_id: 8
+    import_key: 'l.naia.org.mbasket-t.KE8', entity_name: 'Corban', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3782, import_key: 'l.naia.org.mbasket-t.I92', entity_name: 'Dallas Christian', status: 1, entity_type_id: 8
+    import_key: 'l.naia.org.mbasket-t.I92', entity_name: 'Dallas Christian', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3783, import_key: 'l.naia.org.mbasket-t.I95', entity_name: 'Daniel Webster', status: 1, entity_type_id: 8
+    import_key: 'l.naia.org.mbasket-t.I95', entity_name: 'Daniel Webster', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3784, import_key: 'l.ncaa.org.mbasket-t.JJ3', entity_name: 'Dixie State', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JJ3', entity_name: 'Dixie State', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3785, import_key: 'l.ncaa.org.mbasket-t.JL6', entity_name: 'Ecclesia', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JL6', entity_name: 'Ecclesia', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3786, import_key: 'l.ncaa.org.mbasket-t.JL7', entity_name: 'Fisher College', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JL7', entity_name: 'Fisher College', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3787, import_key: 'l.naia.org.mbasket-t.I94', entity_name: 'Florida Southern', status: 1, entity_type_id: 8
+    import_key: 'l.naia.org.mbasket-t.I94', entity_name: 'Florida Southern', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3788, import_key: 'l.ncaa.org.mbasket-t.I25', entity_name: 'Humboldt St', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I25', entity_name: 'Humboldt St', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3789, import_key: 'l.naia.org.mbasket-t.I90', entity_name: 'J&W-North Miami', status: 1, entity_type_id: 8
+    import_key: 'l.naia.org.mbasket-t.I90', entity_name: 'J&W-North Miami', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3790, import_key: 'l.ncaa.org.mbasket-t.I97', entity_name: 'Minot State', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I97', entity_name: 'Minot State', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3791, import_key: 'l.ncaa.org.mbasket-t.I09', entity_name: 'Multnomah Bible', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I09', entity_name: 'Multnomah Bible', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3792, import_key: 'l.naia.org.mbasket-t.KG2', entity_name: 'NW Indian College', status: 1, entity_type_id: 8
+    import_key: 'l.naia.org.mbasket-t.KG2', entity_name: 'NW Indian College', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3793, import_key: 'l.naia.org.mbasket-t.I96', entity_name: 'Oberlin', status: 1, entity_type_id: 8
+    import_key: 'l.naia.org.mbasket-t.I96', entity_name: 'Oberlin', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3794, import_key: 'l.naia.org.mbasket-t.I93', entity_name: 'Ohio Christian', status: 1, entity_type_id: 8
+    import_key: 'l.naia.org.mbasket-t.I93', entity_name: 'Ohio Christian', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3795, import_key: 'l.naia.org.mbasket-t.H87', entity_name: 'PR-Bayamon', status: 1, entity_type_id: 8
+    import_key: 'l.naia.org.mbasket-t.H87', entity_name: 'PR-Bayamon', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3796, import_key: 'l.ncaa.org.mbasket-t.JJ4', entity_name: 'Rogers State', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JJ4', entity_name: 'Rogers State', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3797, import_key: 'l.naia.org.mbasket-t.KG1', entity_name: 'Siena Heights', status: 1, entity_type_id: 8
+    import_key: 'l.naia.org.mbasket-t.KG1', entity_name: 'Siena Heights', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3798, import_key: 'l.naia.org.mbasket-t.G39', entity_name: 'Simpson Redhawks', status: 1, entity_type_id: 8
+    import_key: 'l.naia.org.mbasket-t.G39', entity_name: 'Simpson Redhawks', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3799, import_key: 'l.naia.org.mbasket-t.KF5', entity_name: 'Trinity Christian', status: 1, entity_type_id: 8
+    import_key: 'l.naia.org.mbasket-t.KF5', entity_name: 'Trinity Christian', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3800, import_key: 'l.naia.org.mbasket-t.KF6', entity_name: 'VU of Lynchburg', status: 1, entity_type_id: 8
+    import_key: 'l.naia.org.mbasket-t.KF6', entity_name: 'VU of Lynchburg', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3801, import_key: 'l.ncaa.org.mbasket-t.G88', entity_name: 'West Va. Tech', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G88', entity_name: 'West Va. Tech', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3802, import_key: 'l.ncaa.org.mbasket-t.F60', entity_name: 'Cedarville', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F60', entity_name: 'Cedarville', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3803, import_key: 'l.ncaa.org.mbasket-t.JK1', entity_name: 'Geneva Golden Tornadoes', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JK1', entity_name: 'Geneva Golden Tornadoes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3804, import_key: 'l.ncaa.org.mbasket-t.G65', entity_name: 'Houghton', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G65', entity_name: 'Houghton', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3805, import_key: 'l.ncaa.org.mbasket-t.H53', entity_name: 'Notre Dame, Ohio', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H53', entity_name: 'Notre Dame, Ohio', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3806, import_key: 'l.ncaa.org.mbasket-t.F04', entity_name: 'Ohio Dominican', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F04', entity_name: 'Ohio Dominican', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3807, import_key: 'l.ncaa.org.mbasket-t.JK2', entity_name: 'Rio Grande', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JK2', entity_name: 'Rio Grande', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3808, import_key: 'l.ncaa.org.mbasket-t.E40', entity_name: 'Shawnee St.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E40', entity_name: 'Shawnee St.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3809, import_key: 'l.ncaa.org.mbasket-t.F54', entity_name: 'Urbana', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F54', entity_name: 'Urbana', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3810, import_key: 'l.ncaa.org.mbasket-t.JL3', entity_name: 'Alice Lloyd Eagles', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JL3', entity_name: 'Alice Lloyd Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3811, import_key: 'l.ncaa.org.mbasket-t.H40', entity_name: 'Bluefield', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H40', entity_name: 'Bluefield', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3812, import_key: 'l.ncaa.org.mbasket-t.D47', entity_name: 'Brevard, N.C.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D47', entity_name: 'Brevard, N.C.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3813, import_key: 'l.ncaa.org.mbasket-t.D49', entity_name: 'Bryan', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D49', entity_name: 'Bryan', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3814, import_key: 'l.ncaa.org.mbasket-t.D67', entity_name: 'Covenant', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D67', entity_name: 'Covenant', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3815, import_key: 'l.ncaa.org.mbasket-t.D94', entity_name: 'King, Tenn.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D94', entity_name: 'King, Tenn.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3816, import_key: 'l.ncaa.org.mbasket-t.F74', entity_name: 'Milligan', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F74', entity_name: 'Milligan', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3817, import_key: 'l.ncaa.org.mbasket-t.E15', entity_name: 'Montreat', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E15', entity_name: 'Montreat', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3818, import_key: 'l.ncaa.org.mbasket-t.E53', entity_name: 'Tenn. Wesleyan', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E53', entity_name: 'Tenn. Wesleyan', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3819, import_key: 'l.ncaa.org.mbasket-t.E71', entity_name: 'Va. Intermont', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E71', entity_name: 'Va. Intermont', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3820, import_key: 'l.ncaa.org.mbasket-t.E72', entity_name: 'Virginia-Wise', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E72', entity_name: 'Virginia-Wise', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3821, import_key: 'l.ncaa.org.mbasket-t.F06', entity_name: 'Bethany, Calif.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F06', entity_name: 'Bethany, Calif.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3822, import_key: 'l.ncaa.org.mbasket-t.I22', entity_name: 'CS-Maritime', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I22', entity_name: 'CS-Maritime', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3823, import_key: 'l.ncaa.org.mbasket-t.G58', entity_name: 'Dominican, Calif.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G58', entity_name: 'Dominican, Calif.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3824, import_key: 'l.ncaa.org.mbasket-t.G30', entity_name: 'Holy Names', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G30', entity_name: 'Holy Names', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3825, import_key: 'l.ncaa.org.mbasket-t.F14', entity_name: 'Notre Dame, Calif.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F14', entity_name: 'Notre Dame, Calif.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3826, import_key: 'l.ncaa.org.mbasket-t.G72', entity_name: 'William Jessup', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G72', entity_name: 'William Jessup', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3827, import_key: 'l.ncaa.org.mbasket-t.D34', entity_name: 'Albertson Coyotes', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D34', entity_name: 'Albertson Coyotes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3828, import_key: 'l.ncaa.org.mbasket-t.F36', entity_name: 'Cascade', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F36', entity_name: 'Cascade', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3829, import_key: 'l.ncaa.org.mbasket-t.E96', entity_name: 'Concordia, Ore.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E96', entity_name: 'Concordia, Ore.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3830, import_key: 'l.ncaa.org.mbasket-t.F35', entity_name: 'E. Oregon', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F35', entity_name: 'E. Oregon', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3831, import_key: 'l.ncaa.org.mbasket-t.D75', entity_name: 'Evergreen St.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D75', entity_name: 'Evergreen St.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3832, import_key: 'l.naia.org.mbasket-t.JP8', entity_name: 'Northwest Christian (OR) Beacons', status: 1, entity_type_id: 8
+    import_key: 'l.naia.org.mbasket-t.JP8', entity_name: 'Northwest Christian (OR) Beacons', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3833, import_key: 'l.ncaa.org.mbasket-t.E25', entity_name: 'Northwest College Bearcats', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E25', entity_name: 'Northwest College Bearcats', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3834, import_key: 'l.ncaa.org.mbasket-t.E46', entity_name: 'S. Oregon', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E46', entity_name: 'S. Oregon', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3835, import_key: 'l.ncaa.org.mbasket-t.G64', entity_name: 'Warner Pacific', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G64', entity_name: 'Warner Pacific', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3836, import_key: 'l.ncaa.org.mbasket-t.D54', entity_name: 'Cardinal Stritch', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D54', entity_name: 'Cardinal Stritch', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3837, import_key: 'l.ncaa.org.mbasket-t.H08', entity_name: 'Kendall', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H08', entity_name: 'Kendall', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3838, import_key: 'l.ncaa.org.mbasket-t.G08', entity_name: 'Dickinson St.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G08', entity_name: 'Dickinson St.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3839, import_key: 'l.ncaa.org.mbasket-t.E99', entity_name: 'Jamestown', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E99', entity_name: 'Jamestown', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3840, import_key: 'l.ncaa.org.mbasket-t.H18', entity_name: 'Mary', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H18', entity_name: 'Mary', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3841, import_key: 'l.ncaa.org.mbasket-t.H73', entity_name: 'Mayville St.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H73', entity_name: 'Mayville St.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3842, import_key: 'l.ncaa.org.mbasket-t.D77', entity_name: 'Flagler', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D77', entity_name: 'Flagler', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3843, import_key: 'l.ncaa.org.mbasket-t.E77', entity_name: 'Webber', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E77', entity_name: 'Webber', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3844, import_key: 'l.ncaa.org.mbasket-t.H75', entity_name: 'Dakota Wesleyan Tigers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H75', entity_name: 'Dakota Wesleyan Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3845, import_key: 'l.ncaa.org.mbasket-t.H80', entity_name: 'Morningside Mustangs', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H80', entity_name: 'Morningside Mustangs', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3846, import_key: 'l.ncaa.org.mbasket-t.JL2', entity_name: 'Avila Eagles', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JL2', entity_name: 'Avila Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3847, import_key: 'l.naia.org.mbasket-t.JQ1', entity_name: 'Graceland Yellowjackets', status: 1, entity_type_id: 8
+    import_key: 'l.naia.org.mbasket-t.JQ1', entity_name: 'Graceland Yellowjackets', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3848, import_key: 'l.ncaa.org.mbasket-t.D57', entity_name: 'Cent. Methodist', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D57', entity_name: 'Cent. Methodist', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3849, import_key: 'l.ncaa.org.mbasket-t.G02', entity_name: 'Missouri Valley', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G02', entity_name: 'Missouri Valley', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3850, import_key: 'l.ncaa.org.mbasket-t.H61', entity_name: 'Southwestern, Kan.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H61', entity_name: 'Southwestern, Kan.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3851, import_key: 'l.naia.org.mbasket.div2-t.JN4', entity_name: 'Indiana University East Red Wolves', status: 1, entity_type_id: 8
+    import_key: 'l.naia.org.mbasket.div2-t.JN4', entity_name: 'Indiana University East Red Wolves', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3852, import_key: 'l.ncaa.org.mbasket-t.F20', entity_name: 'Maine-Fort Kent', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F20', entity_name: 'Maine-Fort Kent', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3853, import_key: 'l.ncaa.org.mbasket-t.G16', entity_name: 'Maine-Machias', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G16', entity_name: 'Maine-Machias', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3854, import_key: 'l.ncaa.org.mbasket-t.D84', entity_name: 'Goshen', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D84', entity_name: 'Goshen', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3855, import_key: 'l.ncaa.org.mbasket-t.JK5', entity_name: 'Grace', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JK5', entity_name: 'Grace', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3856, import_key: 'l.ncaa.org.mbasket-t.H54', entity_name: 'Huntington (Ind.)', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H54', entity_name: 'Huntington (Ind.)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3857, import_key: 'l.ncaa.org.mbasket-t.H88', entity_name: 'Indiana Wesleyan', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H88', entity_name: 'Indiana Wesleyan', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3858, import_key: 'l.ncaa.org.mbasket-t.E06', entity_name: 'Marian, Ind.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E06', entity_name: 'Marian, Ind.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3859, import_key: 'l.ncaa.org.mbasket-t.G40', entity_name: 'St. Francis, Ind.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G40', entity_name: 'St. Francis, Ind.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3860, import_key: 'l.ncaa.org.mbasket-t.F56', entity_name: 'Taylor', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F56', entity_name: 'Taylor', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3861, import_key: 'l.ncaa.org.mbasket-t.H81', entity_name: 'Bellevue Bruins', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H81', entity_name: 'Bellevue Bruins', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3862, import_key: 'l.ncaa.org.mbasket-t.E47', entity_name: 'St. Ambrose', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E47', entity_name: 'St. Ambrose', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3863, import_key: 'l.ncaa.org.mbasket-t.I19', entity_name: 'William Penn Statesmen', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I19', entity_name: 'William Penn Statesmen', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3864, import_key: 'l.ncaa.org.mbasket-t.D39', entity_name: 'Asbury Eagles', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D39', entity_name: 'Asbury Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3865, import_key: 'l.ncaa.org.mbasket-t.F91', entity_name: 'Belhaven Blazers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F91', entity_name: 'Belhaven Blazers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3866, import_key: 'l.ncaa.org.mbasket-t.D45', entity_name: 'Bethel, Tenn.', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D45', entity_name: 'Bethel, Tenn.', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3867, import_key: 'l.ncaa.org.mbasket-t.D48', entity_name: 'Briar Cliff', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D48', entity_name: 'Briar Cliff', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3868, import_key: 'l.ncaa.org.mbasket-t.H10', entity_name: 'Indiana-Northwest', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H10', entity_name: 'Indiana-Northwest', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3869, import_key: 'l.ncaa.org.mbasket-t.H55', entity_name: 'Indiana-Southeast', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H55', entity_name: 'Indiana-Southeast', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3870, import_key: 'l.ncaa.org.mbasket-t.H01', entity_name: 'J&W-Denver', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H01', entity_name: 'J&W-Denver', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3871, import_key: 'l.ncaa.org.mbasket-t.F97', entity_name: 'Knoxville', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F97', entity_name: 'Knoxville', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3872, import_key: 'l.ncaa.org.mbasket-t.G56', entity_name: 'S. Virginia', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G56', entity_name: 'S. Virginia', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3873, import_key: 'l.ncaa.org.mbasket-t.G09', entity_name: 'Aquinas Saints', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G09', entity_name: 'Aquinas Saints', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3874, import_key: 'l.ncaa.org.mbasket-t.D92', entity_name: 'Indiana Tech', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D92', entity_name: 'Indiana Tech', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3875, import_key: 'l.ncaa.org.mbasket-t.F30', entity_name: 'Spring Arbor', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F30', entity_name: 'Spring Arbor', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3876, import_key: 'l.naia.org.mbasket.div2-t.KG3', entity_name: 'Portland Bible College', status: 1, entity_type_id: 8
+    import_key: 'l.naia.org.mbasket.div2-t.KG3', entity_name: 'Portland Bible College', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3877, import_key: 'l.ncaa.org.mbasket-t.F82', entity_name: 'Central Baptist', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F82', entity_name: 'Central Baptist', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3878, import_key: 'l.ncaa.org.mbasket-t.F34', entity_name: 'OK Wesleyan', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F34', entity_name: 'OK Wesleyan', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3879, import_key: 'l.ncaa.org.mbasket-t.G32', entity_name: 'Tennessee Temple University', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.G32', entity_name: 'Tennessee Temple University', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3880, import_key: 'l.ncaa.org.mbasket-t.H42', entity_name: 'Atlanta Christian', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H42', entity_name: 'Atlanta Christian', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3881, import_key: 'l.ncaa.org.mbasket-t.H62', entity_name: 'Cincinnati Christian Univeristy', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H62', entity_name: 'Cincinnati Christian Univeristy', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3882, import_key: 'l.ncaa.org.mbasket-t.I14', entity_name: 'Florida Christian College', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I14', entity_name: 'Florida Christian College', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3883, import_key: 'l.ncaa.org.mbasket-t.H38', entity_name: 'Hillsdale Baptist', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H38', entity_name: 'Hillsdale Baptist', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3884, import_key: 'l.ncaa.org.mbasket-t.F96', entity_name: 'Kentucky Christian', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F96', entity_name: 'Kentucky Christian', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3885, import_key: 'l.ncaa.org.mbasket-t.F89', entity_name: 'Southeastern', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F89', entity_name: 'Southeastern', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3886, import_key: 'l.ncaa.org.mbasket-t.E57', entity_name: 'Toccoa Falls', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E57', entity_name: 'Toccoa Falls', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3887, import_key: 'l.ncaa.org.mbasket-t.H63', entity_name: 'Davenport (MI)', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.H63', entity_name: 'Davenport (MI)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3888, import_key: 'l.ncaa.org.mbasket-t.I39', entity_name: 'Marygrove (MI)', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.I39', entity_name: 'Marygrove (MI)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3889, import_key: 'l.theuscaa.com.mbasket-t.JP4', entity_name: 'Northern New Mexico College Eagles', status: 1, entity_type_id: 8
+    import_key: 'l.theuscaa.com.mbasket-t.JP4', entity_name: 'Northern New Mexico College Eagles', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3890, import_key: 'l.ncaa.org.mbasket-t.E29', entity_name: 'Philander Smith (AR)', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E29', entity_name: 'Philander Smith (AR)', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3891, import_key: 'l.ncaa.org.mbasket-t.F08', entity_name: 'Rochester College (MI) Warriors', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.F08', entity_name: 'Rochester College (MI) Warriors', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3892, import_key: 'l.ncaa.org.mbasket-t.D37', entity_name: 'Arkansas Baptist Buffaloes', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.D37', entity_name: 'Arkansas Baptist Buffaloes', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3893, import_key: 'l.ncaa.org.mbasket-t.JQ9', entity_name: 'Champion Baptist College Tigers', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.JQ9', entity_name: 'Champion Baptist College Tigers', status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3894, import_key: 'l.ncaa.org.mbasket-t.E73', entity_name: 'Warren Wilson', status: 1, entity_type_id: 8
+    import_key: 'l.ncaa.org.mbasket-t.E73', entity_name: 'Warren Wilson', status: 1, entity_type_id: entity_type_id
   }
 ])

--- a/db/seeds/009_wftda.rb
+++ b/db/seeds/009_wftda.rb
@@ -1,780 +1,781 @@
 # -*- coding: utf-8 -*-
+entity_type_id = EntityType.find_by_entity_type_abbreviation('WFTDA').id
 Entity.create([
   {
-    id: 1479, entity_name: 'A\'Salt Creek Rollergirls (Casper WY)', entity_type_id: 9, status: 1
+    entity_name: 'A\'Salt Creek Rollergirls (Casper WY)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1480, entity_name: 'Alamo City Rollergirls (San Antonio TX)', entity_type_id: 9, status: 1
+    entity_name: 'Alamo City Rollergirls (San Antonio TX)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1481, entity_name: 'Angel City Derby Girls (Los Angeles CA)', entity_type_id: 9, status: 1
+    entity_name: 'Angel City Derby Girls (Los Angeles CA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1482, entity_name: 'Ann Arbor Derby Dimes (Ann Arbor MI)', entity_type_id: 9, status: 1
+    entity_name: 'Ann Arbor Derby Dimes (Ann Arbor MI)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1483, entity_name: 'Appalachian Rollergirls (Boone NC)', entity_type_id: 9, status: 1
+    entity_name: 'Appalachian Rollergirls (Boone NC)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1484, entity_name: 'Arch Rival Roller Girls (Saint Louis MO)', entity_type_id: 9, status: 1
+    entity_name: 'Arch Rival Roller Girls (Saint Louis MO)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1485, entity_name: 'Arizona Roller Derby (Phoenix AZ)', entity_type_id: 9, status: 1
+    entity_name: 'Arizona Roller Derby (Phoenix AZ)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1486, entity_name: 'Ark Valley High Rollers (Salida CO)', entity_type_id: 9, status: 1
+    entity_name: 'Ark Valley High Rollers (Salida CO)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1487, entity_name: 'Assassination City Roller Derby (Dallas TX)', entity_type_id: 9, status: 1
+    entity_name: 'Assassination City Roller Derby (Dallas TX)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1488, entity_name: 'Assault City Roller Derby (Syracuse NY)', entity_type_id: 9, status: 1
+    entity_name: 'Assault City Roller Derby (Syracuse NY)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1489, entity_name: 'Atlanta Rollergirls (Atlanta GA)', entity_type_id: 9, status: 1
+    entity_name: 'Atlanta Rollergirls (Atlanta GA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1490, entity_name: 'Auld Reekie Roller Girls (Edinburgh)', entity_type_id: 9, status: 1
+    entity_name: 'Auld Reekie Roller Girls (Edinburgh)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1491, entity_name: 'B.ay A.rea D.erby Girls (San Francisco CA)', entity_type_id: 9, status: 1
+    entity_name: 'B.ay A.rea D.erby Girls (San Francisco CA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1492, entity_name: 'Babe City Rollers (Bemidji MN)', entity_type_id: 9, status: 1
+    entity_name: 'Babe City Rollers (Bemidji MN)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1493, entity_name: 'Bakersfield Diamond Divas (Bakersfield CA)', entity_type_id: 9, status: 1
+    entity_name: 'Bakersfield Diamond Divas (Bakersfield CA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1494, entity_name: 'Bay State Brawlers (Brighton MA)', entity_type_id: 9, status: 1
+    entity_name: 'Bay State Brawlers (Brighton MA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1495, entity_name: 'Bear City Roller Derby ( Berlin)', entity_type_id: 9, status: 1
+    entity_name: 'Bear City Roller Derby ( Berlin)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1496, entity_name: 'Bellingham Roller Betties (Bellingham WA)', entity_type_id: 9, status: 1
+    entity_name: 'Bellingham Roller Betties (Bellingham WA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1497, entity_name: 'Big Easy Rollergirls (New Orleans LA)', entity_type_id: 9, status: 1
+    entity_name: 'Big Easy Rollergirls (New Orleans LA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1498, entity_name: 'Black Rose Rollers (Hanover PA)', entity_type_id: 9, status: 1
+    entity_name: 'Black Rose Rollers (Hanover PA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1499, entity_name: 'Black-n-Bluegrass Rollergirls (Latonia KY)', entity_type_id: 9, status: 1
+    entity_name: 'Black-n-Bluegrass Rollergirls (Latonia KY)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1500, entity_name: 'Bleeding Heartland Roller Derby (Bloomington IN)', entity_type_id: 9, status: 1
+    entity_name: 'Bleeding Heartland Roller Derby (Bloomington IN)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1501, entity_name: 'Blue Ridge Rollergirls (Asheville NC)', entity_type_id: 9, status: 1
+    entity_name: 'Blue Ridge Rollergirls (Asheville NC)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1502, entity_name: 'Border City Brawlers (Windsor ON)', entity_type_id: 9, status: 1
+    entity_name: 'Border City Brawlers (Windsor ON)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1503, entity_name: 'Boston Derby Dames (Boston MA)', entity_type_id: 9, status: 1
+    entity_name: 'Boston Derby Dames (Boston MA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1504, entity_name: 'Boulder County Bombers (Longmont CO)', entity_type_id: 9, status: 1
+    entity_name: 'Boulder County Bombers (Longmont CO)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1505, entity_name: 'Brandywine Roller Girls (Downingtown PA)', entity_type_id: 9, status: 1
+    entity_name: 'Brandywine Roller Girls (Downingtown PA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1506, entity_name: 'Brewcity Bruisers (Milwaukee WI)', entity_type_id: 9, status: 1
+    entity_name: 'Brewcity Bruisers (Milwaukee WI)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1507, entity_name: 'Burning River Roller Girls (Cleveland OH)', entity_type_id: 9, status: 1
+    entity_name: 'Burning River Roller Girls (Cleveland OH)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1508, entity_name: 'Cajun Rollergirls (Houma LA)', entity_type_id: 9, status: 1
+    entity_name: 'Cajun Rollergirls (Houma LA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1509, entity_name: 'Calgary Roller Derby Association (Calgary AB)', entity_type_id: 9, status: 1
+    entity_name: 'Calgary Roller Derby Association (Calgary AB)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1510, entity_name: 'Cape Fear Roller Girls (Wilmington NC)', entity_type_id: 9, status: 1
+    entity_name: 'Cape Fear Roller Girls (Wilmington NC)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1511, entity_name: 'Carolina Rollergirls (Raleigh NC)', entity_type_id: 9, status: 1
+    entity_name: 'Carolina Rollergirls (Raleigh NC)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1512, entity_name: 'Castle Rock ’n’ Rollers (Castle Rock CO)', entity_type_id: 9, status: 1
+    entity_name: 'Castle Rock ’n’ Rollers (Castle Rock CO)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1513, entity_name: 'Cedar Rapids RollerGirls (Cedar Rapids IA)', entity_type_id: 9, status: 1
+    entity_name: 'Cedar Rapids RollerGirls (Cedar Rapids IA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1514, entity_name: 'Cedar Valley Derby Divas (Waterloo IA)', entity_type_id: 9, status: 1
+    entity_name: 'Cedar Valley Derby Divas (Waterloo IA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1515, entity_name: 'Cen-Tex Rollergirls (Temple TX)', entity_type_id: 9, status: 1
+    entity_name: 'Cen-Tex Rollergirls (Temple TX)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1516, entity_name: 'Central City Rollergirls (Birmingham)', entity_type_id: 9, status: 1
+    entity_name: 'Central City Rollergirls (Birmingham)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1517, entity_name: 'Central Coast Roller Derby (Paso Robles CA)', entity_type_id: 9, status: 1
+    entity_name: 'Central Coast Roller Derby (Paso Robles CA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1518, entity_name: 'Central New York Roller Derby (Utica NY)', entity_type_id: 9, status: 1
+    entity_name: 'Central New York Roller Derby (Utica NY)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1519, entity_name: 'Charlotte Roller Girls (Charlotte NC)', entity_type_id: 9, status: 1
+    entity_name: 'Charlotte Roller Girls (Charlotte NC)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1520, entity_name: 'Charlottesville Derby Dames (Charlottesville VA)', entity_type_id: 9, status: 1
+    entity_name: 'Charlottesville Derby Dames (Charlottesville VA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1521, entity_name: 'Charm City Roller Girls (Baltimore MD)', entity_type_id: 9, status: 1
+    entity_name: 'Charm City Roller Girls (Baltimore MD)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1522, entity_name: 'Chattanooga Roller Girls (Chattanooga TN)', entity_type_id: 9, status: 1
+    entity_name: 'Chattanooga Roller Girls (Chattanooga TN)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1523, entity_name: 'Chemical Valley Rollergirls (Charleston WV)', entity_type_id: 9, status: 1
+    entity_name: 'Chemical Valley Rollergirls (Charleston WV)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1524, entity_name: 'Cherry City Derby Girls (Salem OR)', entity_type_id: 9, status: 1
+    entity_name: 'Cherry City Derby Girls (Salem OR)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1525, entity_name: 'Cheyenne Capidolls (Cheyenne WY)', entity_type_id: 9, status: 1
+    entity_name: 'Cheyenne Capidolls (Cheyenne WY)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1526, entity_name: 'Chicago Outfit Roller Derby (Chicago IL)', entity_type_id: 9, status: 1
+    entity_name: 'Chicago Outfit Roller Derby (Chicago IL)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1527, entity_name: 'Chippewa Valley Rollergirls (Eau Claire WI)', entity_type_id: 9, status: 1
+    entity_name: 'Chippewa Valley Rollergirls (Eau Claire WI)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1528, entity_name: 'Cincinnati Rollergirls (Cincinnati OH)', entity_type_id: 9, status: 1
+    entity_name: 'Cincinnati Rollergirls (Cincinnati OH)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1529, entity_name: 'Circle City Derby Girls (Indianapolis IN)', entity_type_id: 9, status: 1
+    entity_name: 'Circle City Derby Girls (Indianapolis IN)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1530, entity_name: 'Classic City Rollergirls (Athens GA)', entity_type_id: 9, status: 1
+    entity_name: 'Classic City Rollergirls (Athens GA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1531, entity_name: 'Columbia QuadSquad Rollergirls (Columbia SC)', entity_type_id: 9, status: 1
+    entity_name: 'Columbia QuadSquad Rollergirls (Columbia SC)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1532, entity_name: 'CoMo Derby Dames (Columbia/Jefferson City MO)', entity_type_id: 9, status: 1
+    entity_name: 'CoMo Derby Dames (Columbia/Jefferson City MO)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1533, entity_name: 'Confluence Crush Roller Derby (St. Louis MO)', entity_type_id: 9, status: 1
+    entity_name: 'Confluence Crush Roller Derby (St. Louis MO)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1534, entity_name: 'Copenhagen Roller Derby (  Copenhagen)', entity_type_id: 9, status: 1
+    entity_name: 'Copenhagen Roller Derby (  Copenhagen)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1535, entity_name: 'Cornfed Derby Dames (Muncie IN)', entity_type_id: 9, status: 1
+    entity_name: 'Cornfed Derby Dames (Muncie IN)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1536, entity_name: 'Cowboy Capital Rollergirls (Stephenville TX)', entity_type_id: 9, status: 1
+    entity_name: 'Cowboy Capital Rollergirls (Stephenville TX)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1537, entity_name: 'Crime City Rollers ( Malmo)', entity_type_id: 9, status: 1
+    entity_name: 'Crime City Rollers ( Malmo)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1538, entity_name: 'Crossroads City Derby (Las Cruces NM)', entity_type_id: 9, status: 1
+    entity_name: 'Crossroads City Derby (Las Cruces NM)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1539, entity_name: 'CT RollerGirls (New Haven CT)', entity_type_id: 9, status: 1
+    entity_name: 'CT RollerGirls (New Haven CT)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1540, entity_name: 'Dallas Derby Devils (Dallas TX)', entity_type_id: 9, status: 1
+    entity_name: 'Dallas Derby Devils (Dallas TX)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1541, entity_name: 'DC Rollergirls (Washington DC)', entity_type_id: 9, status: 1
+    entity_name: 'DC Rollergirls (Washington DC)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1542, entity_name: 'Demolition City Roller Derby (Evansville IN)', entity_type_id: 9, status: 1
+    entity_name: 'Demolition City Roller Derby (Evansville IN)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1543, entity_name: 'Denali Destroyer Dolls (Wasilla AK)', entity_type_id: 9, status: 1
+    entity_name: 'Denali Destroyer Dolls (Wasilla AK)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1544, entity_name: 'Denver Roller Dolls (Denver CO)', entity_type_id: 9, status: 1
+    entity_name: 'Denver Roller Dolls (Denver CO)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1545, entity_name: 'Derby City Rollergirls (Louisville KY)', entity_type_id: 9, status: 1
+    entity_name: 'Derby City Rollergirls (Louisville KY)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1546, entity_name: 'Derby Revolution of Bakersfield (Bakersfield CA)', entity_type_id: 9, status: 1
+    entity_name: 'Derby Revolution of Bakersfield (Bakersfield CA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1547, entity_name: 'Des Moines Derby Dames (Des Moines IA)', entity_type_id: 9, status: 1
+    entity_name: 'Des Moines Derby Dames (Des Moines IA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1548, entity_name: 'Detroit Derby Girls (Detroit MI)', entity_type_id: 9, status: 1
+    entity_name: 'Detroit Derby Girls (Detroit MI)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1549, entity_name: 'Devil Dog Derby Dames (Okinawa, -ken)', entity_type_id: 9, status: 1
+    entity_name: 'Devil Dog Derby Dames (Okinawa, -ken)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1550, entity_name: 'Diamond State Roller Girls (Wilmington DE)', entity_type_id: 9, status: 1
+    entity_name: 'Diamond State Roller Girls (Wilmington DE)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1551, entity_name: 'Dixie Derby Girls (Huntsville AL)', entity_type_id: 9, status: 1
+    entity_name: 'Dixie Derby Girls (Huntsville AL)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1552, entity_name: 'Dockyard Derby Dames (Tacoma WA)', entity_type_id: 9, status: 1
+    entity_name: 'Dockyard Derby Dames (Tacoma WA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1553, entity_name: 'Dolly Rockit Rollers (Leicestershire)', entity_type_id: 9, status: 1
+    entity_name: 'Dolly Rockit Rollers (Leicestershire)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1554, entity_name: 'Dominion Derby Girls (Virginia Beach VA)', entity_type_id: 9, status: 1
+    entity_name: 'Dominion Derby Girls (Virginia Beach VA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1555, entity_name: 'Duke City Roller Derby (Albuquerque NM)', entity_type_id: 9, status: 1
+    entity_name: 'Duke City Roller Derby (Albuquerque NM)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1556, entity_name: 'Durango Roller Girls (Durango CO)', entity_type_id: 9, status: 1
+    entity_name: 'Durango Roller Girls (Durango CO)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1557, entity_name: 'Dutchland Derby Rollers (Lancaster PA)', entity_type_id: 9, status: 1
+    entity_name: 'Dutchland Derby Rollers (Lancaster PA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1558, entity_name: 'El Paso Roller Derby (El Paso TX)', entity_type_id: 9, status: 1
+    entity_name: 'El Paso Roller Derby (El Paso TX)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1559, entity_name: 'Emerald City Roller Girls (Eugene OR)', entity_type_id: 9, status: 1
+    entity_name: 'Emerald City Roller Girls (Eugene OR)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1560, entity_name: 'Enid Roller Girls (Enid OK)', entity_type_id: 9, status: 1
+    entity_name: 'Enid Roller Girls (Enid OK)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1561, entity_name: 'Fabulous Sin City Rollergirls (Las Vegas NV)', entity_type_id: 9, status: 1
+    entity_name: 'Fabulous Sin City Rollergirls (Las Vegas NV)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1562, entity_name: 'Fairbanks Rollergirls (Fairbanks AK)', entity_type_id: 9, status: 1
+    entity_name: 'Fairbanks Rollergirls (Fairbanks AK)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1563, entity_name: 'Fargo Moorhead Derby Girls (Fargo ND)', entity_type_id: 9, status: 1
+    entity_name: 'Fargo Moorhead Derby Girls (Fargo ND)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1564, entity_name: 'FoCo Girls Gone Derby (Fort Collins CO)', entity_type_id: 9, status: 1
+    entity_name: 'FoCo Girls Gone Derby (Fort Collins CO)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1565, entity_name: 'Forest City Derby Girls (London ON)', entity_type_id: 9, status: 1
+    entity_name: 'Forest City Derby Girls (London ON)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1566, entity_name: 'Fort Myers Derby Girls (Fort Myers FL)', entity_type_id: 9, status: 1
+    entity_name: 'Fort Myers Derby Girls (Fort Myers FL)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1567, entity_name: 'Fort Wayne Derby Girls (Fort Wayne IN)', entity_type_id: 9, status: 1
+    entity_name: 'Fort Wayne Derby Girls (Fort Wayne IN)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1568, entity_name: 'Fox Cityz Foxz (Appleton WI)', entity_type_id: 9, status: 1
+    entity_name: 'Fox Cityz Foxz (Appleton WI)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1569, entity_name: 'Gainesville Roller Rebels (Gainesville FL)', entity_type_id: 9, status: 1
+    entity_name: 'Gainesville Roller Rebels (Gainesville FL)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1570, entity_name: 'Garden State Rollergirls (Wallington NJ)', entity_type_id: 9, status: 1
+    entity_name: 'Garden State Rollergirls (Wallington NJ)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1571, entity_name: 'Gem City Rollergirls (Dayton OH)', entity_type_id: 9, status: 1
+    entity_name: 'Gem City Rollergirls (Dayton OH)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1572, entity_name: 'Gent Go Go Rollergirls ( Gent)', entity_type_id: 9, status: 1
+    entity_name: 'Gent Go Go Rollergirls ( Gent)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1573, entity_name: 'Glasgow Roller Derby (Glasgow)', entity_type_id: 9, status: 1
+    entity_name: 'Glasgow Roller Derby (Glasgow)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1574, entity_name: 'Glass City Rollers (Toledo OH)', entity_type_id: 9, status: 1
+    entity_name: 'Glass City Rollers (Toledo OH)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1575, entity_name: 'Gold Coast Derby Grrls (Fort Lauderdale FL)', entity_type_id: 9, status: 1
+    entity_name: 'Gold Coast Derby Grrls (Fort Lauderdale FL)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1576, entity_name: 'Gotham Girls Roller Derby (New York NY)', entity_type_id: 9, status: 1
+    entity_name: 'Gotham Girls Roller Derby (New York NY)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1577, entity_name: 'Grand Raggidy Roller Girls (Grand Rapids MI)', entity_type_id: 9, status: 1
+    entity_name: 'Grand Raggidy Roller Girls (Grand Rapids MI)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1578, entity_name: 'Granite State Roller Derby (Concord NH)', entity_type_id: 9, status: 1
+    entity_name: 'Granite State Roller Derby (Concord NH)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1579, entity_name: 'Greater Toronto Area Rollergirls (Toronto ON)', entity_type_id: 9, status: 1
+    entity_name: 'Greater Toronto Area Rollergirls (Toronto ON)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1580, entity_name: 'Green Mountain Derby Dames (Essex Junction VT)', entity_type_id: 9, status: 1
+    entity_name: 'Green Mountain Derby Dames (Essex Junction VT)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1581, entity_name: 'Greensboro Roller Derby (Greensboro NC)', entity_type_id: 9, status: 1
+    entity_name: 'Greensboro Roller Derby (Greensboro NC)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1582, entity_name: 'Greenville Derby Dames (Greenville SC)', entity_type_id: 9, status: 1
+    entity_name: 'Greenville Derby Dames (Greenville SC)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1583, entity_name: 'Hammer City Roller Girls (Hamilton ON)', entity_type_id: 9, status: 1
+    entity_name: 'Hammer City Roller Girls (Hamilton ON)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1584, entity_name: 'Happy Valley Derby Darlins (Utah County UT)', entity_type_id: 9, status: 1
+    entity_name: 'Happy Valley Derby Darlins (Utah County UT)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1585, entity_name: 'Harbor City Roller Dames (Duluth MN)', entity_type_id: 9, status: 1
+    entity_name: 'Harbor City Roller Dames (Duluth MN)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1586, entity_name: 'Hard Knox Roller Girls (Knoxville TN)', entity_type_id: 9, status: 1
+    entity_name: 'Hard Knox Roller Girls (Knoxville TN)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1587, entity_name: 'Harrisburg Area Roller Derby (Enola PA)', entity_type_id: 9, status: 1
+    entity_name: 'Harrisburg Area Roller Derby (Enola PA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1588, entity_name: 'Hartford Area Roller Derby (Manchester CT)', entity_type_id: 9, status: 1
+    entity_name: 'Hartford Area Roller Derby (Manchester CT)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1589, entity_name: 'Hellions of Troy Roller Derby (Saratoga Springs NY)', entity_type_id: 9, status: 1
+    entity_name: 'Hellions of Troy Roller Derby (Saratoga Springs NY)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1590, entity_name: 'Helsinki Roller Derby ( Helsinki)', entity_type_id: 9, status: 1
+    entity_name: 'Helsinki Roller Derby ( Helsinki)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1591, entity_name: 'Houston Roller Derby (Houston TX)', entity_type_id: 9, status: 1
+    entity_name: 'Houston Roller Derby (Houston TX)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1592, entity_name: 'Hub City Derby Dames (Hattiesburg MS)', entity_type_id: 9, status: 1
+    entity_name: 'Hub City Derby Dames (Hattiesburg MS)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1593, entity_name: 'Hudson Valley Horrors Roller Derby (Kingston NY)', entity_type_id: 9, status: 1
+    entity_name: 'Hudson Valley Horrors Roller Derby (Kingston NY)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1594, entity_name: 'Humboldt Roller Derby (Eureka CA)', entity_type_id: 9, status: 1
+    entity_name: 'Humboldt Roller Derby (Eureka CA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1595, entity_name: 'ICT Roller Girls (Wichita KS)', entity_type_id: 9, status: 1
+    entity_name: 'ICT Roller Girls (Wichita KS)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1596, entity_name: 'Ithaca League of Women Rollers (Ithaca NY)', entity_type_id: 9, status: 1
+    entity_name: 'Ithaca League of Women Rollers (Ithaca NY)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1597, entity_name: 'Jacksonville Rollergirls (Jacksonville FL)', entity_type_id: 9, status: 1
+    entity_name: 'Jacksonville Rollergirls (Jacksonville FL)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1598, entity_name: 'Jersey Shore Roller Girls (Toms River NJ)', entity_type_id: 9, status: 1
+    entity_name: 'Jersey Shore Roller Girls (Toms River NJ)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1599, entity_name: 'Jet City Rollergirls (Everett WA)', entity_type_id: 9, status: 1
+    entity_name: 'Jet City Rollergirls (Everett WA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1600, entity_name: 'Junction City Roller Dolls (Ogden UT)', entity_type_id: 9, status: 1
+    entity_name: 'Junction City Roller Dolls (Ogden UT)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1601, entity_name: 'Kallio Rolling Rainbow ( Helsinki)', entity_type_id: 9, status: 1
+    entity_name: 'Kallio Rolling Rainbow ( Helsinki)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1602, entity_name: 'Kansas City Roller Warriors (Kansas City MO)', entity_type_id: 9, status: 1
+    entity_name: 'Kansas City Roller Warriors (Kansas City MO)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1603, entity_name: 'Killamazoo Derby Darlins (Kalamazoo MI)', entity_type_id: 9, status: 1
+    entity_name: 'Killamazoo Derby Darlins (Kalamazoo MI)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1604, entity_name: 'Kokeshi Roller Dolls (Okinawa, -ken)', entity_type_id: 9, status: 1
+    entity_name: 'Kokeshi Roller Dolls (Okinawa, -ken)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1605, entity_name: 'Lafayette Brawlin’ Dolls (Lafayette IN)', entity_type_id: 9, status: 1
+    entity_name: 'Lafayette Brawlin’ Dolls (Lafayette IN)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1606, entity_name: 'Lansing Derby Vixens (Lansing MI)', entity_type_id: 9, status: 1
+    entity_name: 'Lansing Derby Vixens (Lansing MI)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1607, entity_name: 'Lava City Roller Dolls (Bend OR)', entity_type_id: 9, status: 1
+    entity_name: 'Lava City Roller Dolls (Bend OR)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1608, entity_name: 'Leeds Roller Dolls (Leeds)', entity_type_id: 9, status: 1
+    entity_name: 'Leeds Roller Dolls (Leeds)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1609, entity_name: 'Lehigh Valley Rollergirls (Schnecksville PA)', entity_type_id: 9, status: 1
+    entity_name: 'Lehigh Valley Rollergirls (Schnecksville PA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1610, entity_name: 'Lilac City Rollergirls (Spokane WA)', entity_type_id: 9, status: 1
+    entity_name: 'Lilac City Rollergirls (Spokane WA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1611, entity_name: 'Lincolnshire Bombers Roller Girls (Lincolnshire)', entity_type_id: 9, status: 1
+    entity_name: 'Lincolnshire Bombers Roller Girls (Lincolnshire)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1612, entity_name: 'Little City Roller Girls (Johnson City TN)', entity_type_id: 9, status: 1
+    entity_name: 'Little City Roller Girls (Johnson City TN)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1613, entity_name: 'Little Steel Derby Girls (Youngstown OH)', entity_type_id: 9, status: 1
+    entity_name: 'Little Steel Derby Girls (Youngstown OH)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1614, entity_name: 'London Rockin\' Rollers (London)', entity_type_id: 9, status: 1
+    entity_name: 'London Rockin\' Rollers (London)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1615, entity_name: 'London Rollergirls (London)', entity_type_id: 9, status: 1
+    entity_name: 'London Rollergirls (London)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1616, entity_name: 'Long Island Roller Rebels (Massapequa NY)', entity_type_id: 9, status: 1
+    entity_name: 'Long Island Roller Rebels (Massapequa NY)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1617, entity_name: 'Lowcountry Highrollers (Charleston SC)', entity_type_id: 9, status: 1
+    entity_name: 'Lowcountry Highrollers (Charleston SC)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1618, entity_name: 'Mad Rollin’ Dolls (Madison WI)', entity_type_id: 9, status: 1
+    entity_name: 'Mad Rollin’ Dolls (Madison WI)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1619, entity_name: 'Magnolia Roller Vixens (Jackson MS)', entity_type_id: 9, status: 1
+    entity_name: 'Magnolia Roller Vixens (Jackson MS)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1620, entity_name: 'Maine Roller Derby (Portland ME)', entity_type_id: 9, status: 1
+    entity_name: 'Maine Roller Derby (Portland ME)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1621, entity_name: 'Mason-Dixon Roller Vixens (Hagerstown MD)', entity_type_id: 9, status: 1
+    entity_name: 'Mason-Dixon Roller Vixens (Hagerstown MD)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1622, entity_name: 'Mass Attack Roller Derby (Taunton MA)', entity_type_id: 9, status: 1
+    entity_name: 'Mass Attack Roller Derby (Taunton MA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1623, entity_name: 'McLean County MissFits (Danvers IL)', entity_type_id: 9, status: 1
+    entity_name: 'McLean County MissFits (Danvers IL)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1624, entity_name: 'Memphis Roller Derby (Memphis TN)', entity_type_id: 9, status: 1
+    entity_name: 'Memphis Roller Derby (Memphis TN)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1625, entity_name: 'Mid Iowa Rollers (Des Moines IA)', entity_type_id: 9, status: 1
+    entity_name: 'Mid Iowa Rollers (Des Moines IA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1626, entity_name: 'Mid-State Sisters of Skate (Stevens Point WI)', entity_type_id: 9, status: 1
+    entity_name: 'Mid-State Sisters of Skate (Stevens Point WI)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1627, entity_name: 'Middlesbrough Milk Rollers (Middlesbrough)', entity_type_id: 9, status: 1
+    entity_name: 'Middlesbrough Milk Rollers (Middlesbrough)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1628, entity_name: 'Minnesota RollerGirls (Saint Paul MN)', entity_type_id: 9, status: 1
+    entity_name: 'Minnesota RollerGirls (Saint Paul MN)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1629, entity_name: 'Mississippi Rollergirls (Gulfport MS)', entity_type_id: 9, status: 1
+    entity_name: 'Mississippi Rollergirls (Gulfport MS)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1630, entity_name: 'Mississippi Valley Mayhem (La Crosse WI)', entity_type_id: 9, status: 1
+    entity_name: 'Mississippi Valley Mayhem (La Crosse WI)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1631, entity_name: 'Mo-Kan Roller Girlz (Joplin MO)', entity_type_id: 9, status: 1
+    entity_name: 'Mo-Kan Roller Girlz (Joplin MO)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1632, entity_name: 'Monterey Bay Derby Dames (Monterey CA)', entity_type_id: 9, status: 1
+    entity_name: 'Monterey Bay Derby Dames (Monterey CA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1633, entity_name: 'Montréal Roller Derby (Montréal QC)', entity_type_id: 9, status: 1
+    entity_name: 'Montréal Roller Derby (Montréal QC)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1634, entity_name: 'Mother State Roller Derby (Richmond VA)', entity_type_id: 9, status: 1
+    entity_name: 'Mother State Roller Derby (Richmond VA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1635, entity_name: 'Naptown Roller Girls (Indianapolis IN)', entity_type_id: 9, status: 1
+    entity_name: 'Naptown Roller Girls (Indianapolis IN)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1636, entity_name: 'Nashville Rollergirls (Nashville TN)', entity_type_id: 9, status: 1
+    entity_name: 'Nashville Rollergirls (Nashville TN)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1637, entity_name: 'NEO Roller Derby (Akron OH)', entity_type_id: 9, status: 1
+    entity_name: 'NEO Roller Derby (Akron OH)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1638, entity_name: 'New Hampshire Roller Derby (Nashua NH)', entity_type_id: 9, status: 1
+    entity_name: 'New Hampshire Roller Derby (Nashua NH)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1639, entity_name: 'New Jersey Roller Derby (Morristown NJ)', entity_type_id: 9, status: 1
+    entity_name: 'New Jersey Roller Derby (Morristown NJ)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1640, entity_name: 'Newcastle Roller Girls (Newcastle Upon Tyne)', entity_type_id: 9, status: 1
+    entity_name: 'Newcastle Roller Girls (Newcastle Upon Tyne)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1641, entity_name: 'Nidaros Roller Derby ( Trondheim)', entity_type_id: 9, status: 1
+    entity_name: 'Nidaros Roller Derby ( Trondheim)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1642, entity_name: 'No Coast Derby Girls (Lincoln NE)', entity_type_id: 9, status: 1
+    entity_name: 'No Coast Derby Girls (Lincoln NE)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1643, entity_name: 'North Star Roller Girls (Minneapolis MN)', entity_type_id: 9, status: 1
+    entity_name: 'North Star Roller Girls (Minneapolis MN)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1644, entity_name: 'North Texas Derby Revolution (Justin TX)', entity_type_id: 9, status: 1
+    entity_name: 'North Texas Derby Revolution (Justin TX)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1645, entity_name: 'Northwest Arkansas Roller Derby (Fayetteville AR)', entity_type_id: 9, status: 1
+    entity_name: 'Northwest Arkansas Roller Derby (Fayetteville AR)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1646, entity_name: 'Nottingham Hellfire Harlots (Nottingham)', entity_type_id: 9, status: 1
+    entity_name: 'Nottingham Hellfire Harlots (Nottingham)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1647, entity_name: 'NRV Roller Girls (Christiansburg VA)', entity_type_id: 9, status: 1
+    entity_name: 'NRV Roller Girls (Christiansburg VA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1648, entity_name: 'Ohio Roller Girls (Columbus OH)', entity_type_id: 9, status: 1
+    entity_name: 'Ohio Roller Girls (Columbus OH)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1649, entity_name: 'Oklahoma City Roller Derby (Oklahoma City OK)', entity_type_id: 9, status: 1
+    entity_name: 'Oklahoma City Roller Derby (Oklahoma City OK)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1650, entity_name: 'Oklahoma Victory Dolls (Oklahoma City OK)', entity_type_id: 9, status: 1
+    entity_name: 'Oklahoma Victory Dolls (Oklahoma City OK)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1651, entity_name: 'Old Capitol City Roller Girls (Iowa City IA)', entity_type_id: 9, status: 1
+    entity_name: 'Old Capitol City Roller Girls (Iowa City IA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1652, entity_name: 'Oly Rollers (Olympia WA)', entity_type_id: 9, status: 1
+    entity_name: 'Oly Rollers (Olympia WA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1653, entity_name: 'Omaha Rollergirls (Omaha NE)', entity_type_id: 9, status: 1
+    entity_name: 'Omaha Rollergirls (Omaha NE)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1654, entity_name: 'Oslo Roller Derby ( Oslo)', entity_type_id: 9, status: 1
+    entity_name: 'Oslo Roller Derby ( Oslo)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1655, entity_name: 'Pacific Roller Derby (Honolulu HI)', entity_type_id: 9, status: 1
+    entity_name: 'Pacific Roller Derby (Honolulu HI)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1656, entity_name: 'Paper Valley Roller Girls (Appleton WI)', entity_type_id: 9, status: 1
+    entity_name: 'Paper Valley Roller Girls (Appleton WI)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1657, entity_name: 'Paradise Rollergirls (Hilo HI)', entity_type_id: 9, status: 1
+    entity_name: 'Paradise Rollergirls (Hilo HI)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1658, entity_name: 'Paris Rollergirls ( Paris)', entity_type_id: 9, status: 1
+    entity_name: 'Paris Rollergirls ( Paris)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1659, entity_name: 'Philly Roller Girls (Philadelphia PA)', entity_type_id: 9, status: 1
+    entity_name: 'Philly Roller Girls (Philadelphia PA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1660, entity_name: 'Pikes Peak Derby Dames (Colorado Springs CO)', entity_type_id: 9, status: 1
+    entity_name: 'Pikes Peak Derby Dames (Colorado Springs CO)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1661, entity_name: 'Pirate City Rollers (Auckland)', entity_type_id: 9, status: 1
+    entity_name: 'Pirate City Rollers (Auckland)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1662, entity_name: 'Port Scandalous Roller Derby (Port Angeles WA)', entity_type_id: 9, status: 1
+    entity_name: 'Port Scandalous Roller Derby (Port Angeles WA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1663, entity_name: 'Providence Roller Derby (Providence RI)', entity_type_id: 9, status: 1
+    entity_name: 'Providence Roller Derby (Providence RI)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1664, entity_name: 'Pueblo Derby Devil Dollz (Pueblo CO)', entity_type_id: 9, status: 1
+    entity_name: 'Pueblo Derby Devil Dollz (Pueblo CO)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1665, entity_name: 'Quad City Rollers (Bettendorf IA)', entity_type_id: 9, status: 1
+    entity_name: 'Quad City Rollers (Bettendorf IA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1666, entity_name: 'Queen City Roller Girls (Buffalo NY)', entity_type_id: 9, status: 1
+    entity_name: 'Queen City Roller Girls (Buffalo NY)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1667, entity_name: 'Rage City Rollergirls (Anchorage AK)', entity_type_id: 9, status: 1
+    entity_name: 'Rage City Rollergirls (Anchorage AK)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1668, entity_name: 'Rainy City Roller Dolls (Centralia WA)', entity_type_id: 9, status: 1
+    entity_name: 'Rainy City Roller Dolls (Centralia WA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1669, entity_name: 'Rainy City Roller Girls (Oldham)', entity_type_id: 9, status: 1
+    entity_name: 'Rainy City Roller Girls (Oldham)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1670, entity_name: 'Rat City Rollergirls (Seattle WA)', entity_type_id: 9, status: 1
+    entity_name: 'Rat City Rollergirls (Seattle WA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1671, entity_name: 'Red Stick Roller Derby (Baton Rouge LA)', entity_type_id: 9, status: 1
+    entity_name: 'Red Stick Roller Derby (Baton Rouge LA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1672, entity_name: 'Renegade Derby Dames (Alliston ON)', entity_type_id: 9, status: 1
+    entity_name: 'Renegade Derby Dames (Alliston ON)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1673, entity_name: 'Richland County Regulators Derby Team (Columbia SC)', entity_type_id: 9, status: 1
+    entity_name: 'Richland County Regulators Derby Team (Columbia SC)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1674, entity_name: 'Richter City Roller Derby (Wellington)', entity_type_id: 9, status: 1
+    entity_name: 'Richter City Roller Derby (Wellington)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1675, entity_name: 'Rideau Valley Roller Girls (Ottawa ON)', entity_type_id: 9, status: 1
+    entity_name: 'Rideau Valley Roller Girls (Ottawa ON)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1676, entity_name: 'River City Rollergirls (Richmond VA)', entity_type_id: 9, status: 1
+    entity_name: 'River City Rollergirls (Richmond VA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1677, entity_name: 'Roc City Roller Derby (Rochester NY)', entity_type_id: 9, status: 1
+    entity_name: 'Roc City Roller Derby (Rochester NY)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1678, entity_name: 'Rock Coast Rollers (Rockland ME)', entity_type_id: 9, status: 1
+    entity_name: 'Rock Coast Rollers (Rockland ME)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1679, entity_name: 'Rock n Roller Queens (Bogota)', entity_type_id: 9, status: 1
+    entity_name: 'Rock n Roller Queens (Bogota)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1680, entity_name: 'Rockford Rage Women’s Roller Derby (Rockford IL)', entity_type_id: 9, status: 1
+    entity_name: 'Rockford Rage Women’s Roller Derby (Rockford IL)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1681, entity_name: 'Rocktown Rollers (Harrisonburg VA)', entity_type_id: 9, status: 1
+    entity_name: 'Rocktown Rollers (Harrisonburg VA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1682, entity_name: 'Rocky Mountain Rollergirls (Denver CO)', entity_type_id: 9, status: 1
+    entity_name: 'Rocky Mountain Rollergirls (Denver CO)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1683, entity_name: 'Rodeo City Rollergirls (Ellensburg WA)', entity_type_id: 9, status: 1
+    entity_name: 'Rodeo City Rollergirls (Ellensburg WA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1684, entity_name: 'Roller Girls of the Apocalypse ( Rhineland-Pfalz)', entity_type_id: 9, status: 1
+    entity_name: 'Roller Girls of the Apocalypse ( Rhineland-Pfalz)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1685, entity_name: 'Rollergirls of Central Kentucky (Lexington KY)', entity_type_id: 9, status: 1
+    entity_name: 'Rollergirls of Central Kentucky (Lexington KY)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1686, entity_name: 'Rose City Rollers (Portland OR)', entity_type_id: 9, status: 1
+    entity_name: 'Rose City Rollers (Portland OR)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1687, entity_name: 'Roughneck Roller Derby (Tulsa OK)', entity_type_id: 9, status: 1
+    entity_name: 'Roughneck Roller Derby (Tulsa OK)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1688, entity_name: 'Royal Windsor Rollergirls (Windsor)', entity_type_id: 9, status: 1
+    entity_name: 'Royal Windsor Rollergirls (Windsor)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1689, entity_name: 'Sac City Rollers (Sacramento CA)', entity_type_id: 9, status: 1
+    entity_name: 'Sac City Rollers (Sacramento CA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1690, entity_name: 'Sacred City Derby Girls (Sacramento CA)', entity_type_id: 9, status: 1
+    entity_name: 'Sacred City Derby Girls (Sacramento CA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1691, entity_name: 'Salisbury Rollergirls (Salisbury MD)', entity_type_id: 9, status: 1
+    entity_name: 'Salisbury Rollergirls (Salisbury MD)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1692, entity_name: 'San Fernando Valley Roller Derby (Van Nuys CA)', entity_type_id: 9, status: 1
+    entity_name: 'San Fernando Valley Roller Derby (Van Nuys CA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1693, entity_name: 'Santa Cruz Derby Girls (Santa Cruz CA)', entity_type_id: 9, status: 1
+    entity_name: 'Santa Cruz Derby Girls (Santa Cruz CA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1694, entity_name: 'Savannah Derby Devils (Savannah GA)', entity_type_id: 9, status: 1
+    entity_name: 'Savannah Derby Devils (Savannah GA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1695, entity_name: 'Shasta Roller Derby (Redding CA)', entity_type_id: 9, status: 1
+    entity_name: 'Shasta Roller Derby (Redding CA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1696, entity_name: 'Sheffield Steel Rollergirls (Sheffield)', entity_type_id: 9, status: 1
+    entity_name: 'Sheffield Steel Rollergirls (Sheffield)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1697, entity_name: 'Shore Points Roller Derby (Williamstown NJ)', entity_type_id: 9, status: 1
+    entity_name: 'Shore Points Roller Derby (Williamstown NJ)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1698, entity_name: 'Sick Town Derby Dames (Corvallis OR)', entity_type_id: 9, status: 1
+    entity_name: 'Sick Town Derby Dames (Corvallis OR)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1699, entity_name: 'Silicon Valley Roller Girls (San Jose CA)', entity_type_id: 9, status: 1
+    entity_name: 'Silicon Valley Roller Girls (San Jose CA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1700, entity_name: 'Sioux City Roller Dames (Sioux City IA)', entity_type_id: 9, status: 1
+    entity_name: 'Sioux City Roller Dames (Sioux City IA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1701, entity_name: 'Sioux Falls Roller Dollz (Sioux Falls SD)', entity_type_id: 9, status: 1
+    entity_name: 'Sioux Falls Roller Dollz (Sioux Falls SD)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1702, entity_name: 'Slaughter County Roller Vixens (Kitsap County WA)', entity_type_id: 9, status: 1
+    entity_name: 'Slaughter County Roller Vixens (Kitsap County WA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1703, entity_name: 'Slaughterhouse Derby Girls (Greeley CO)', entity_type_id: 9, status: 1
+    entity_name: 'Slaughterhouse Derby Girls (Greeley CO)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1704, entity_name: 'SoCal Derby (San Diego CA)', entity_type_id: 9, status: 1
+    entity_name: 'SoCal Derby (San Diego CA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1705, entity_name: 'Sonoma County Roller Derby (Santa Rosa CA)', entity_type_id: 9, status: 1
+    entity_name: 'Sonoma County Roller Derby (Santa Rosa CA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1706, entity_name: 'Soul City Sirens (Augusta GA)', entity_type_id: 9, status: 1
+    entity_name: 'Soul City Sirens (Augusta GA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1707, entity_name: 'South Bend Roller Girls (South Bend IN)', entity_type_id: 9, status: 1
+    entity_name: 'South Bend Roller Girls (South Bend IN)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1708, entity_name: 'South Sea Roller Derby (Parkdale VIC)', entity_type_id: 9, status: 1
+    entity_name: 'South Sea Roller Derby (Parkdale VIC)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1709, entity_name: 'Southern Illinois Roller Girls (Marion IL)', entity_type_id: 9, status: 1
+    entity_name: 'Southern Illinois Roller Girls (Marion IL)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1710, entity_name: 'Southern Oregon Rollergirls (Medford OR)', entity_type_id: 9, status: 1
+    entity_name: 'Southern Oregon Rollergirls (Medford OR)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1711, entity_name: 'Spindletop Roller Girls (Beaumont TX)', entity_type_id: 9, status: 1
+    entity_name: 'Spindletop Roller Girls (Beaumont TX)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1712, entity_name: 'Springfield RollerGirls (Springfield MO)', entity_type_id: 9, status: 1
+    entity_name: 'Springfield RollerGirls (Springfield MO)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1713, entity_name: 'St. Chux Derby Chix (O\'Fallon MO)', entity_type_id: 9, status: 1
+    entity_name: 'St. Chux Derby Chix (O\'Fallon MO)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1714, entity_name: 'Steel City Roller Derby (Pittsburgh PA)', entity_type_id: 9, status: 1
+    entity_name: 'Steel City Roller Derby (Pittsburgh PA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1715, entity_name: 'Stockholm Roller Derby ( Stockholm)', entity_type_id: 9, status: 1
+    entity_name: 'Stockholm Roller Derby ( Stockholm)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1716, entity_name: 'Stuttgart Valley Roller Girls ( Stuttgart)', entity_type_id: 9, status: 1
+    entity_name: 'Stuttgart Valley Roller Girls ( Stuttgart)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1717, entity_name: 'Suburbia Roller Derby (Yonkers NY)', entity_type_id: 9, status: 1
+    entity_name: 'Suburbia Roller Derby (Yonkers NY)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1718, entity_name: 'Sun State Roller Girls (Browns Plains QLD)', entity_type_id: 9, status: 1
+    entity_name: 'Sun State Roller Girls (Browns Plains QLD)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1719, entity_name: 'Tallahassee Rollergirls (Tallahassee FL)', entity_type_id: 9, status: 1
+    entity_name: 'Tallahassee Rollergirls (Tallahassee FL)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1720, entity_name: 'Tampa Roller Derby (Tampa FL)', entity_type_id: 9, status: 1
+    entity_name: 'Tampa Roller Derby (Tampa FL)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1721, entity_name: 'Terminal City Rollergirls (Vancouver BC)', entity_type_id: 9, status: 1
+    entity_name: 'Terminal City Rollergirls (Vancouver BC)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1722, entity_name: 'Texas Rollergirls (Austin TX)', entity_type_id: 9, status: 1
+    entity_name: 'Texas Rollergirls (Austin TX)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1723, entity_name: 'Tiger Bay Brawlers (Cardiff, Wales)', entity_type_id: 9, status: 1
+    entity_name: 'Tiger Bay Brawlers (Cardiff, Wales)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1724, entity_name: 'Tokyo Roller Girls (Tōkyō-to)', entity_type_id: 9, status: 1
+    entity_name: 'Tokyo Roller Girls (Tōkyō-to)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1725, entity_name: 'Toronto Roller Derby (Toronto ON)', entity_type_id: 9, status: 1
+    entity_name: 'Toronto Roller Derby (Toronto ON)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1726, entity_name: 'Tragic City Rollers (Birmingham AL)', entity_type_id: 9, status: 1
+    entity_name: 'Tragic City Rollers (Birmingham AL)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1727, entity_name: 'Treasure Valley Roller Derby (Boise ID)', entity_type_id: 9, status: 1
+    entity_name: 'Treasure Valley Roller Derby (Boise ID)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1728, entity_name: 'Tri-City Roller Derby (Kitchener ON)', entity_type_id: 9, status: 1
+    entity_name: 'Tri-City Roller Derby (Kitchener ON)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1729, entity_name: 'Tucson Roller Derby (Tucson AZ)', entity_type_id: 9, status: 1
+    entity_name: 'Tucson Roller Derby (Tucson AZ)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1730, entity_name: 'Twin City Derby Girls (Champaign IL)', entity_type_id: 9, status: 1
+    entity_name: 'Twin City Derby Girls (Champaign IL)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1731, entity_name: 'Ventura County Derby Darlins (Ventura CA)', entity_type_id: 9, status: 1
+    entity_name: 'Ventura County Derby Darlins (Ventura CA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1732, entity_name: 'Vette City Roller Derby (Bowling Green KY)', entity_type_id: 9, status: 1
+    entity_name: 'Vette City Roller Derby (Bowling Green KY)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1733, entity_name: 'Victorian Roller Derby League (Melbourne VIC)', entity_type_id: 9, status: 1
+    entity_name: 'Victorian Roller Derby League (Melbourne VIC)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1734, entity_name: 'Wasatch Roller Derby (Salt Lake City UT)', entity_type_id: 9, status: 1
+    entity_name: 'Wasatch Roller Derby (Salt Lake City UT)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1735, entity_name: 'West Coast Derby Knockouts (Ventura CA)', entity_type_id: 9, status: 1
+    entity_name: 'West Coast Derby Knockouts (Ventura CA)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1736, entity_name: 'West Texas Roller Dollz (Lubbock TX)', entity_type_id: 9, status: 1
+    entity_name: 'West Texas Roller Dollz (Lubbock TX)', entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 1737, entity_name: 'Windy City Rollers (Chicago IL)', entity_type_id: 9, status: 1
+    entity_name: 'Windy City Rollers (Chicago IL)', entity_type_id: entity_type_id, status: 1
   }
 ])

--- a/db/seeds/010_ncaawb.rb
+++ b/db/seeds/010_ncaawb.rb
@@ -1,1041 +1,1042 @@
 # -*- coding: utf-8 -*-
+entity_type_id = EntityType.find_by_entity_type_abbreviation('NCAAWB').id
 Entity.create([
   {
-    id: 3895, import_key: "l.ncaa.org.wbasket-t.RA3", entity_name: "CS-Bakersfield Roadrunners", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.RA3", entity_name: "CS-Bakersfield Roadrunners", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3896, import_key: "l.ncaa.org.wbasket-t.P10", entity_name: "Albany, N.Y. Great Danes", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P10", entity_name: "Albany, N.Y. Great Danes", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3897, import_key: "l.ncaa.org.wbasket-t.P19", entity_name: "Binghamton Bearcats", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P19", entity_name: "Binghamton Bearcats", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3898, import_key: "l.ncaa.org.wbasket-t.N66", entity_name: "Boston U. Terriers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N66", entity_name: "Boston U. Terriers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3899, import_key: "l.ncaa.org.wbasket-t.N92", entity_name: "Hartford Hawks", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N92", entity_name: "Hartford Hawks", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3900, import_key: "l.ncaa.org.wbasket-t.P03", entity_name: "Maine Black Bears", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P03", entity_name: "Maine Black Bears", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3901, import_key: "l.ncaa.org.wbasket-t.P86", entity_name: "New Hampshire Wildcats", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P86", entity_name: "New Hampshire Wildcats", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3902, import_key: "l.ncaa.org.wbasket-t.Q09", entity_name: "Stony Brook Seawolves", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q09", entity_name: "Stony Brook Seawolves", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3903, import_key: "l.ncaa.org.wbasket-t.N80", entity_name: "UMBC Retrievers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N80", entity_name: "UMBC Retrievers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3904, import_key: "l.ncaa.org.wbasket-t.Q27", entity_name: "Vermont Catamounts", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q27", entity_name: "Vermont Catamounts", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3905, import_key: "l.ncaa.org.wbasket-t.SB1", entity_name: "UMass-Lowell River Hawks", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.SB1", entity_name: "UMass-Lowell River Hawks", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3906, import_key: "l.ncaa.org.wbasket-t.N51", entity_name: "Fordham Rams", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N51", entity_name: "Fordham Rams", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3907, import_key: "l.ncaa.org.wbasket-t.O95", entity_name: "N.C. Charlotte 49ers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O95", entity_name: "N.C. Charlotte 49ers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3908, import_key: "l.ncaa.org.wbasket-t.P98", entity_name: "Rhode Island Rams", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P98", entity_name: "Rhode Island Rams", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3909, import_key: "l.ncaa.org.wbasket-t.Q07", entity_name: "St. Bonaventure Bonnies", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q07", entity_name: "St. Bonaventure Bonnies", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3910, import_key: "l.ncaa.org.wbasket-t.O38", entity_name: "St. Joseph's Hawks", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O38", entity_name: "St. Joseph's Hawks", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3911, import_key: "l.ncaa.org.wbasket-t.O30", entity_name: "Temple Owls", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O30", entity_name: "Temple Owls", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3912, import_key: "l.ncaa.org.wbasket-t.P77", entity_name: "UMass Minutewomen", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P77", entity_name: "UMass Minutewomen", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3913, import_key: "l.ncaa.org.wbasket-t.P42", entity_name: "Dayton Flyers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P42", entity_name: "Dayton Flyers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3914, import_key: "l.ncaa.org.wbasket-t.P47", entity_name: "Duquesne Dukes", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P47", entity_name: "Duquesne Dukes", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3915, import_key: "l.ncaa.org.wbasket-t.N67", entity_name: "George Washington Colonials", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N67", entity_name: "George Washington Colonials", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3916, import_key: "l.ncaa.org.wbasket-t.P70", entity_name: "La Salle Explorers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P70", entity_name: "La Salle Explorers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3917, import_key: "l.ncaa.org.wbasket-t.O66", entity_name: "Richmond Spiders", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O66", entity_name: "Richmond Spiders", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3918, import_key: "l.ncaa.org.wbasket-t.O12", entity_name: "Saint Louis Billikens", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O12", entity_name: "Saint Louis Billikens", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3919, import_key: "l.ncaa.org.wbasket-t.Q32", entity_name: "Xavier Musketeers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q32", entity_name: "Xavier Musketeers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3920, import_key: "l.ncaa.org.wbasket-t.O50", entity_name: "Boston College Eagles", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O50", entity_name: "Boston College Eagles", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3921, import_key: "l.ncaa.org.wbasket-t.N89", entity_name: "Clemson Lady Tigers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N89", entity_name: "Clemson Lady Tigers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3922, import_key: "l.ncaa.org.wbasket-t.N03", entity_name: "Duke Blue Devils", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N03", entity_name: "Duke Blue Devils", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3923, import_key: "l.ncaa.org.wbasket-t.N54", entity_name: "Florida St. Seminoles", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N54", entity_name: "Florida St. Seminoles", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3924, import_key: "l.ncaa.org.wbasket-t.O58", entity_name: "Georgia Tech Yellow Jackets", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O58", entity_name: "Georgia Tech Yellow Jackets", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3925, import_key: "l.ncaa.org.wbasket-t.O04", entity_name: "Maryland Terrapins", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O04", entity_name: "Maryland Terrapins", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3926, import_key: "l.ncaa.org.wbasket-t.O72", entity_name: "Miami Hurricanes", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O72", entity_name: "Miami Hurricanes", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3927, import_key: "l.ncaa.org.wbasket-t.N48", entity_name: "N.C. State Wolfpack", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N48", entity_name: "N.C. State Wolfpack", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3928, import_key: "l.ncaa.org.wbasket-t.N14", entity_name: "North Carolina Tar Heels", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N14", entity_name: "North Carolina Tar Heels", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3929, import_key: "l.ncaa.org.wbasket-t.N96", entity_name: "Virginia Tech Hokies", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N96", entity_name: "Virginia Tech Hokies", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3930, import_key: "l.ncaa.org.wbasket-t.N25", entity_name: "Virginia Cavaliers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N25", entity_name: "Virginia Cavaliers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3931, import_key: "l.ncaa.org.wbasket-t.N77", entity_name: "Wake Forest Demon Deacons", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N77", entity_name: "Wake Forest Demon Deacons", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3932, import_key: "l.ncaa.org.wbasket-t.P17", entity_name: "Belmont Bruins", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P17", entity_name: "Belmont Bruins", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3933, import_key: "l.ncaa.org.wbasket-t.P48", entity_name: "East Tennessee St. Lady Bucs", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P48", entity_name: "East Tennessee St. Lady Bucs", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3934, import_key: "l.ncaa.org.wbasket-t.P56", entity_name: "Gardner-Webb Bulldogs", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P56", entity_name: "Gardner-Webb Bulldogs", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3935, import_key: "l.ncaa.org.wbasket-t.P68", entity_name: "Jacksonville Dolphins", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P68", entity_name: "Jacksonville Dolphins", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3936, import_key: "l.ncaa.org.wbasket-t.R22", entity_name: "Kennesaw St. Owls", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.R22", entity_name: "Kennesaw St. Owls", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3937, import_key: "l.ncaa.org.wbasket-t.P06", entity_name: "Lipscomb Lady Bisons", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P06", entity_name: "Lipscomb Lady Bisons", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3938, import_key: "l.ncaa.org.wbasket-t.P80", entity_name: "Mercer Bears", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P80", entity_name: "Mercer Bears", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3939, import_key: "l.ncaa.org.wbasket-t.N40", entity_name: "Stetson Hatters", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N40", entity_name: "Stetson Hatters", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3940, import_key: "l.ncaa.org.wbasket-t.O23", entity_name: "Cincinnati Bearcats", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O23", entity_name: "Cincinnati Bearcats", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3941, import_key: "l.ncaa.org.wbasket-t.N01", entity_name: "Connecticut Huskies", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N01", entity_name: "Connecticut Huskies", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3942, import_key: "l.ncaa.org.wbasket-t.O39", entity_name: "DePaul Blue Demons", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O39", entity_name: "DePaul Blue Demons", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3943, import_key: "l.ncaa.org.wbasket-t.O56", entity_name: "Georgetown Hoyas", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O56", entity_name: "Georgetown Hoyas", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3944, import_key: "l.ncaa.org.wbasket-t.O69", entity_name: "Louisville Cardinals", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O69", entity_name: "Louisville Cardinals", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3945, import_key: "l.ncaa.org.wbasket-t.O97", entity_name: "Marquette Golden Eagles", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O97", entity_name: "Marquette Golden Eagles", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3946, import_key: "l.ncaa.org.wbasket-t.N15", entity_name: "Notre Dame Fighting Irish", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N15", entity_name: "Notre Dame Fighting Irish", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3947, import_key: "l.ncaa.org.wbasket-t.O42", entity_name: "Pittsburgh Panthers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O42", entity_name: "Pittsburgh Panthers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3948, import_key: "l.ncaa.org.wbasket-t.O80", entity_name: "Providence Friars", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O80", entity_name: "Providence Friars", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3949, import_key: "l.ncaa.org.wbasket-t.N02", entity_name: "Rutgers Scarlet Knights", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N02", entity_name: "Rutgers Scarlet Knights", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3950, import_key: "l.ncaa.org.wbasket-t.N79", entity_name: "Seton Hall Pirates", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N79", entity_name: "Seton Hall Pirates", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3951, import_key: "l.ncaa.org.wbasket-t.O78", entity_name: "South Florida Bulls", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O78", entity_name: "South Florida Bulls", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3952, import_key: "l.ncaa.org.wbasket-t.O21", entity_name: "St. John's Red Storm", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O21", entity_name: "St. John's Red Storm", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3953, import_key: "l.ncaa.org.wbasket-t.O62", entity_name: "Syracuse Orange", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O62", entity_name: "Syracuse Orange", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3954, import_key: "l.ncaa.org.wbasket-t.O83", entity_name: "Villanova Wildcats", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O83", entity_name: "Villanova Wildcats", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3955, import_key: "l.ncaa.org.wbasket-t.O73", entity_name: "West Virginia Mountaineers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O73", entity_name: "West Virginia Mountaineers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3956, import_key: "l.ncaa.org.wbasket-t.P50", entity_name: "Eastern Washington Eagles", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P50", entity_name: "Eastern Washington Eagles", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3957, import_key: "l.ncaa.org.wbasket-t.N73", entity_name: "Idaho St. Bengals", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N73", entity_name: "Idaho St. Bengals", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3958, import_key: "l.ncaa.org.wbasket-t.O24", entity_name: "Montana St. Bobcats", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O24", entity_name: "Montana St. Bobcats", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3959, import_key: "l.ncaa.org.wbasket-t.N93", entity_name: "Montana Lady Grizzlies", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N93", entity_name: "Montana Lady Grizzlies", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3960, import_key: "l.ncaa.org.wbasket-t.N45", entity_name: "Northern Arizona Lumberjacks", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N45", entity_name: "Northern Arizona Lumberjacks", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3961, import_key: "l.ncaa.org.wbasket-t.P94", entity_name: "Portland St. Vikings", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P94", entity_name: "Portland St. Vikings", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3962, import_key: "l.ncaa.org.wbasket-t.O14", entity_name: "Sacramento St. Hornets", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O14", entity_name: "Sacramento St. Hornets", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3963, import_key: "l.ncaa.org.wbasket-t.O48", entity_name: "Weber St. Wildcats", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O48", entity_name: "Weber St. Wildcats", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3964, import_key: "l.ncaa.org.wbasket-t.P26", entity_name: "Campbell Lady Camels", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P26", entity_name: "Campbell Lady Camels", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3965, import_key: "l.ncaa.org.wbasket-t.P31", entity_name: "Charleston Southern Lady Buccaneers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P31", entity_name: "Charleston Southern Lady Buccaneers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3966, import_key: "l.ncaa.org.wbasket-t.P34", entity_name: "Coastal Carolina Lady Chanticleers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P34", entity_name: "Coastal Carolina Lady Chanticleers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3967, import_key: "l.ncaa.org.wbasket-t.P59", entity_name: "High Point Panthers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P59", entity_name: "High Point Panthers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3968, import_key: "l.ncaa.org.wbasket-t.O79", entity_name: "Liberty Flames", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O79", entity_name: "Liberty Flames", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3969, import_key: "l.ncaa.org.wbasket-t.P97", entity_name: "Radford Highlanders", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P97", entity_name: "Radford Highlanders", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3970, import_key: "l.ncaa.org.wbasket-t.Q20", entity_name: "UNC-Asheville Bulldogs", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q20", entity_name: "UNC-Asheville Bulldogs", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3971, import_key: "l.ncaa.org.wbasket-t.Q31", entity_name: "Winthrop Lady Eagles", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q31", entity_name: "Winthrop Lady Eagles", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3972, import_key: "l.ncaa.org.wbasket-t.O19", entity_name: "Nebraska Cornhuskers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O19", entity_name: "Nebraska Cornhuskers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3973, import_key: "l.ncaa.org.wbasket-t.N52", entity_name: "Illinois Fighting Illini", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N52", entity_name: "Illinois Fighting Illini", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3974, import_key: "l.ncaa.org.wbasket-t.O84", entity_name: "Indiana Hoosiers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O84", entity_name: "Indiana Hoosiers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3975, import_key: "l.ncaa.org.wbasket-t.O15", entity_name: "Iowa Hawkeyes", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O15", entity_name: "Iowa Hawkeyes", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3976, import_key: "l.ncaa.org.wbasket-t.N64", entity_name: "Michigan St. Spartans", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N64", entity_name: "Michigan St. Spartans", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3977, import_key: "l.ncaa.org.wbasket-t.N30", entity_name: "Michigan Wolverines", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N30", entity_name: "Michigan Wolverines", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3978, import_key: "l.ncaa.org.wbasket-t.N13", entity_name: "Minnesota Golden Gophers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N13", entity_name: "Minnesota Golden Gophers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3979, import_key: "l.ncaa.org.wbasket-t.O75", entity_name: "Northwestern Wildcats", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O75", entity_name: "Northwestern Wildcats", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3980, import_key: "l.ncaa.org.wbasket-t.N17", entity_name: "Ohio St. Buckeyes", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N17", entity_name: "Ohio St. Buckeyes", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3981, import_key: "l.ncaa.org.wbasket-t.N08", entity_name: "Penn St. Lady Lions", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N08", entity_name: "Penn St. Lady Lions", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3982, import_key: "l.ncaa.org.wbasket-t.N07", entity_name: "Purdue Boilermakers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N07", entity_name: "Purdue Boilermakers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3983, import_key: "l.ncaa.org.wbasket-t.O65", entity_name: "Wisconsin Badgers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O65", entity_name: "Wisconsin Badgers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3984, import_key: "l.ncaa.org.wbasket-t.O05", entity_name: "Baylor Lady Bears", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O05", entity_name: "Baylor Lady Bears", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3985, import_key: "l.ncaa.org.wbasket-t.O86", entity_name: "Iowa St. Cyclones", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O86", entity_name: "Iowa St. Cyclones", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3986, import_key: "l.ncaa.org.wbasket-t.N05", entity_name: "Kansas St. Wildcats", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N05", entity_name: "Kansas St. Wildcats", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3987, import_key: "l.ncaa.org.wbasket-t.N74", entity_name: "Kansas Jayhawks", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N74", entity_name: "Kansas Jayhawks", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3988, import_key: "l.ncaa.org.wbasket-t.O77", entity_name: "Missouri Tigers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O77", entity_name: "Missouri Tigers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3989, import_key: "l.ncaa.org.wbasket-t.O33", entity_name: "Oklahoma St. Cowgirls", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O33", entity_name: "Oklahoma St. Cowgirls", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3990, import_key: "l.ncaa.org.wbasket-t.N21", entity_name: "Oklahoma Sooners", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N21", entity_name: "Oklahoma Sooners", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3991, import_key: "l.ncaa.org.wbasket-t.N71", entity_name: "Texas A&M Aggies", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N71", entity_name: "Texas A&M Aggies", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3992, import_key: "l.ncaa.org.wbasket-t.N10", entity_name: "Texas Tech Lady Raiders", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N10", entity_name: "Texas Tech Lady Raiders", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3993, import_key: "l.ncaa.org.wbasket-t.N16", entity_name: "Texas Longhorns", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N16", entity_name: "Texas Longhorns", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3994, import_key: "l.ncaa.org.wbasket-t.P25", entity_name: "Cal Poly-SLO Mustangs", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P25", entity_name: "Cal Poly-SLO Mustangs", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3995, import_key: "l.ncaa.org.wbasket-t.P55", entity_name: "Cal. St.-Fullerton Titans", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P55", entity_name: "Cal. St.-Fullerton Titans", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3996, import_key: "l.ncaa.org.wbasket-t.P39", entity_name: "Cal. St.-Northridge Matadors", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P39", entity_name: "Cal. St.-Northridge Matadors", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3997, import_key: "l.ncaa.org.wbasket-t.P72", entity_name: "Long Beach St. 49ers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P72", entity_name: "Long Beach St. 49ers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3998, import_key: "l.ncaa.org.wbasket-t.O01", entity_name: "Pacific Tigers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O01", entity_name: "Pacific Tigers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 3999, import_key: "l.ncaa.org.wbasket-t.Q16", entity_name: "UC Davis Aggies", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q16", entity_name: "UC Davis Aggies", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4000, import_key: "l.ncaa.org.wbasket-t.Q17", entity_name: "UC Irvine Anteaters", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q17", entity_name: "UC Irvine Anteaters", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4001, import_key: "l.ncaa.org.wbasket-t.N82", entity_name: "UC Riverside Highlanders", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N82", entity_name: "UC Riverside Highlanders", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4002, import_key: "l.ncaa.org.wbasket-t.N18", entity_name: "UC Santa Barbara Gauchos", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N18", entity_name: "UC Santa Barbara Gauchos", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4003, import_key: "l.ncaa.org.wbasket-t.P43", entity_name: "Delaware Blue Hens", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P43", entity_name: "Delaware Blue Hens", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4004, import_key: "l.ncaa.org.wbasket-t.P46", entity_name: "Drexel Dragons", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P46", entity_name: "Drexel Dragons", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4005, import_key: "l.ncaa.org.wbasket-t.P57", entity_name: "George Mason Patriots", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P57", entity_name: "George Mason Patriots", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4006, import_key: "l.ncaa.org.wbasket-t.N34", entity_name: "Georgia St. Lady Panthers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N34", entity_name: "Georgia St. Lady Panthers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4007, import_key: "l.ncaa.org.wbasket-t.N46", entity_name: "Hofstra Pride", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N46", entity_name: "Hofstra Pride", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4008, import_key: "l.ncaa.org.wbasket-t.O46", entity_name: "James Madison Dukes", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O46", entity_name: "James Madison Dukes", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4009, import_key: "l.ncaa.org.wbasket-t.P91", entity_name: "Northeastern Huskies", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P91", entity_name: "Northeastern Huskies", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4010, import_key: "l.ncaa.org.wbasket-t.N26", entity_name: "Old Dominion Lady Monarchs", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N26", entity_name: "Old Dominion Lady Monarchs", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4011, import_key: "l.ncaa.org.wbasket-t.Q13", entity_name: "Towson Tigers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q13", entity_name: "Towson Tigers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4012, import_key: "l.ncaa.org.wbasket-t.N61", entity_name: "UNC-Wilmington Lady Seahawks", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N61", entity_name: "UNC-Wilmington Lady Seahawks", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4013, import_key: "l.ncaa.org.wbasket-t.Q26", entity_name: "Va. Commonwealth Rams", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q26", entity_name: "Va. Commonwealth Rams", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4014, import_key: "l.ncaa.org.wbasket-t.Q30", entity_name: "William & Mary Tribe", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q30", entity_name: "William & Mary Tribe", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4015, import_key: "l.ncaa.org.wbasket-t.O96", entity_name: "East Carolina Pirates", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O96", entity_name: "East Carolina Pirates", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4016, import_key: "l.ncaa.org.wbasket-t.O03", entity_name: "Houston Lady Cougars", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O03", entity_name: "Houston Lady Cougars", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4017, import_key: "l.ncaa.org.wbasket-t.P76", entity_name: "Marshall Thundering Herd", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P76", entity_name: "Marshall Thundering Herd", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4018, import_key: "l.ncaa.org.wbasket-t.O89", entity_name: "Memphis Lady Tigers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O89", entity_name: "Memphis Lady Tigers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4019, import_key: "l.ncaa.org.wbasket-t.N81", entity_name: "Rice Lady Owls", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N81", entity_name: "Rice Lady Owls", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4020, import_key: "l.ncaa.org.wbasket-t.N53", entity_name: "SMU Mustangs", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N53", entity_name: "SMU Mustangs", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4021, import_key: "l.ncaa.org.wbasket-t.O92", entity_name: "Southern Miss. Lady Eagles", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O92", entity_name: "Southern Miss. Lady Eagles", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4022, import_key: "l.ncaa.org.wbasket-t.O09", entity_name: "Tulane Green Wave", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O09", entity_name: "Tulane Green Wave", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4023, import_key: "l.ncaa.org.wbasket-t.N97", entity_name: "Tulsa Golden Hurricane", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N97", entity_name: "Tulsa Golden Hurricane", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4024, import_key: "l.ncaa.org.wbasket-t.O88", entity_name: "UAB Lady Blazers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O88", entity_name: "UAB Lady Blazers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4025, import_key: "l.ncaa.org.wbasket-t.O94", entity_name: "UTEP Miners", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O94", entity_name: "UTEP Miners", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4026, import_key: "l.ncaa.org.wbasket-t.Q25", entity_name: "Houston Baptist Huskies", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q25", entity_name: "Houston Baptist Huskies", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4027, import_key: "l.ncaa.org.wbasket-t.R73", entity_name: "NJIT Highlanders", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.R73", entity_name: "NJIT Highlanders", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4028, import_key: "l.ncaa.org.wbasket-t.RD2", entity_name: "North Dakota Fighting Sioux", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.RD2", entity_name: "North Dakota Fighting Sioux", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4029, import_key: "l.ncaa.org.wbasket-t.O13", entity_name: "Texas-Pan American Lady Broncs", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O13", entity_name: "Texas-Pan American Lady Broncs", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4030, import_key: "l.ncaa.org.wbasket-t.P24", entity_name: "Butler Bulldogs", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P24", entity_name: "Butler Bulldogs", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4031, import_key: "l.ncaa.org.wbasket-t.P33", entity_name: "Cleveland St. Vikings", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P33", entity_name: "Cleveland St. Vikings", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4032, import_key: "l.ncaa.org.wbasket-t.O90", entity_name: "Detroit Titans", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O90", entity_name: "Detroit Titans", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4033, import_key: "l.ncaa.org.wbasket-t.P62", entity_name: "Ill.-Chicago Flames", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P62", entity_name: "Ill.-Chicago Flames", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4034, import_key: "l.ncaa.org.wbasket-t.O68", entity_name: "Loyola of Chicago Ramblers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O68", entity_name: "Loyola of Chicago Ramblers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4035, import_key: "l.ncaa.org.wbasket-t.N38", entity_name: "Valparaiso Crusaders", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N38", entity_name: "Valparaiso Crusaders", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4036, import_key: "l.ncaa.org.wbasket-t.O07", entity_name: "Wis.-Green Bay Phoenix", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O07", entity_name: "Wis.-Green Bay Phoenix", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4037, import_key: "l.ncaa.org.wbasket-t.N57", entity_name: "Wis.-Milwaukee Panthers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N57", entity_name: "Wis.-Milwaukee Panthers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4038, import_key: "l.ncaa.org.wbasket-t.O20", entity_name: "Wright St. Raiders", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O20", entity_name: "Wright St. Raiders", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4039, import_key: "l.ncaa.org.wbasket-t.N63", entity_name: "Youngstown St. Penguins", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N63", entity_name: "Youngstown St. Penguins", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4040, import_key: "l.ncaa.org.wbasket-t.RH5", entity_name: "Seattle Redhawks", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.RH5", entity_name: "Seattle Redhawks", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4041, import_key: "l.ncaa.org.wbasket-t.Q99", entity_name: "SIU-Edwardsville Cougars", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q99", entity_name: "SIU-Edwardsville Cougars", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4042, import_key: "l.ncaa.org.wbasket-t.Q24", entity_name: "Utah Valley St. Wolverines", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q24", entity_name: "Utah Valley St. Wolverines", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4043, import_key: "l.ncaa.org.wbasket-t.Q37", entity_name: "Longwood Lancers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q37", entity_name: "Longwood Lancers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4044, import_key: "l.ncaa.org.wbasket-t.P22", entity_name: "Brown Bears", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P22", entity_name: "Brown Bears", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4045, import_key: "l.ncaa.org.wbasket-t.P36", entity_name: "Columbia Lions", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P36", entity_name: "Columbia Lions", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4046, import_key: "l.ncaa.org.wbasket-t.P38", entity_name: "Cornell Big Red", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P38", entity_name: "Cornell Big Red", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4047, import_key: "l.ncaa.org.wbasket-t.P40", entity_name: "Dartmouth Big Green", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P40", entity_name: "Dartmouth Big Green", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4048, import_key: "l.ncaa.org.wbasket-t.N43", entity_name: "Harvard Crimson", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N43", entity_name: "Harvard Crimson", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4049, import_key: "l.ncaa.org.wbasket-t.O67", entity_name: "Penn Quakers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O67", entity_name: "Penn Quakers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4050, import_key: "l.ncaa.org.wbasket-t.P95", entity_name: "Princeton Tigers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P95", entity_name: "Princeton Tigers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4051, import_key: "l.ncaa.org.wbasket-t.Q33", entity_name: "Yale Bulldogs", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q33", entity_name: "Yale Bulldogs", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4052, import_key: "l.ncaa.org.wbasket-t.P27", entity_name: "Canisius Golden Griffins", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P27", entity_name: "Canisius Golden Griffins", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4053, import_key: "l.ncaa.org.wbasket-t.Q34", entity_name: "Fairfield Stags", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q34", entity_name: "Fairfield Stags", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4054, import_key: "l.ncaa.org.wbasket-t.P65", entity_name: "Iona Gaels", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P65", entity_name: "Iona Gaels", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4055, import_key: "l.ncaa.org.wbasket-t.P74", entity_name: "Loyola, Md. Greyhounds", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P74", entity_name: "Loyola, Md. Greyhounds", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4056, import_key: "l.ncaa.org.wbasket-t.P75", entity_name: "Manhattan Lady Jaspers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P75", entity_name: "Manhattan Lady Jaspers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4057, import_key: "l.ncaa.org.wbasket-t.O54", entity_name: "Marist Red Foxes", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O54", entity_name: "Marist Red Foxes", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4058, import_key: "l.ncaa.org.wbasket-t.P88", entity_name: "Niagara Purple Eagles", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P88", entity_name: "Niagara Purple Eagles", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4059, import_key: "l.ncaa.org.wbasket-t.P99", entity_name: "Rider Broncs", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P99", entity_name: "Rider Broncs", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4060, import_key: "l.ncaa.org.wbasket-t.N72", entity_name: "Siena Saints", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N72", entity_name: "Siena Saints", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4061, import_key: "l.ncaa.org.wbasket-t.N27", entity_name: "St. Peter's Peahens", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N27", entity_name: "St. Peter's Peahens", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4062, import_key: "l.ncaa.org.wbasket-t.P08", entity_name: "Akron Zips", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P08", entity_name: "Akron Zips", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4063, import_key: "l.ncaa.org.wbasket-t.P21", entity_name: "Bowling Green Falcons", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P21", entity_name: "Bowling Green Falcons", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4064, import_key: "l.ncaa.org.wbasket-t.O35", entity_name: "Buffalo Bulls", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O35", entity_name: "Buffalo Bulls", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4065, import_key: "l.ncaa.org.wbasket-t.O32", entity_name: "Kent St. Golden Flashes", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O32", entity_name: "Kent St. Golden Flashes", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4066, import_key: "l.ncaa.org.wbasket-t.P81", entity_name: "Miami (Ohio) RedHawks", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P81", entity_name: "Miami (Ohio) RedHawks", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4067, import_key: "l.ncaa.org.wbasket-t.N37", entity_name: "Ohio Bobcats", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N37", entity_name: "Ohio Bobcats", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4068, import_key: "l.ncaa.org.wbasket-t.P16", entity_name: "Ball St. Cardinals", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P16", entity_name: "Ball St. Cardinals", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4069, import_key: "l.ncaa.org.wbasket-t.P30", entity_name: "Central Michigan Chippewas", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P30", entity_name: "Central Michigan Chippewas", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4070, import_key: "l.ncaa.org.wbasket-t.P04", entity_name: "Eastern Michigan Eagles", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P04", entity_name: "Eastern Michigan Eagles", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4071, import_key: "l.ncaa.org.wbasket-t.O11", entity_name: "Northern Illinois Huskies", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O11", entity_name: "Northern Illinois Huskies", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4072, import_key: "l.ncaa.org.wbasket-t.O34", entity_name: "Toledo Rockets", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O34", entity_name: "Toledo Rockets", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4073, import_key: "l.ncaa.org.wbasket-t.P18", entity_name: "Bethune-Cookman Lady Cats", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P18", entity_name: "Bethune-Cookman Lady Cats", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4074, import_key: "l.ncaa.org.wbasket-t.P37", entity_name: "Coppin St. Lady Eagles", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P37", entity_name: "Coppin St. Lady Eagles", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4075, import_key: "l.ncaa.org.wbasket-t.P44", entity_name: "Delaware St. Hornets", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P44", entity_name: "Delaware St. Hornets", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4076, import_key: "l.ncaa.org.wbasket-t.N47", entity_name: "Florida A&M Rattlerettes", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N47", entity_name: "Florida A&M Rattlerettes", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4077, import_key: "l.ncaa.org.wbasket-t.O40", entity_name: "Hampton Lady Pirates", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O40", entity_name: "Hampton Lady Pirates", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4078, import_key: "l.ncaa.org.wbasket-t.P60", entity_name: "Howard Lady Bisons", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P60", entity_name: "Howard Lady Bisons", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4079, import_key: "l.ncaa.org.wbasket-t.P79", entity_name: "Md.-Eastern Shore Lady Hawks", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P79", entity_name: "Md.-Eastern Shore Lady Hawks", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4080, import_key: "l.ncaa.org.wbasket-t.Q35", entity_name: "Morgan St. Lady Bears", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q35", entity_name: "Morgan St. Lady Bears", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4081, import_key: "l.ncaa.org.wbasket-t.O36", entity_name: "N.C. A&T Lady Aggies", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O36", entity_name: "N.C. A&T Lady Aggies", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4082, import_key: "l.ncaa.org.wbasket-t.P90", entity_name: "Norfolk St. Lady Spartans", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P90", entity_name: "Norfolk St. Lady Spartans", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4083, import_key: "l.ncaa.org.wbasket-t.O17", entity_name: "S. Carolina St. Lady Bulldogs", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O17", entity_name: "S. Carolina St. Lady Bulldogs", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4084, import_key: "l.ncaa.org.wbasket-t.O85", entity_name: "Savannah St. Tigers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O85", entity_name: "Savannah St. Tigers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4085, import_key: "l.ncaa.org.wbasket-t.R77", entity_name: "NC Central Lady Eagles", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.R77", entity_name: "NC Central Lady Eagles", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4086, import_key: "l.ncaa.org.wbasket-t.P01", entity_name: "Bradley Braves", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P01", entity_name: "Bradley Braves", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4087, import_key: "l.ncaa.org.wbasket-t.N88", entity_name: "Creighton Bluejays", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N88", entity_name: "Creighton Bluejays", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4088, import_key: "l.ncaa.org.wbasket-t.N59", entity_name: "Drake Bulldogs", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N59", entity_name: "Drake Bulldogs", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4089, import_key: "l.ncaa.org.wbasket-t.P51", entity_name: "Evansville Aces", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P51", entity_name: "Evansville Aces", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4090, import_key: "l.ncaa.org.wbasket-t.P63", entity_name: "Illinois St. Redbirds", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P63", entity_name: "Illinois St. Redbirds", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4091, import_key: "l.ncaa.org.wbasket-t.P64", entity_name: "Indiana St. Sycamores", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P64", entity_name: "Indiana St. Sycamores", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4092, import_key: "l.ncaa.org.wbasket-t.O98", entity_name: "Missouri St. Lady Bears", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O98", entity_name: "Missouri St. Lady Bears", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4093, import_key: "l.ncaa.org.wbasket-t.O99", entity_name: "Northern Iowa Panthers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O99", entity_name: "Northern Iowa Panthers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4094, import_key: "l.ncaa.org.wbasket-t.Q05", entity_name: "Southern Illinois Salukis", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q05", entity_name: "Southern Illinois Salukis", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4095, import_key: "l.ncaa.org.wbasket-t.O61", entity_name: "Wichita St. Shockers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O61", entity_name: "Wichita St. Shockers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4096, import_key: "l.ncaa.org.wbasket-t.P02", entity_name: "Air Force Falcons", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P02", entity_name: "Air Force Falcons", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4097, import_key: "l.ncaa.org.wbasket-t.O93", entity_name: "Boise St. Broncos", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O93", entity_name: "Boise St. Broncos", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4098, import_key: "l.ncaa.org.wbasket-t.O25", entity_name: "Colorado St. Rams", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O25", entity_name: "Colorado St. Rams", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4099, import_key: "l.ncaa.org.wbasket-t.O74", entity_name: "New Mexico Lobos", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O74", entity_name: "New Mexico Lobos", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4100, import_key: "l.ncaa.org.wbasket-t.Q03", entity_name: "San Diego St. Aztecs", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q03", entity_name: "San Diego St. Aztecs", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4101, import_key: "l.ncaa.org.wbasket-t.N24", entity_name: "TCU Lady Frogs", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N24", entity_name: "TCU Lady Frogs", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4102, import_key: "l.ncaa.org.wbasket-t.Q21", entity_name: "UNLV Lady Rebels", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q21", entity_name: "UNLV Lady Rebels", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4103, import_key: "l.ncaa.org.wbasket-t.N99", entity_name: "Wyoming Cowgirls", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N99", entity_name: "Wyoming Cowgirls", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4104, import_key: "l.ncaa.org.wbasket-t.RH4", entity_name: "Bryant Bulldogs", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.RH4", entity_name: "Bryant Bulldogs", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4105, import_key: "l.ncaa.org.wbasket-t.P29", entity_name: "Cent. Connecticut St. Blue Devils", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P29", entity_name: "Cent. Connecticut St. Blue Devils", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4106, import_key: "l.ncaa.org.wbasket-t.P52", entity_name: "Fairleigh Dickinson Knights", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P52", entity_name: "Fairleigh Dickinson Knights", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4107, import_key: "l.ncaa.org.wbasket-t.P73", entity_name: "Long Island U. Blackbirds", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P73", entity_name: "Long Island U. Blackbirds", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4108, import_key: "l.ncaa.org.wbasket-t.O82", entity_name: "Monmouth Hawks", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O82", entity_name: "Monmouth Hawks", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4109, import_key: "l.ncaa.org.wbasket-t.P83", entity_name: "Mount St. Mary's, Md. Mountaineers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P83", entity_name: "Mount St. Mary's, Md. Mountaineers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4110, import_key: "l.ncaa.org.wbasket-t.P96", entity_name: "Quinnipiac Bobcats", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P96", entity_name: "Quinnipiac Bobcats", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4111, import_key: "l.ncaa.org.wbasket-t.Q01", entity_name: "Robert Morris Colonials", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q01", entity_name: "Robert Morris Colonials", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4112, import_key: "l.ncaa.org.wbasket-t.O51", entity_name: "Sacred Heart Pioneers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O51", entity_name: "Sacred Heart Pioneers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4113, import_key: "l.ncaa.org.wbasket-t.Q08", entity_name: "St. Francis, NY Terriers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q08", entity_name: "St. Francis, NY Terriers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4114, import_key: "l.ncaa.org.wbasket-t.N36", entity_name: "St. Francis, Pa. Red Flash", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N36", entity_name: "St. Francis, Pa. Red Flash", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4115, import_key: "l.ncaa.org.wbasket-t.Q28", entity_name: "Wagner Seahawks", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q28", entity_name: "Wagner Seahawks", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4116, import_key: "l.ncaa.org.wbasket-t.P07", entity_name: "Austin Peay Lady Govs", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P07", entity_name: "Austin Peay Lady Govs", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4117, import_key: "l.ncaa.org.wbasket-t.P49", entity_name: "Eastern Illinois Panthers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P49", entity_name: "Eastern Illinois Panthers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4118, import_key: "l.ncaa.org.wbasket-t.O60", entity_name: "Eastern Kentucky Lady Colonels", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O60", entity_name: "Eastern Kentucky Lady Colonels", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4119, import_key: "l.ncaa.org.wbasket-t.P69", entity_name: "Jacksonville St. Gamecocks", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P69", entity_name: "Jacksonville St. Gamecocks", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4120, import_key: "l.ncaa.org.wbasket-t.O59", entity_name: "Morehead St. Lady Eagles", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O59", entity_name: "Morehead St. Lady Eagles", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4121, import_key: "l.ncaa.org.wbasket-t.P84", entity_name: "Murray St. Lady Racers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P84", entity_name: "Murray St. Lady Racers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4122, import_key: "l.ncaa.org.wbasket-t.N28", entity_name: "SE Missouri Otahkians", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N28", entity_name: "SE Missouri Otahkians", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4123, import_key: "l.ncaa.org.wbasket-t.O16", entity_name: "Tenn.-Martin Skyhawks", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O16", entity_name: "Tenn.-Martin Skyhawks", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4124, import_key: "l.ncaa.org.wbasket-t.Q10", entity_name: "Tennessee St. Tigers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q10", entity_name: "Tennessee St. Tigers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4125, import_key: "l.ncaa.org.wbasket-t.Q11", entity_name: "Tennessee Tech Golden Eaglettes", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q11", entity_name: "Tennessee Tech Golden Eaglettes", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4126, import_key: "l.ncaa.org.wbasket-t.N20", entity_name: "Colorado Buffaloes", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N20", entity_name: "Colorado Buffaloes", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4127, import_key: "l.ncaa.org.wbasket-t.N69", entity_name: "Arizona St. Sun Devils", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N69", entity_name: "Arizona St. Sun Devils", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4128, import_key: "l.ncaa.org.wbasket-t.N23", entity_name: "Arizona Wildcats", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N23", entity_name: "Arizona Wildcats", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4129, import_key: "l.ncaa.org.wbasket-t.N84", entity_name: "California Golden Bears", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N84", entity_name: "California Golden Bears", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4130, import_key: "l.ncaa.org.wbasket-t.O49", entity_name: "Oregon St. Beavers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O49", entity_name: "Oregon St. Beavers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4131, import_key: "l.ncaa.org.wbasket-t.N41", entity_name: "Oregon Ducks", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N41", entity_name: "Oregon Ducks", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4132, import_key: "l.ncaa.org.wbasket-t.N06", entity_name: "Stanford Cardinal", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N06", entity_name: "Stanford Cardinal", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4133, import_key: "l.ncaa.org.wbasket-t.N56", entity_name: "UCLA Bruins", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N56", entity_name: "UCLA Bruins", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4134, import_key: "l.ncaa.org.wbasket-t.N78", entity_name: "USC Trojans", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N78", entity_name: "USC Trojans", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4135, import_key: "l.ncaa.org.wbasket-t.N19", entity_name: "Utah Utes", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N19", entity_name: "Utah Utes", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4136, import_key: "l.ncaa.org.wbasket-t.O47", entity_name: "Washington St. Cougars", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O47", entity_name: "Washington St. Cougars", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4137, import_key: "l.ncaa.org.wbasket-t.O02", entity_name: "Washington Huskies", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O02", entity_name: "Washington Huskies", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4138, import_key: "l.ncaa.org.wbasket-t.P12", entity_name: "American U. Eagles", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P12", entity_name: "American U. Eagles", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4139, import_key: "l.ncaa.org.wbasket-t.O53", entity_name: "Army Black Knights", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O53", entity_name: "Army Black Knights", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4140, import_key: "l.ncaa.org.wbasket-t.P23", entity_name: "Bucknell Bisons", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P23", entity_name: "Bucknell Bisons", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4141, import_key: "l.ncaa.org.wbasket-t.P05", entity_name: "Colgate Red Raiders", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P05", entity_name: "Colgate Red Raiders", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4142, import_key: "l.ncaa.org.wbasket-t.N90", entity_name: "Holy Cross Crusaders", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N90", entity_name: "Holy Cross Crusaders", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4143, import_key: "l.ncaa.org.wbasket-t.P71", entity_name: "Lafayette Leopards", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P71", entity_name: "Lafayette Leopards", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4144, import_key: "l.ncaa.org.wbasket-t.N83", entity_name: "Lehigh Mountain Hawks", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N83", entity_name: "Lehigh Mountain Hawks", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4145, import_key: "l.ncaa.org.wbasket-t.N65", entity_name: "Navy Mids", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N65", entity_name: "Navy Mids", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4146, import_key: "l.ncaa.org.wbasket-t.O31", entity_name: "Alabama Tide", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O31", entity_name: "Alabama Tide", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4147, import_key: "l.ncaa.org.wbasket-t.O29", entity_name: "Arkansas Ladybacks", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O29", entity_name: "Arkansas Ladybacks", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4148, import_key: "l.ncaa.org.wbasket-t.N22", entity_name: "Auburn Tigers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N22", entity_name: "Auburn Tigers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4149, import_key: "l.ncaa.org.wbasket-t.O22", entity_name: "Florida Lady Gators", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O22", entity_name: "Florida Lady Gators", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4150, import_key: "l.ncaa.org.wbasket-t.N11", entity_name: "Georgia Lady Bulldogs", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N11", entity_name: "Georgia Lady Bulldogs", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4151, import_key: "l.ncaa.org.wbasket-t.N60", entity_name: "Kentucky Wildcats", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N60", entity_name: "Kentucky Wildcats", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4152, import_key: "l.ncaa.org.wbasket-t.N09", entity_name: "LSU Lady Tigers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N09", entity_name: "LSU Lady Tigers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4153, import_key: "l.ncaa.org.wbasket-t.O44", entity_name: "Mississippi St. Lady Bulldogs", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O44", entity_name: "Mississippi St. Lady Bulldogs", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4154, import_key: "l.ncaa.org.wbasket-t.O91", entity_name: "Mississippi Lady Rebels", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O91", entity_name: "Mississippi Lady Rebels", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4155, import_key: "l.ncaa.org.wbasket-t.O45", entity_name: "South Carolina Lady Gamecocks", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O45", entity_name: "South Carolina Lady Gamecocks", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4156, import_key: "l.ncaa.org.wbasket-t.N04", entity_name: "Tennessee Lady Vols", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N04", entity_name: "Tennessee Lady Vols", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4157, import_key: "l.ncaa.org.wbasket-t.O71", entity_name: "Vanderbilt Commodores", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O71", entity_name: "Vanderbilt Commodores", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4158, import_key: "l.ncaa.org.wbasket-t.P13", entity_name: "Appalachian St. Mountaineers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P13", entity_name: "Appalachian St. Mountaineers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4159, import_key: "l.ncaa.org.wbasket-t.N50", entity_name: "Chattanooga Lady Mocs", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N50", entity_name: "Chattanooga Lady Mocs", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4160, import_key: "l.ncaa.org.wbasket-t.P35", entity_name: "Coll. of Charleston Cougars", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P35", entity_name: "Coll. of Charleston Cougars", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4161, import_key: "l.ncaa.org.wbasket-t.P41", entity_name: "Davidson Wildcats", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P41", entity_name: "Davidson Wildcats", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4162, import_key: "l.ncaa.org.wbasket-t.N31", entity_name: "Elon Phoenix", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N31", entity_name: "Elon Phoenix", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4163, import_key: "l.ncaa.org.wbasket-t.O43", entity_name: "Furman Lady Paladins", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O43", entity_name: "Furman Lady Paladins", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4164, import_key: "l.ncaa.org.wbasket-t.N58", entity_name: "Georgia Southern Lady Eagles", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N58", entity_name: "Georgia Southern Lady Eagles", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4165, import_key: "l.ncaa.org.wbasket-t.Q02", entity_name: "Samford Bulldogs", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q02", entity_name: "Samford Bulldogs", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4166, import_key: "l.ncaa.org.wbasket-t.O52", entity_name: "UNC-Greensboro Spartans", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O52", entity_name: "UNC-Greensboro Spartans", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4167, import_key: "l.ncaa.org.wbasket-t.Q29", entity_name: "Western Carolina Catamounts", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q29", entity_name: "Western Carolina Catamounts", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4168, import_key: "l.ncaa.org.wbasket-t.O18", entity_name: "Wofford Lady Terriers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O18", entity_name: "Wofford Lady Terriers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4169, import_key: "l.ncaa.org.wbasket-t.P89", entity_name: "Nicholls Lady Colonels", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P89", entity_name: "Nicholls Lady Colonels", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4170, import_key: "l.ncaa.org.wbasket-t.N98", entity_name: "Northwestern St. Lady Demons", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N98", entity_name: "Northwestern St. Lady Demons", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4171, import_key: "l.ncaa.org.wbasket-t.O63", entity_name: "SE Louisiana Lady Lions", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O63", entity_name: "SE Louisiana Lady Lions", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4172, import_key: "l.ncaa.org.wbasket-t.N39", entity_name: "Texas State Bobcats", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N39", entity_name: "Texas State Bobcats", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4173, import_key: "l.ncaa.org.wbasket-t.SA9", entity_name: "Abilene Christian Wildcats", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.SA9", entity_name: "Abilene Christian Wildcats", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4174, import_key: "l.ncaa.org.wbasket-t.O55", entity_name: "Alabama A&M Lady Bulldogs", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O55", entity_name: "Alabama A&M Lady Bulldogs", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4175, import_key: "l.ncaa.org.wbasket-t.P09", entity_name: "Alabama St. Lady Hornets", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P09", entity_name: "Alabama St. Lady Hornets", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4176, import_key: "l.ncaa.org.wbasket-t.P11", entity_name: "Alcorn St. Lady Braves", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P11", entity_name: "Alcorn St. Lady Braves", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4177, import_key: "l.ncaa.org.wbasket-t.P14", entity_name: "Ark.-Pine Bluff Golden Lionettes", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P14", entity_name: "Ark.-Pine Bluff Golden Lionettes", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4178, import_key: "l.ncaa.org.wbasket-t.P58", entity_name: "Grambling St. Lady Tigers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P58", entity_name: "Grambling St. Lady Tigers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4179, import_key: "l.ncaa.org.wbasket-t.P67", entity_name: "Jackson St. Lady Tigers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P67", entity_name: "Jackson St. Lady Tigers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4180, import_key: "l.ncaa.org.wbasket-t.P82", entity_name: "MVSU Devilettes", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P82", entity_name: "MVSU Devilettes", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4181, import_key: "l.ncaa.org.wbasket-t.O37", entity_name: "Prairie View Lady Panthers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O37", entity_name: "Prairie View Lady Panthers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4182, import_key: "l.ncaa.org.wbasket-t.N42", entity_name: "Southern U. Jaguars", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N42", entity_name: "Southern U. Jaguars", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4183, import_key: "l.ncaa.org.wbasket-t.Q12", entity_name: "Texas Southern Lady Tigers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q12", entity_name: "Texas Southern Lady Tigers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4184, import_key: "l.ncaa.org.wbasket-t.P32", entity_name: "Chicago St. Lady Cougars", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P32", entity_name: "Chicago St. Lady Cougars", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4185, import_key: "l.ncaa.org.wbasket-t.P66", entity_name: "IUPU-Ft. Wayne Mastodons", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P66", entity_name: "IUPU-Ft. Wayne Mastodons", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4186, import_key: "l.ncaa.org.wbasket-t.N95", entity_name: "IUPU-Indianapolis Jaguars", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N95", entity_name: "IUPU-Indianapolis Jaguars", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4187, import_key: "l.ncaa.org.wbasket-t.Q40", entity_name: "North Dakota St. Fighting Sioux", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q40", entity_name: "North Dakota St. Fighting Sioux", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4188, import_key: "l.ncaa.org.wbasket-t.P93", entity_name: "Oakland, Mich. Golden Grizzlies", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P93", entity_name: "Oakland, Mich. Golden Grizzlies", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4189, import_key: "l.ncaa.org.wbasket-t.N44", entity_name: "Oral Roberts Golden Eagles", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N44", entity_name: "Oral Roberts Golden Eagles", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4190, import_key: "l.ncaa.org.wbasket-t.P85", entity_name: "South Dakota St. Jackrabbits", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P85", entity_name: "South Dakota St. Jackrabbits", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4191, import_key: "l.ncaa.org.wbasket-t.RH3", entity_name: "South Dakota Coyotes", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.RH3", entity_name: "South Dakota Coyotes", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4192, import_key: "l.ncaa.org.wbasket-t.Q06", entity_name: "Southern Utah Thunderbirds", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q06", entity_name: "Southern Utah Thunderbirds", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4193, import_key: "l.ncaa.org.wbasket-t.O06", entity_name: "UMKC Kangaroos", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O06", entity_name: "UMKC Kangaroos", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4194, import_key: "l.ncaa.org.wbasket-t.N33", entity_name: "Western Illinois Leathernecks", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N33", entity_name: "Western Illinois Leathernecks", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4195, import_key: "l.ncaa.org.wbasket-t.P54", entity_name: "Fla. International Golden Panthers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P54", entity_name: "Fla. International Golden Panthers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4196, import_key: "l.ncaa.org.wbasket-t.O10", entity_name: "Middle Tenn. St. Blue Raiders", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O10", entity_name: "Middle Tenn. St. Blue Raiders", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4197, import_key: "l.ncaa.org.wbasket-t.Q14", entity_name: "Troy Lady Trojans", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q14", entity_name: "Troy Lady Trojans", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4198, import_key: "l.ncaa.org.wbasket-t.N75", entity_name: "Western Kentucky Lady Toppers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N75", entity_name: "Western Kentucky Lady Toppers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4199, import_key: "l.ncaa.org.wbasket-t.P45", entity_name: "Denver Pioneers", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P45", entity_name: "Denver Pioneers", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4200, import_key: "l.ncaa.org.wbasket-t.Q18", entity_name: "Louisiana Ragin' Cajuns", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q18", entity_name: "Louisiana Ragin' Cajuns", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4201, import_key: "l.ncaa.org.wbasket-t.N86", entity_name: "ULM Warhawks", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N86", entity_name: "ULM Warhawks", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4202, import_key: "l.ncaa.org.wbasket-t.N87", entity_name: "BYU Cougars", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N87", entity_name: "BYU Cougars", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4203, import_key: "l.ncaa.org.wbasket-t.N62", entity_name: "Gonzaga Bulldogs", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N62", entity_name: "Gonzaga Bulldogs", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4204, import_key: "l.ncaa.org.wbasket-t.O70", entity_name: "Loyola Marymount Lions", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O70", entity_name: "Loyola Marymount Lions", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4205, import_key: "l.ncaa.org.wbasket-t.N32", entity_name: "Pepperdine Waves", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N32", entity_name: "Pepperdine Waves", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4206, import_key: "l.ncaa.org.wbasket-t.O28", entity_name: "Portland Pilots", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O28", entity_name: "Portland Pilots", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4207, import_key: "l.ncaa.org.wbasket-t.O57", entity_name: "San Diego Toreros", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O57", entity_name: "San Diego Toreros", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4208, import_key: "l.ncaa.org.wbasket-t.N55", entity_name: "San Francisco Lady Dons", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N55", entity_name: "San Francisco Lady Dons", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4209, import_key: "l.ncaa.org.wbasket-t.N70", entity_name: "Santa Clara Broncos", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N70", entity_name: "Santa Clara Broncos", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4210, import_key: "l.ncaa.org.wbasket-t.O27", entity_name: "St. Mary's, Cal. Galloping Gaels", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O27", entity_name: "St. Mary's, Cal. Galloping Gaels", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4211, import_key: "l.ncaa.org.wbasket-t.N85", entity_name: "Fresno St. Bulldogs", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N85", entity_name: "Fresno St. Bulldogs", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4212, import_key: "l.ncaa.org.wbasket-t.N94", entity_name: "Hawaii Warriors", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N94", entity_name: "Hawaii Warriors", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4213, import_key: "l.ncaa.org.wbasket-t.P61", entity_name: "Idaho Vandals", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P61", entity_name: "Idaho Vandals", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4214, import_key: "l.ncaa.org.wbasket-t.N12", entity_name: "Louisiana Tech Bulldogs", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N12", entity_name: "Louisiana Tech Bulldogs", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4215, import_key: "l.ncaa.org.wbasket-t.O76", entity_name: "Nevada Wolf Pack", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O76", entity_name: "Nevada Wolf Pack", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4216, import_key: "l.ncaa.org.wbasket-t.O81", entity_name: "New Mexico St. Aggies", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O81", entity_name: "New Mexico St. Aggies", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4217, import_key: "l.ncaa.org.wbasket-t.O87", entity_name: "San Jose St. Spartans", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O87", entity_name: "San Jose St. Spartans", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4218, import_key: "l.ncaa.org.wbasket-t.Q23", entity_name: "Utah State Aggies", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q23", entity_name: "Utah State Aggies", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4219, import_key: "l.ncaa.org.wbasket-t.Q78", entity_name: "blank blank", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q78", entity_name: "blank blank", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4220, import_key: "l.ncaa.org.wbasket-t.P28", entity_name: "Centenary Centenary Ladies", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P28", entity_name: "Centenary Centenary Ladies", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4221, import_key: "l.ncaa.org.wbasket-t.R23", entity_name: "North Florida Ospreys", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.R23", entity_name: "North Florida Ospreys", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4222, import_key: "l.ncaa.org.wbasket-t.RC7", entity_name: "Florida Gulf Coast Eagles", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.RC7", entity_name: "Florida Gulf Coast Eagles", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4223, import_key: "l.ncaa.org.wbasket-t.RC8", entity_name: "USC Upstate Spartans", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.RC8", entity_name: "USC Upstate Spartans", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4224, import_key: "l.ncaa.org.wbasket-t.P92", entity_name: "Northern Colorado Bears", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P92", entity_name: "Northern Colorado Bears", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4225, import_key: "l.ncaa.org.wbasket-t.R51", entity_name: "Presbyterian College Blue Hose", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.R51", entity_name: "Presbyterian College Blue Hose", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4226, import_key: "l.ncaa.org.wbasket-t.N68", entity_name: "Central Florida Knights", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N68", entity_name: "Central Florida Knights", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4227, import_key: "l.ncaa.org.wbasket-t.N49", entity_name: "Western Michigan Broncos", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N49", entity_name: "Western Michigan Broncos", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4228, import_key: "l.ncaa.org.wbasket-t.P78", entity_name: "McNeese St. Cowgirls", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P78", entity_name: "McNeese St. Cowgirls", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4229, import_key: "l.ncaa.org.wbasket-t.N35", entity_name: "Stephen F. Austin Ladyjacks", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N35", entity_name: "Stephen F. Austin Ladyjacks", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4230, import_key: "l.ncaa.org.wbasket-t.Q15", entity_name: "Texas A&M-Corpus Christi Islanders", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q15", entity_name: "Texas A&M-Corpus Christi Islanders", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4231, import_key: "l.ncaa.org.wbasket-t.R39", entity_name: "Central Arkansas Sugar Bears", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.R39", entity_name: "Central Arkansas Sugar Bears", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4232, import_key: "l.ncaa.org.wbasket-t.O64", entity_name: "Lamar Lady Cardinals", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O64", entity_name: "Lamar Lady Cardinals", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4233, import_key: "l.ncaa.org.wbasket-t.O26", entity_name: "Sam Houston St. Bearkats", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O26", entity_name: "Sam Houston St. Bearkats", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4234, import_key: "l.ncaa.org.wbasket-t.N76", entity_name: "Texas-Arlington Lady Mavericks", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N76", entity_name: "Texas-Arlington Lady Mavericks", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4235, import_key: "l.ncaa.org.wbasket-t.N29", entity_name: "Texas-San Antonio Roadrunners", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.N29", entity_name: "Texas-San Antonio Roadrunners", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4236, import_key: "l.ncaa.org.wbasket-t.P53", entity_name: "Florida Atlantic Lady Owls", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P53", entity_name: "Florida Atlantic Lady Owls", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4237, import_key: "l.ncaa.org.wbasket-t.Q04", entity_name: "South Alabama Jaguars", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.Q04", entity_name: "South Alabama Jaguars", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4238, import_key: "l.ncaa.org.wbasket-t.O08", entity_name: "Ark.-Little Rock Lady Trojans", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O08", entity_name: "Ark.-Little Rock Lady Trojans", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4239, import_key: "l.ncaa.org.wbasket-t.P15", entity_name: "Arkansas St. Red Wolves", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.P15", entity_name: "Arkansas St. Red Wolves", status: 1, entity_type_id: entity_type_id
   },
   {
-    id: 4240, import_key: "l.ncaa.org.wbasket-t.O41", entity_name: "North Texas Mean Green", status: 1, entity_type_id: 10
+    import_key: "l.ncaa.org.wbasket-t.O41", entity_name: "North Texas Mean Green", status: 1, entity_type_id: entity_type_id
   }
 ])

--- a/db/seeds/011_milb.rb
+++ b/db/seeds/011_milb.rb
@@ -1,180 +1,181 @@
 # -*- coding: utf-8 -*-
+entity_type_id = EntityType.find_by_entity_type_abbreviation('MILB').id
 Entity.create([
   {
-    id: 4241, import_key: "l.ilbaseball.com-t.325", entity_name: "Scranton/Wilkes-Barre Yankees", entity_type_id: 11, status: 1
+    import_key: "l.ilbaseball.com-t.325", entity_name: "Scranton/Wilkes-Barre Yankees", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4242, import_key: "l.ilbaseball.com-t.318", entity_name: "Lehigh Valley IronPigs", entity_type_id: 11, status: 1
+    import_key: "l.ilbaseball.com-t.318", entity_name: "Lehigh Valley IronPigs", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4243, import_key: "l.ilbaseball.com-t.319", entity_name: "Pawtucket Red Sox", entity_type_id: 11, status: 1
+    import_key: "l.ilbaseball.com-t.319", entity_name: "Pawtucket Red Sox", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4244, import_key: "l.ilbaseball.com-t.322", entity_name: "Rochester Red Wings", entity_type_id: 11, status: 1
+    import_key: "l.ilbaseball.com-t.322", entity_name: "Rochester Red Wings", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4245, import_key: "l.ilbaseball.com-t.300", entity_name: "Buffalo Bisons", entity_type_id: 11, status: 1
+    import_key: "l.ilbaseball.com-t.300", entity_name: "Buffalo Bisons", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4246, import_key: "l.ilbaseball.com-t.326", entity_name: "Syracuse Chiefs", entity_type_id: 11, status: 1
+    import_key: "l.ilbaseball.com-t.326", entity_name: "Syracuse Chiefs", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4247, import_key: "l.ilbaseball.com-t.321", entity_name: "Gwinnett Braves", entity_type_id: 11, status: 1
+    import_key: "l.ilbaseball.com-t.321", entity_name: "Gwinnett Braves", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4248, import_key: "l.ilbaseball.com-t.305", entity_name: "Durham Bulls", entity_type_id: 11, status: 1
+    import_key: "l.ilbaseball.com-t.305", entity_name: "Durham Bulls", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4249, import_key: "l.ilbaseball.com-t.302", entity_name: "Charlotte Knights", entity_type_id: 11, status: 1
+    import_key: "l.ilbaseball.com-t.302", entity_name: "Charlotte Knights", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4250, import_key: "l.ilbaseball.com-t.315", entity_name: "Norfolk Tides", entity_type_id: 11, status: 1
+    import_key: "l.ilbaseball.com-t.315", entity_name: "Norfolk Tides", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4251, import_key: "l.ilbaseball.com-t.304", entity_name: "Columbus Clippers", entity_type_id: 11, status: 1
+    import_key: "l.ilbaseball.com-t.304", entity_name: "Columbus Clippers", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4252, import_key: "l.ilbaseball.com-t.311", entity_name: "Louisville Bats", entity_type_id: 11, status: 1
+    import_key: "l.ilbaseball.com-t.311", entity_name: "Louisville Bats", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4253, import_key: "l.ilbaseball.com-t.328", entity_name: "Toledo Mud Hens", entity_type_id: 11, status: 1
+    import_key: "l.ilbaseball.com-t.328", entity_name: "Toledo Mud Hens", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4254, import_key: "l.ilbaseball.com-t.308", entity_name: "Indianapolis Indians", entity_type_id: 11, status: 1
+    import_key: "l.ilbaseball.com-t.308", entity_name: "Indianapolis Indians", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4255, import_key: "l.pclbaseball.com-t.317", entity_name: "Omaha Storm Chasers", entity_type_id: 11, status: 1
+    import_key: "l.pclbaseball.com-t.317", entity_name: "Omaha Storm Chasers", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4256, import_key: "l.pclbaseball.com-t.309", entity_name: "Iowa Cubs", entity_type_id: 11, status: 1
+    import_key: "l.pclbaseball.com-t.309", entity_name: "Iowa Cubs", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4257, import_key: "l.pclbaseball.com-t.312", entity_name: "Memphis Redbirds", entity_type_id: 11, status: 1
+    import_key: "l.pclbaseball.com-t.312", entity_name: "Memphis Redbirds", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4258, import_key: "l.pclbaseball.com-t.313", entity_name: "Nashville Sounds", entity_type_id: 11, status: 1
+    import_key: "l.pclbaseball.com-t.313", entity_name: "Nashville Sounds", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4259, import_key: "l.pclbaseball.com-t.422", entity_name: "Round Rock Express", entity_type_id: 11, status: 1
+    import_key: "l.pclbaseball.com-t.422", entity_name: "Round Rock Express", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4260, import_key: "l.pclbaseball.com-t.301", entity_name: "Albuquerque Isotopes", entity_type_id: 11, status: 1
+    import_key: "l.pclbaseball.com-t.301", entity_name: "Albuquerque Isotopes", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4261, import_key: "l.pclbaseball.com-t.314", entity_name: "New Orleans Zephyrs", entity_type_id: 11, status: 1
+    import_key: "l.pclbaseball.com-t.314", entity_name: "New Orleans Zephyrs", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4262, import_key: "l.pclbaseball.com-t.316", entity_name: "Oklahoma City RedHawks", entity_type_id: 11, status: 1
+    import_key: "l.pclbaseball.com-t.316", entity_name: "Oklahoma City RedHawks", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4263, import_key: "l.pclbaseball.com-t.329", entity_name: "Reno Aces", entity_type_id: 11, status: 1
+    import_key: "l.pclbaseball.com-t.329", entity_name: "Reno Aces", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4264, import_key: "l.pclbaseball.com-t.324", entity_name: "Salt Lake Bees", entity_type_id: 11, status: 1
+    import_key: "l.pclbaseball.com-t.324", entity_name: "Salt Lake Bees", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4265, import_key: "l.pclbaseball.com-t.303", entity_name: "Colorado Springs Sky Sox", entity_type_id: 11, status: 1
+    import_key: "l.pclbaseball.com-t.303", entity_name: "Colorado Springs Sky Sox", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4266, import_key: "l.pclbaseball.com-t.327", entity_name: "Tacoma Rainiers", entity_type_id: 11, status: 1
+    import_key: "l.pclbaseball.com-t.327", entity_name: "Tacoma Rainiers", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4267, import_key: "l.pclbaseball.com-t.323", entity_name: "Sacramento River Cats", entity_type_id: 11, status: 1
+    import_key: "l.pclbaseball.com-t.323", entity_name: "Sacramento River Cats", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4268, import_key: "l.pclbaseball.com-t.307", entity_name: "Fresno Grizzlies", entity_type_id: 11, status: 1
+    import_key: "l.pclbaseball.com-t.307", entity_name: "Fresno Grizzlies", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4269, import_key: "l.pclbaseball.com-t.AZ1", entity_name: "El Paso Chihuahuas", entity_type_id: 11, status: 1
+    import_key: "l.pclbaseball.com-t.AZ1", entity_name: "El Paso Chihuahuas", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4270, import_key: "l.pclbaseball.com-t.310", entity_name: "Las Vegas 51s", entity_type_id: 11, status: 1
+    import_key: "l.pclbaseball.com-t.310", entity_name: "Las Vegas 51s", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4271, import_key: "l.texas-league.com-t.Y95", entity_name: "Corpus Christi Hooks", entity_type_id: 11, status: 1
+    import_key: "l.texas-league.com-t.Y95", entity_name: "Corpus Christi Hooks", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4272, import_key: "l.texas-league.com-t.354", entity_name: "Frisco RoughRiders", entity_type_id: 11, status: 1
+    import_key: "l.texas-league.com-t.354", entity_name: "Frisco RoughRiders", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4273, import_key: "l.texas-league.com-t.344", entity_name: "Midland RockHounds", entity_type_id: 11, status: 1
+    import_key: "l.texas-league.com-t.344", entity_name: "Midland RockHounds", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4274, import_key: "l.texas-league.com-t.353", entity_name: "San Antonio Missions", entity_type_id: 11, status: 1
+    import_key: "l.texas-league.com-t.353", entity_name: "San Antonio Missions", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4275, import_key: "l.texas-league.com-t.332", entity_name: "Arkansas Travelers", entity_type_id: 11, status: 1
+    import_key: "l.texas-league.com-t.332", entity_name: "Arkansas Travelers", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4276, import_key: "l.texas-league.com-t.359", entity_name: "Northwest Arkansas Naturals", entity_type_id: 11, status: 1
+    import_key: "l.texas-league.com-t.359", entity_name: "Northwest Arkansas Naturals", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4277, import_key: "l.texas-league.com-t.338", entity_name: "Springfield Cardinals", entity_type_id: 11, status: 1
+    import_key: "l.texas-league.com-t.338", entity_name: "Springfield Cardinals", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4278, import_key: "l.texas-league.com-t.357", entity_name: "Tulsa Drillers", entity_type_id: 11, status: 1
+    import_key: "l.texas-league.com-t.357", entity_name: "Tulsa Drillers", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4279, import_key: "l.southernleague.com-t.343", entity_name: "Jacksonville Suns", entity_type_id: 11, status: 1
+    import_key: "l.southernleague.com-t.343", entity_name: "Jacksonville Suns", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4280, import_key: "l.southernleague.com-t.340", entity_name: "Mississippi Braves", entity_type_id: 11, status: 1
+    import_key: "l.southernleague.com-t.340", entity_name: "Mississippi Braves", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4281, import_key: "l.southernleague.com-t.345", entity_name: "Mobile BayBears", entity_type_id: 11, status: 1
+    import_key: "l.southernleague.com-t.345", entity_name: "Mobile BayBears", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4282, import_key: "l.southernleague.com-t.ZX9", entity_name: "Pensacola Blue Wahoos", entity_type_id: 11, status: 1
+    import_key: "l.southernleague.com-t.ZX9", entity_name: "Pensacola Blue Wahoos", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4283, import_key: "l.southernleague.com-t.342", entity_name: "Biloxi Shuckers", entity_type_id: 11, status: 1
+    import_key: "l.southernleague.com-t.342", entity_name: "Biloxi Shuckers", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4284, import_key: "l.southernleague.com-t.334", entity_name: "Birmingham Barons", entity_type_id: 11, status: 1
+    import_key: "l.southernleague.com-t.334", entity_name: "Birmingham Barons", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4285, import_key: "l.southernleague.com-t.337", entity_name: "Chattanooga Lookouts", entity_type_id: 11, status: 1
+    import_key: "l.southernleague.com-t.337", entity_name: "Chattanooga Lookouts", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4286, import_key: "l.southernleague.com-t.358", entity_name: "Jackson Generals", entity_type_id: 11, status: 1
+    import_key: "l.southernleague.com-t.358", entity_name: "Jackson Generals", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4287, import_key: "l.southernleague.com-t.349", entity_name: "Montgomery Biscuits", entity_type_id: 11, status: 1
+    import_key: "l.southernleague.com-t.349", entity_name: "Montgomery Biscuits", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4288, import_key: "l.southernleague.com-t.355", entity_name: "Tennessee Smokies", entity_type_id: 11, status: 1
+    import_key: "l.southernleague.com-t.355", entity_name: "Tennessee Smokies", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4289, import_key: "l.easternleague.com-t.330", entity_name: "Akron RubberDucks", entity_type_id: 11, status: 1
+    import_key: "l.easternleague.com-t.330", entity_name: "Akron RubberDucks", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4290, import_key: "l.easternleague.com-t.331", entity_name: "Altoona Curve", entity_type_id: 11, status: 1
+    import_key: "l.easternleague.com-t.331", entity_name: "Altoona Curve", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4291, import_key: "l.easternleague.com-t.335", entity_name: "Bowie Baysox", entity_type_id: 11, status: 1
+    import_key: "l.easternleague.com-t.335", entity_name: "Bowie Baysox", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4292, import_key: "l.easternleague.com-t.339", entity_name: "Erie SeaWolves", entity_type_id: 11, status: 1
+    import_key: "l.easternleague.com-t.339", entity_name: "Erie SeaWolves", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4293, import_key: "l.easternleague.com-t.341", entity_name: "Harrisburg Senators", entity_type_id: 11, status: 1
+    import_key: "l.easternleague.com-t.341", entity_name: "Harrisburg Senators", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4294, import_key: "l.easternleague.com-t.348", entity_name: "Richmond Flying Squirrels", entity_type_id: 11, status: 1
+    import_key: "l.easternleague.com-t.348", entity_name: "Richmond Flying Squirrels", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4295, import_key: "l.easternleague.com-t.333", entity_name: "Binghamton Mets", entity_type_id: 11, status: 1
+    import_key: "l.easternleague.com-t.333", entity_name: "Binghamton Mets", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4296, import_key: "l.easternleague.com-t.346", entity_name: "New Britain Rock Cats", entity_type_id: 11, status: 1
+    import_key: "l.easternleague.com-t.346", entity_name: "New Britain Rock Cats", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4297, import_key: "l.easternleague.com-t.347", entity_name: "New Hampshire Fisher Cats", entity_type_id: 11, status: 1
+    import_key: "l.easternleague.com-t.347", entity_name: "New Hampshire Fisher Cats", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4298, import_key: "l.easternleague.com-t.350", entity_name: "Portland Sea Dogs", entity_type_id: 11, status: 1
+    import_key: "l.easternleague.com-t.350", entity_name: "Portland Sea Dogs", entity_type_id: entity_type_id, status: 1
   },
   {
-    id: 4299, import_key: "l.easternleague.com-t.356", entity_name: "Trenton Thunder", entity_type_id: 11, status: 1
+    import_key: "l.easternleague.com-t.356", entity_name: "Trenton Thunder", entity_type_id: entity_type_id, status: 1
   }
 ])

--- a/db/seeds/012_ncaacb.rb
+++ b/db/seeds/012_ncaacb.rb
@@ -1,264 +1,265 @@
 # -*- coding: utf-8 -*-
+entity_type_id = EntityType.find_by_entity_type_abbreviation('NCAACB').id
 Entity.create([
   {
-    entity_name: 'LSU Tigers', import_key: 'https://api.seatgeek.com/2/events?performers.slug=lsu-tigers-baseball&venue.id=5362', entity_type_id: 12, status: 1
+    entity_name: 'LSU Tigers', import_key: 'https://api.seatgeek.com/2/events?performers.slug=lsu-tigers-baseball&venue.id=5362', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'South Carolina Gamecocks', import_key: 'https://api.seatgeek.com/2/events?performers.slug=south-carolina-gamecocks-baseball&venue.id=5334', entity_type_id: 12, status: 1
+    entity_name: 'South Carolina Gamecocks', import_key: 'https://api.seatgeek.com/2/events?performers.slug=south-carolina-gamecocks-baseball&venue.id=5334', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Texas Longhorns', import_key: 'https://api.seatgeek.com/2/events?performers.slug=texas-longhorns-baseball&venue.id=5339', entity_type_id: 12, status: 1
+    entity_name: 'Texas Longhorns', import_key: 'https://api.seatgeek.com/2/events?performers.slug=texas-longhorns-baseball&venue.id=5339', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'College of Charleston Cougars', import_key: 'https://api.seatgeek.com/2/events?performers.slug=college-of-charleston-cougars-baseball&venue.id=3111', entity_type_id: 12, status: 1
+    entity_name: 'College of Charleston Cougars', import_key: 'https://api.seatgeek.com/2/events?performers.slug=college-of-charleston-cougars-baseball&venue.id=3111', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Oregon State Beavers', import_key: 'https://api.seatgeek.com/2/events?performers.slug=oregon-state-beavers-baseball&venue.id=5346', entity_type_id: 12, status: 1
+    entity_name: 'Oregon State Beavers', import_key: 'https://api.seatgeek.com/2/events?performers.slug=oregon-state-beavers-baseball&venue.id=5346', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Florida State Seminoles', import_key: 'https://api.seatgeek.com/2/events?performers.slug=florida-state-seminoles-baseball&venue.id=5350', entity_type_id: 12, status: 1
+    entity_name: 'Florida State Seminoles', import_key: 'https://api.seatgeek.com/2/events?performers.slug=florida-state-seminoles-baseball&venue.id=5350', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Texas AM Aggies', import_key: 'https://api.seatgeek.com/2/events?performers.slug=texas-am-aggies-baseball&venue.id=5352', entity_type_id: 12, status: 1
+    entity_name: 'Texas AM Aggies', import_key: 'https://api.seatgeek.com/2/events?performers.slug=texas-am-aggies-baseball&venue.id=5352', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Tulane Green Wave', import_key: 'https://api.seatgeek.com/2/events?performers.slug=tulane-green-wave-baseball&venue.id=7720', entity_type_id: 12, status: 1
+    entity_name: 'Tulane Green Wave', import_key: 'https://api.seatgeek.com/2/events?performers.slug=tulane-green-wave-baseball&venue.id=7720', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'North Carolina Tar Heels', import_key: 'https://api.seatgeek.com/2/events?performers.slug=north-carolina-tar-heels-baseball&venue.id=5336', entity_type_id: 12, status: 1
+    entity_name: 'North Carolina Tar Heels', import_key: 'https://api.seatgeek.com/2/events?performers.slug=north-carolina-tar-heels-baseball&venue.id=5336', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Vanderbilt Commodores', import_key: 'https://api.seatgeek.com/2/events?performers.slug=vanderbilt-commodores-baseball&venue.id=5349', entity_type_id: 12, status: 1
+    entity_name: 'Vanderbilt Commodores', import_key: 'https://api.seatgeek.com/2/events?performers.slug=vanderbilt-commodores-baseball&venue.id=5349', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Arkansas Razorbacks', import_key: 'https://api.seatgeek.com/2/events?performers.slug=arkansas-razorbacks-baseball&venue.id=5344', entity_type_id: 12, status: 1
+    entity_name: 'Arkansas Razorbacks', import_key: 'https://api.seatgeek.com/2/events?performers.slug=arkansas-razorbacks-baseball&venue.id=5344', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Oregon Ducks', import_key: 'https://api.seatgeek.com/2/events?performers.slug=oregon-ducks-baseball&venue.id=5347', entity_type_id: 12, status: 1
+    entity_name: 'Oregon Ducks', import_key: 'https://api.seatgeek.com/2/events?performers.slug=oregon-ducks-baseball&venue.id=5347', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'UNLV Rebels', import_key: 'https://api.seatgeek.com/2/events?performers.slug=unlv-rebels-baseball&venue.id=7961', entity_type_id: 12, status: 1
+    entity_name: 'UNLV Rebels', import_key: 'https://api.seatgeek.com/2/events?performers.slug=unlv-rebels-baseball&venue.id=7961', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Nebraska Cornhuskers', import_key: 'https://api.seatgeek.com/2/events?performers.slug=nebraska-cornhuskers-baseball&venue.id=5351', entity_type_id: 12, status: 1
+    entity_name: 'Nebraska Cornhuskers', import_key: 'https://api.seatgeek.com/2/events?performers.slug=nebraska-cornhuskers-baseball&venue.id=5351', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Ole Miss Rebels', import_key: 'https://api.seatgeek.com/2/events?performers.slug=ole-miss-rebels-baseball&venue.id=5343', entity_type_id: 12, status: 1
+    entity_name: 'Ole Miss Rebels', import_key: 'https://api.seatgeek.com/2/events?performers.slug=ole-miss-rebels-baseball&venue.id=5343', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Furman Paladins', import_key: 'https://api.seatgeek.com/2/events?performers.slug=furman-paladins-baseball&venue.id=8163', entity_type_id: 12, status: 1
+    entity_name: 'Furman Paladins', import_key: 'https://api.seatgeek.com/2/events?performers.slug=furman-paladins-baseball&venue.id=8163', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Clemson Tigers', import_key: 'https://api.seatgeek.com/2/events?performers.slug=clemson-tigers-baseball&venue.id=5338', entity_type_id: 12, status: 1
+    entity_name: 'Clemson Tigers', import_key: 'https://api.seatgeek.com/2/events?performers.slug=clemson-tigers-baseball&venue.id=5338', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Georgia Bulldogs', import_key: 'https://api.seatgeek.com/2/events?performers.slug=georgia-bulldogs-baseball&venue.id=5495', entity_type_id: 12, status: 1
+    entity_name: 'Georgia Bulldogs', import_key: 'https://api.seatgeek.com/2/events?performers.slug=georgia-bulldogs-baseball&venue.id=5495', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Ohio State Buckeyes', import_key: 'https://api.seatgeek.com/2/events?performers.slug=ohio-state-buckeyes-baseball&venue.id=7849', entity_type_id: 12, status: 1
+    entity_name: 'Ohio State Buckeyes', import_key: 'https://api.seatgeek.com/2/events?performers.slug=ohio-state-buckeyes-baseball&venue.id=7849', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Florida Gators', import_key: 'https://api.seatgeek.com/2/events?performers.slug=florida-gators-baseball&venue.id=5360', entity_type_id: 12, status: 1
+    entity_name: 'Florida Gators', import_key: 'https://api.seatgeek.com/2/events?performers.slug=florida-gators-baseball&venue.id=5360', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Auburn Tigers', import_key: 'https://api.seatgeek.com/2/events?performers.slug=auburn-tigers-baseball&venue.id=5364', entity_type_id: 12, status: 1
+    entity_name: 'Auburn Tigers', import_key: 'https://api.seatgeek.com/2/events?performers.slug=auburn-tigers-baseball&venue.id=5364', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Mississippi State Bulldogs', import_key: 'https://api.seatgeek.com/2/events?performers.slug=mississippi-state-bulldogs-baseball&venue.id=5355', entity_type_id: 12, status: 1
+    entity_name: 'Mississippi State Bulldogs', import_key: 'https://api.seatgeek.com/2/events?performers.slug=mississippi-state-bulldogs-baseball&venue.id=5355', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Miami Hurricanes', import_key: 'https://api.seatgeek.com/2/events?performers.slug=miami-hurricanes-baseball&venue.id=5341', entity_type_id: 12, status: 1
+    entity_name: 'Miami Hurricanes', import_key: 'https://api.seatgeek.com/2/events?performers.slug=miami-hurricanes-baseball&venue.id=5341', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Creighton Bluejays', import_key: 'https://api.seatgeek.com/2/events?performers.slug=creighton-bluejays-baseball&venue.id=5374', entity_type_id: 12, status: 1
+    entity_name: 'Creighton Bluejays', import_key: 'https://api.seatgeek.com/2/events?performers.slug=creighton-bluejays-baseball&venue.id=5374', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Virginia Cavaliers', import_key: 'https://api.seatgeek.com/2/events?performers.slug=virginia-cavaliers-baseball&venue.id=5367', entity_type_id: 12, status: 1
+    entity_name: 'Virginia Cavaliers', import_key: 'https://api.seatgeek.com/2/events?performers.slug=virginia-cavaliers-baseball&venue.id=5367', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Coastal Carolina Chanticleers', import_key: 'https://api.seatgeek.com/2/events?performers.slug=coastal-carolina-chanticleers-baseball&venue.id=5363', entity_type_id: 12, status: 1
+    entity_name: 'Coastal Carolina Chanticleers', import_key: 'https://api.seatgeek.com/2/events?performers.slug=coastal-carolina-chanticleers-baseball&venue.id=5363', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Stanford Cardinal', import_key: 'https://api.seatgeek.com/2/events?performers.slug=stanford-cardinal-baseball&venue.id=5370', entity_type_id: 12, status: 1
+    entity_name: 'Stanford Cardinal', import_key: 'https://api.seatgeek.com/2/events?performers.slug=stanford-cardinal-baseball&venue.id=5370', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Arizona State Sun Devils', import_key: 'https://api.seatgeek.com/2/events?performers.slug=arizona-state-sun-devils-baseball&venue.id=3940', entity_type_id: 12, status: 1
+    entity_name: 'Arizona State Sun Devils', import_key: 'https://api.seatgeek.com/2/events?performers.slug=arizona-state-sun-devils-baseball&venue.id=3940', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'TCU Horned Frogs', import_key: 'https://api.seatgeek.com/2/events?performers.slug=tcu-horned-frogs-baseball&venue.id=5359', entity_type_id: 12, status: 1
+    entity_name: 'TCU Horned Frogs', import_key: 'https://api.seatgeek.com/2/events?performers.slug=tcu-horned-frogs-baseball&venue.id=5359', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'North Carolina State Wolfpack', import_key: 'https://api.seatgeek.com/2/events?performers.slug=north-carolina-state-wolfpack-baseball&venue.id=41782', entity_type_id: 12, status: 1
+    entity_name: 'North Carolina State Wolfpack', import_key: 'https://api.seatgeek.com/2/events?performers.slug=north-carolina-state-wolfpack-baseball&venue.id=41782', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'UCLA Bruins', import_key: 'https://api.seatgeek.com/2/events?performers.slug=ucla-bruins-baseball&venue.id=5342', entity_type_id: 12, status: 1
+    entity_name: 'UCLA Bruins', import_key: 'https://api.seatgeek.com/2/events?performers.slug=ucla-bruins-baseball&venue.id=5342', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Tennessee Volunteers', import_key: 'https://api.seatgeek.com/2/events?performers.slug=tennessee-volunteers-baseball&venue.id=2481', entity_type_id: 12, status: 1
+    entity_name: 'Tennessee Volunteers', import_key: 'https://api.seatgeek.com/2/events?performers.slug=tennessee-volunteers-baseball&venue.id=2481', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Rice Owls', import_key: 'https://api.seatgeek.com/2/events?performers.slug=rice-owls-baseball&venue.id=5356', entity_type_id: 12, status: 1
+    entity_name: 'Rice Owls', import_key: 'https://api.seatgeek.com/2/events?performers.slug=rice-owls-baseball&venue.id=5356', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Washington Huskies', import_key: 'https://api.seatgeek.com/2/events?performers.slug=washington-huskies-baseball&venue.id=41889', entity_type_id: 12, status: 1
+    entity_name: 'Washington Huskies', import_key: 'https://api.seatgeek.com/2/events?performers.slug=washington-huskies-baseball&venue.id=41889', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Baylor Bears', import_key: 'https://api.seatgeek.com/2/events?performers.slug=baylor-bears-baseball&venue.id=7498', entity_type_id: 12, status: 1
+    entity_name: 'Baylor Bears', import_key: 'https://api.seatgeek.com/2/events?performers.slug=baylor-bears-baseball&venue.id=7498', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Alabama Crimson Tide', import_key: 'https://api.seatgeek.com/2/events?performers.slug=alabama-crimson-tide-baseball&venue.id=5695', entity_type_id: 12, status: 1
+    entity_name: 'Alabama Crimson Tide', import_key: 'https://api.seatgeek.com/2/events?performers.slug=alabama-crimson-tide-baseball&venue.id=5695', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'The Citadel Bulldogs', import_key: 'https://api.seatgeek.com/2/events?performers.slug=the-citadel-bulldogs-baseball&venue.id=5222', entity_type_id: 12, status: 1
+    entity_name: 'The Citadel Bulldogs', import_key: 'https://api.seatgeek.com/2/events?performers.slug=the-citadel-bulldogs-baseball&venue.id=5222', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Oklahoma Sooners', import_key: 'https://api.seatgeek.com/2/events?performers.slug=oklahoma-sooners-baseball&venue.id=5358', entity_type_id: 12, status: 1
+    entity_name: 'Oklahoma Sooners', import_key: 'https://api.seatgeek.com/2/events?performers.slug=oklahoma-sooners-baseball&venue.id=5358', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Arizona Wildcats', import_key: 'https://api.seatgeek.com/2/events?performers.slug=arizona-wildcats-baseball&venue.id=7743', entity_type_id: 12, status: 1
+    entity_name: 'Arizona Wildcats', import_key: 'https://api.seatgeek.com/2/events?performers.slug=arizona-wildcats-baseball&venue.id=7743', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Texas State Bobcats', import_key: 'https://api.seatgeek.com/2/events?performers.slug=texas-state-bobcats-baseball&venue.id=46066', entity_type_id: 12, status: 1
+    entity_name: 'Texas State Bobcats', import_key: 'https://api.seatgeek.com/2/events?performers.slug=texas-state-bobcats-baseball&venue.id=46066', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Cal Golden Bears', import_key: 'https://api.seatgeek.com/2/events?performers.slug=cal-golden-bears-baseball&venue.id=6456', entity_type_id: 12, status: 1
+    entity_name: 'Cal Golden Bears', import_key: 'https://api.seatgeek.com/2/events?performers.slug=cal-golden-bears-baseball&venue.id=6456', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Kentucky Wildcats', import_key: 'https://api.seatgeek.com/2/events?performers.slug=kentucky-wildcats-baseball&venue.id=7911', entity_type_id: 12, status: 1
+    entity_name: 'Kentucky Wildcats', import_key: 'https://api.seatgeek.com/2/events?performers.slug=kentucky-wildcats-baseball&venue.id=7911', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'UCF Knights', import_key: 'https://api.seatgeek.com/2/events?performers.slug=ucf-knights-baseball&venue.id=7096', entity_type_id: 12, status: 1
+    entity_name: 'UCF Knights', import_key: 'https://api.seatgeek.com/2/events?performers.slug=ucf-knights-baseball&venue.id=7096', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Wake Forest Demon Deacons', import_key: 'https://api.seatgeek.com/2/events?performers.slug=wake-forest-demon-deacons-baseball&venue.id=41763', entity_type_id: 12, status: 1
+    entity_name: 'Wake Forest Demon Deacons', import_key: 'https://api.seatgeek.com/2/events?performers.slug=wake-forest-demon-deacons-baseball&venue.id=41763', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'San Jose State Spartans', import_key: 'https://api.seatgeek.com/2/events?performers.slug=san-jose-state-spartans-baseball&venue.id=8084', entity_type_id: 12, status: 1
+    entity_name: 'San Jose State Spartans', import_key: 'https://api.seatgeek.com/2/events?performers.slug=san-jose-state-spartans-baseball&venue.id=8084', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Liberty Flames', import_key: 'https://api.seatgeek.com/2/events?performers.slug=liberty-flames-baseball&venue.id=43593', entity_type_id: 12, status: 1
+    entity_name: 'Liberty Flames', import_key: 'https://api.seatgeek.com/2/events?performers.slug=liberty-flames-baseball&venue.id=43593', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Connecticut Huskies', import_key: 'https://api.seatgeek.com/2/events?performers.slug=connecticut-huskies-baseball&venue.id=5365', entity_type_id: 12, status: 1
+    entity_name: 'Connecticut Huskies', import_key: 'https://api.seatgeek.com/2/events?performers.slug=connecticut-huskies-baseball&venue.id=5365', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'UC Irvine Anteaters', import_key: 'https://api.seatgeek.com/2/events?performers.slug=uc-irvine-anteaters-baseball&venue.id=5361', entity_type_id: 12, status: 1
+    entity_name: 'UC Irvine Anteaters', import_key: 'https://api.seatgeek.com/2/events?performers.slug=uc-irvine-anteaters-baseball&venue.id=5361', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Long Beach State 49ers', import_key: 'https://api.seatgeek.com/2/events?performers.slug=long-beach-state-49ers-baseball&venue.id=41846', entity_type_id: 12, status: 1
+    entity_name: 'Long Beach State 49ers', import_key: 'https://api.seatgeek.com/2/events?performers.slug=long-beach-state-49ers-baseball&venue.id=41846', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Houston Cougars', import_key: 'https://api.seatgeek.com/2/events?performers.slug=houston-cougars-baseball&venue.id=78588', entity_type_id: 12, status: 1
+    entity_name: 'Houston Cougars', import_key: 'https://api.seatgeek.com/2/events?performers.slug=houston-cougars-baseball&venue.id=78588', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Texas Tech Red Raiders', import_key: 'https://api.seatgeek.com/2/events?performers.slug=texas-tech-red-raiders-baseball&venue.id=43576', entity_type_id: 12, status: 1
+    entity_name: 'Texas Tech Red Raiders', import_key: 'https://api.seatgeek.com/2/events?performers.slug=texas-tech-red-raiders-baseball&venue.id=43576', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Kansas Jayhawks', import_key: 'https://api.seatgeek.com/2/events?performers.slug=kansas-jayhawks-baseball&venue.id=45359', entity_type_id: 12, status: 1
+    entity_name: 'Kansas Jayhawks', import_key: 'https://api.seatgeek.com/2/events?performers.slug=kansas-jayhawks-baseball&venue.id=45359', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Louisiana Tech Bulldogs', import_key: 'https://api.seatgeek.com/2/events?performers.slug=louisiana-tech-bulldogs-baseball&venue.id=7672', entity_type_id: 12, status: 1
+    entity_name: 'Louisiana Tech Bulldogs', import_key: 'https://api.seatgeek.com/2/events?performers.slug=louisiana-tech-bulldogs-baseball&venue.id=7672', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Missouri State Bears', import_key: 'https://api.seatgeek.com/2/events?performers.slug=missouri-state-bears-baseball&venue.id=5260', entity_type_id: 12, status: 1
+    entity_name: 'Missouri State Bears', import_key: 'https://api.seatgeek.com/2/events?performers.slug=missouri-state-bears-baseball&venue.id=5260', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Jackson State Tigers', import_key: 'https://api.seatgeek.com/2/events?performers.slug=jackson-state-tigers-baseball&venue.id=43597', entity_type_id: 12, status: 1
+    entity_name: 'Jackson State Tigers', import_key: 'https://api.seatgeek.com/2/events?performers.slug=jackson-state-tigers-baseball&venue.id=43597', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Samford Bulldogs', import_key: 'https://api.seatgeek.com/2/events?performers.slug=samford-bulldogs-baseball&venue.id=43572', entity_type_id: 12, status: 1
+    entity_name: 'Samford Bulldogs', import_key: 'https://api.seatgeek.com/2/events?performers.slug=samford-bulldogs-baseball&venue.id=43572', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'New Mexico Lobos', import_key: 'https://api.seatgeek.com/2/events?performers.slug=new-mexico-lobos-baseball&venue.id=41815', entity_type_id: 12, status: 1
+    entity_name: 'New Mexico Lobos', import_key: 'https://api.seatgeek.com/2/events?performers.slug=new-mexico-lobos-baseball&venue.id=41815', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Purdue Boilermakers', import_key: 'https://api.seatgeek.com/2/events?performers.slug=purdue-boilermakers-baseball&venue.id=43574', entity_type_id: 12, status: 1
+    entity_name: 'Purdue Boilermakers', import_key: 'https://api.seatgeek.com/2/events?performers.slug=purdue-boilermakers-baseball&venue.id=43574', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Michigan State Spartans', import_key: 'https://api.seatgeek.com/2/events?performers.slug=michigan-state-spartans-baseball&venue.id=41843', entity_type_id: 12, status: 1
+    entity_name: 'Michigan State Spartans', import_key: 'https://api.seatgeek.com/2/events?performers.slug=michigan-state-spartans-baseball&venue.id=41843', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Washington State Cougars', import_key: 'https://api.seatgeek.com/2/events?performers.slug=washington-state-cougars-baseball&venue.id=5357', entity_type_id: 12, status: 1
+    entity_name: 'Washington State Cougars', import_key: 'https://api.seatgeek.com/2/events?performers.slug=washington-state-cougars-baseball&venue.id=5357', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Elon Phoenix', import_key: 'https://api.seatgeek.com/2/events?performers.slug=elon-phoenix-baseball&venue.id=43581', entity_type_id: 12, status: 1
+    entity_name: 'Elon Phoenix', import_key: 'https://api.seatgeek.com/2/events?performers.slug=elon-phoenix-baseball&venue.id=43581', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Georgia Tech Yellow Jackets', import_key: 'https://api.seatgeek.com/2/events?performers.slug=georgia-tech-yellow-jackets-baseball&venue.id=5335', entity_type_id: 12, status: 1
+    entity_name: 'Georgia Tech Yellow Jackets', import_key: 'https://api.seatgeek.com/2/events?performers.slug=georgia-tech-yellow-jackets-baseball&venue.id=5335', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Bethune Cookman Wildcats', import_key: 'https://api.seatgeek.com/2/events?performers.slug=bethune-cookman-wildcats-baseball&venue.id=7669', entity_type_id: 12, status: 1
+    entity_name: 'Bethune Cookman Wildcats', import_key: 'https://api.seatgeek.com/2/events?performers.slug=bethune-cookman-wildcats-baseball&venue.id=7669', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Grambling State Tigers', import_key: 'https://api.seatgeek.com/2/events?performers.slug=grambling-state-tigers-baseball&venue.id=42255', entity_type_id: 12, status: 1
+    entity_name: 'Grambling State Tigers', import_key: 'https://api.seatgeek.com/2/events?performers.slug=grambling-state-tigers-baseball&venue.id=42255', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Cal Poly Mustangs', import_key: 'https://api.seatgeek.com/2/events?performers.slug=cal-poly-mustangs-baseball&venue.id=43577', entity_type_id: 12, status: 1
+    entity_name: 'Cal Poly Mustangs', import_key: 'https://api.seatgeek.com/2/events?performers.slug=cal-poly-mustangs-baseball&venue.id=43577', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Louisville Cardinals', import_key: 'https://api.seatgeek.com/2/events?performers.slug=louisville-cardinals-baseball&venue.id=5348', entity_type_id: 12, status: 1
+    entity_name: 'Louisville Cardinals', import_key: 'https://api.seatgeek.com/2/events?performers.slug=louisville-cardinals-baseball&venue.id=5348', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Stony Brook Seawolves', import_key: 'https://api.seatgeek.com/2/events?performers.slug=stony-brook-seawolves-baseball&venue.id=41783', entity_type_id: 12, status: 1
+    entity_name: 'Stony Brook Seawolves', import_key: 'https://api.seatgeek.com/2/events?performers.slug=stony-brook-seawolves-baseball&venue.id=41783', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'South Alabama Jaguars', import_key: 'https://api.seatgeek.com/2/events?performers.slug=south-alabama-jaguars-baseball&venue.id=41919', entity_type_id: 12, status: 1
+    entity_name: 'South Alabama Jaguars', import_key: 'https://api.seatgeek.com/2/events?performers.slug=south-alabama-jaguars-baseball&venue.id=41919', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Louisiana-Lafayette Rajin\' Cajuns', import_key: 'https://api.seatgeek.com/2/events?performers.slug=louisiana-lafayette-rajin-cajuns-baseball&venue.id=2796', entity_type_id: 12, status: 1
+    entity_name: 'Louisiana-Lafayette Rajin\' Cajuns', import_key: 'https://api.seatgeek.com/2/events?performers.slug=louisiana-lafayette-rajin-cajuns-baseball&venue.id=2796', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'New Mexico State Aggies', import_key: 'https://api.seatgeek.com/2/events?performers.slug=new-mexico-state-aggies-baseball&venue.id=41765', entity_type_id: 12, status: 1
+    entity_name: 'New Mexico State Aggies', import_key: 'https://api.seatgeek.com/2/events?performers.slug=new-mexico-state-aggies-baseball&venue.id=41765', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Oklahoma State Cowboys', import_key: 'https://api.seatgeek.com/2/events?performers.slug=oklahoma-state-cowboys-baseball&venue.id=8166', entity_type_id: 12, status: 1
+    entity_name: 'Oklahoma State Cowboys', import_key: 'https://api.seatgeek.com/2/events?performers.slug=oklahoma-state-cowboys-baseball&venue.id=8166', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Sam Houston State Bearkats', import_key: 'https://api.seatgeek.com/2/events?performers.slug=sam-houston-state-bearkats-baseball&venue.id=43586', entity_type_id: 12, status: 1
+    entity_name: 'Sam Houston State Bearkats', import_key: 'https://api.seatgeek.com/2/events?performers.slug=sam-houston-state-bearkats-baseball&venue.id=43586', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'USC Trojans', import_key: 'https://api.seatgeek.com/2/events?performers.slug=usc-trojans-baseball&venue.id=7765', entity_type_id: 12, status: 1
+    entity_name: 'USC Trojans', import_key: 'https://api.seatgeek.com/2/events?performers.slug=usc-trojans-baseball&venue.id=7765', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'South Florida Bulls', import_key: 'https://api.seatgeek.com/2/events?performers.slug=south-florida-bulls-baseball&venue.id=5372', entity_type_id: 12, status: 1
+    entity_name: 'South Florida Bulls', import_key: 'https://api.seatgeek.com/2/events?performers.slug=south-florida-bulls-baseball&venue.id=5372', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Wichita State Shockers', import_key: 'https://api.seatgeek.com/2/events?performers.slug=wichita-state-shockers-baseball&venue.id=8075', entity_type_id: 12, status: 1
+    entity_name: 'Wichita State Shockers', import_key: 'https://api.seatgeek.com/2/events?performers.slug=wichita-state-shockers-baseball&venue.id=8075', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Cal State Fullerton Titans', import_key: 'https://api.seatgeek.com/2/events?performers.slug=cal-state-fullerton-titans-baseball&venue.id=5369', entity_type_id: 12, status: 1
+    entity_name: 'Cal State Fullerton Titans', import_key: 'https://api.seatgeek.com/2/events?performers.slug=cal-state-fullerton-titans-baseball&venue.id=5369', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'East Carolina Pirates', import_key: 'https://api.seatgeek.com/2/events?performers.slug=east-carolina-pirates-baseball&venue.id=43579', entity_type_id: 12, status: 1
+    entity_name: 'East Carolina Pirates', import_key: 'https://api.seatgeek.com/2/events?performers.slug=east-carolina-pirates-baseball&venue.id=43579', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'San Diego State Aztecs', import_key: 'https://api.seatgeek.com/2/events?performers.slug=san-diego-state-aztecs-baseball&venue.id=77667', entity_type_id: 12, status: 1
+    entity_name: 'San Diego State Aztecs', import_key: 'https://api.seatgeek.com/2/events?performers.slug=san-diego-state-aztecs-baseball&venue.id=77667', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Southeastern Louisiana Lions', import_key: 'https://api.seatgeek.com/2/events?performers.slug=southeastern-louisiana-lions-baseball&venue.id=41813', entity_type_id: 12, status: 1
+    entity_name: 'Southeastern Louisiana Lions', import_key: 'https://api.seatgeek.com/2/events?performers.slug=southeastern-louisiana-lions-baseball&venue.id=41813', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'San Diego Toreros', import_key: 'https://api.seatgeek.com/2/events?performers.slug=san-diego-toreros-baseball&venue.id=43580', entity_type_id: 12, status: 1
+    entity_name: 'San Diego Toreros', import_key: 'https://api.seatgeek.com/2/events?performers.slug=san-diego-toreros-baseball&venue.id=43580', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Stetson Hatters', import_key: 'https://api.seatgeek.com/2/events?performers.slug=stetson-hatters-baseball&venue.id=41814', entity_type_id: 12, status: 1
+    entity_name: 'Stetson Hatters', import_key: 'https://api.seatgeek.com/2/events?performers.slug=stetson-hatters-baseball&venue.id=41814', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Texas Arlington Mavericks', import_key: 'https://api.seatgeek.com/2/events?performers.slug=texas-arlington-mavericks-baseball&venue.id=35973', entity_type_id: 12, status: 1
+    entity_name: 'Texas Arlington Mavericks', import_key: 'https://api.seatgeek.com/2/events?performers.slug=texas-arlington-mavericks-baseball&venue.id=35973', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Indiana State Sycamores', import_key: 'https://api.seatgeek.com/2/events?performers.slug=indiana-state-sycamores-baseball&venue.id=51321', entity_type_id: 12, status: 1
+    entity_name: 'Indiana State Sycamores', import_key: 'https://api.seatgeek.com/2/events?performers.slug=indiana-state-sycamores-baseball&venue.id=51321', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'UNC Wilmington Seahawks', import_key: 'https://api.seatgeek.com/2/events?performers.slug=unc-wilmington-seahawks-baseball&venue.id=43595', entity_type_id: 12, status: 1
+    entity_name: 'UNC Wilmington Seahawks', import_key: 'https://api.seatgeek.com/2/events?performers.slug=unc-wilmington-seahawks-baseball&venue.id=43595', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'St Johns Red Storm', import_key: 'https://api.seatgeek.com/2/events?performers.slug=st-johns-red-storm-baseball&venue.id=5353', entity_type_id: 12, status: 1
+    entity_name: 'St Johns Red Storm', import_key: 'https://api.seatgeek.com/2/events?performers.slug=st-johns-red-storm-baseball&venue.id=5353', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Virginia Tech Hokies', import_key: 'https://api.seatgeek.com/2/events?performers.slug=virginia-tech-hokies-baseball&venue.id=5345', entity_type_id: 12, status: 1
+    entity_name: 'Virginia Tech Hokies', import_key: 'https://api.seatgeek.com/2/events?performers.slug=virginia-tech-hokies-baseball&venue.id=5345', entity_type_id: entity_type_id, status: 1
   },
   {
-    entity_name: 'Maryland Terrapins', import_key: 'https://api.seatgeek.com/2/events?performers.slug=maryland-terrapins-baseball&venue.id=43575', entity_type_id: 12, status: 1
+    entity_name: 'Maryland Terrapins', import_key: 'https://api.seatgeek.com/2/events?performers.slug=maryland-terrapins-baseball&venue.id=43575', entity_type_id: entity_type_id, status: 1
   }
 ])


### PR DESCRIPTION
This was a bad idea to begin with, but it worked. Annoying to have to manually reset Postgres sequences because of it.
