### PR TITLE
Re-arrange page events: Zeroclipboard/Turbolinks

### DIFF
--- a/app/assets/javascripts/seatshare.js.coffee
+++ b/app/assets/javascripts/seatshare.js.coffee
@@ -1,5 +1,4 @@
-seatshareReady = ->
-
+$(document).on 'page:load ready', ->
   # Navbar group switching
   $('#group_switcher select#group_selector').change (e) ->
   	window.location = '/groups/' + $(this).val()
@@ -14,5 +13,5 @@ seatshareReady = ->
   # Zeroclipboard
   clip = new ZeroClipboard($("button.zeroclipboard"))
 
-$(document).ready(seatshareReady)
-$(document).on('page:load', seatshareReady)
+$(document).on 'page:before-change', ->
+  ZeroClipboard.destroy()


### PR DESCRIPTION
Fixes #240

It appears that calling these in sequence was not a great idea, and the unload event may be necessary to prevent errors from being thrown on subsequent loads.

Error content:

```
14:42:44.901 Error: Bad NPObject as private data!
result</swf[desiredSwfCallbackName]() 1:18
_setHandCursor() ZeroClipboard.self-d26cc6a0ee41fe5041eaa12f4a8cfdc63d44072cb190db9a7aa2df8896e1fdc8.js:1679
_focus() ZeroClipboard.self-d26cc6a0ee41fe5041eaa12f4a8cfdc63d44072cb190db9a7aa2df8896e1fdc8.js:708
ZeroClipboard.activate() ZeroClipboard.self-d26cc6a0ee41fe5041eaa12f4a8cfdc63d44072cb190db9a7aa2df8896e1fdc8.js:1985
_addMouseHandlers/_elementMouseOver() ZeroClipboard.self-d26cc6a0ee41fe5041eaa12f4a8cfdc63d44072cb190db9a7aa2df8896e1fdc8.js:2381
1 1:18:20

```
