### PR TITLE
Fix responsive table clipping dropdown menu

### DIFF
--- a/app/assets/javascripts/seatshare.js.coffee
+++ b/app/assets/javascripts/seatshare.js.coffee
@@ -1,17 +1,23 @@
 $(document).on 'page:load ready', ->
   # Navbar group switching
   $('#group_switcher select#group_selector').change (e) ->
-  	window.location = '/groups/' + $(this).val()
+    window.location = '/groups/' + $(this).val()
 
   # Confirm actions
   $('a.confirm').click () ->
-  	return window.confirm 'Are you sure?'
+    return window.confirm 'Are you sure?'
 
   # Tooltips
   $('a[data-toggle="tooltip"], span[data-toggle="tooltip"], div[data-toggle="tooltip"], button[data-toggle="tooltip"]').tooltip()
 
   # Zeroclipboard
   clip = new ZeroClipboard($("button.zeroclipboard"))
+  
+  # Responsive Tables
+  $('.table-responsive').on 'show.bs.dropdown', () ->
+    $('.table-responsive').css "overflow", "inherit"
+  $('.table-responsive').on 'hide.bs.dropdown', () ->
+    $('.table-responsive').css "overflow", "auto"
 
 $(document).on 'page:before-change', ->
   ZeroClipboard.destroy()


### PR DESCRIPTION
Fixes #244

Stole idea from [a StackOverflow question](http://stackoverflow.com/a/26097713/772387) to let JavaScript solve my woes. The behavior is still a bit janky (removes the responsiveness of the table while the menu is open), but is an improvement over what is currently happening.
