### PR TITLE
Fix broken SeatGeek import

### DIFF
--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -42,6 +42,7 @@ class Entity < ActiveRecord::Base
     fail 'Not a SeatGeek entity' unless seatgeek?
     params = Rack::Utils.parse_query URI(import_key).query
     params[:per_page] = 500
+    SeatGeek::Connection.protocol = :https
     response = SeatGeek::Connection.events(params)
     fail 'No events.' unless response && response['events'].count > 0
     records = []

--- a/lib/tasks/seatgeek.rake
+++ b/lib/tasks/seatgeek.rake
@@ -97,6 +97,7 @@ namespace :seatgeek do
       next unless et.seatgeek?
       params = Rack::Utils.parse_query URI(et.import_key).query
       params[:per_page] = 1000
+      SeatGeek::Connection.protocol = :https
       response = SeatGeek::Connection.performers(params)
       seatgeek_data[et.import_key] = response['performers']
     end

--- a/test/models/entity_test.rb
+++ b/test/models/entity_test.rb
@@ -41,7 +41,7 @@ class EntityTest < ActiveSupport::TestCase
   test 'import from SeatGeek' do
     stub_request(
       :get,
-      'http://api.seatgeek.com/2/events'\
+      'https://api.seatgeek.com/2/events'\
         '?per_page=500&performers.slug=nashville-predators&venue.id=2195'
     ).to_return(
       status: 200,


### PR DESCRIPTION
SeatGeek apparently started forwared non-SSL traffic to the SSL endpoints. The gem in production does not use that by default (nor does it follow redirected paths), but does provide a way to override it.
