### PR TITLE
Re-map deprecated `datetime_tbd` to `date_tbd`

### DIFF
--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -54,7 +54,7 @@ class Entity < ActiveRecord::Base
           description: "#{venue['name']} (#{venue['display_location']})",
           entity_id: id,
           start_time: "#{event['datetime_utc']}+00:00",
-          date_tba: event['datetime_tbd'],
+          date_tba: event['date_tbd'],
           time_tba: event['time_tbd']
         }, overwrite
       )


### PR DESCRIPTION
Saw this in [the documentation](http://platform.seatgeek.com/) for SeatGeek. Prevents issues later.

> datetime_tbd:
>    **DEPRECATED**. Will be removed
