### PR TITLE
Deprecate Mandrill

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -15,9 +15,9 @@ export TWILIO_OUTBOUND_NUMBER=the_number
 export SLACK_WEBHOOK_URL=webook_url
 
 # These values are production only
-# export MANDRILL_SMTP_USER=mandrill_user
-# export MANDRILL_SMTP_PASS=mandril_password
-# export MANDRILL_SMTP_HOST=mandrill_hostname
+# export SMTP_USER=smtp_user
+# export SMTP_PASS=smtp_password
+# export SMTP_HOST=smtp_hostname
 # export GOOGLE_ANALYTICS_ID=google_analytics_id
 # export ADWORDS_CONVERSION_ID=adwords_conversion_id
 # export ADWORDS_CONVERSION_LABEL=adwords_conversion_label

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,14 +78,14 @@ SeatShare::Application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 
-  # Mandrill SMTP
+  # SMTP Configuration
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    address:              ENV['MANDRILL_SMTP_HOST'],
+    address:              ENV['SMTP_HOST'],
     port:                 587,
     domain:               'myseatshare.com',
-    user_name:            ENV['MANDRILL_SMTP_USER'],
-    password:             ENV['MANDRILL_SMTP_PASS'],
+    user_name:            ENV['SMTP_USER'],
+    password:             ENV['SMTP_PASS'],
     authentication:       'plain',
     enable_starttls_auto: true  }
   config.action_mailer.default_url_options = { :host => 'https://myseatshare.com' }


### PR DESCRIPTION
I've got a configured Mailgun account ready, so this removes references to Mandrill.
