### PR TITLE
Add SeatGeek API credential

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -12,6 +12,8 @@ export TWILIO_ACCOUNT_SID=some_sid
 export TWILIO_AUTH_TOKEN=some_token
 export TWILIO_OUTBOUND_NUMBER=the_number
 
+export SEATGEEK_CLIENT_ID=some_value
+
 export SLACK_WEBHOOK_URL=webook_url
 
 # These values are production only

--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ gem 'active_admin_importable', github: 'krhorst/active_admin_importable'
 gem 'mailchimp-api', '~> 2.0.6'
 
 # SeatGeek data provider
-gem 'seatgeek', '~> 0.1.2'
+gem 'seatgeek', '~> 1.0.0'
 
 # Capistrano
 gem 'capistrano', '~> 3.4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,7 +343,7 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
-    seatgeek (0.1.2)
+    seatgeek (1.0.0)
       faraday
       multi_json
       rake
@@ -446,7 +446,7 @@ DEPENDENCIES
   rest-client (~> 1.8.0)
   sass-rails (~> 5.0.4)
   sdoc (~> 0.4.1)
-  seatgeek (~> 0.1.2)
+  seatgeek (~> 1.0.0)
   select2-rails (~> 4.0.0)
   slack-notifier (~> 1.5.1)
   slackistrano (~> 1.0.0)

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -42,8 +42,8 @@ class Entity < ActiveRecord::Base
     fail 'Not a SeatGeek entity' unless seatgeek?
     params = Rack::Utils.parse_query URI(import_key).query
     params[:per_page] = 500
-    SeatGeek::Connection.protocol = :https
     response = SeatGeek::Connection.events(params)
+    fail response[:body] if response.key?(:status) && response[:status] != 200
     fail 'No events.' unless response && response['events'].count > 0
     records = []
     response['events'].each do |event|

--- a/config/initializers/seatgeek.rb
+++ b/config/initializers/seatgeek.rb
@@ -1,0 +1,6 @@
+if ENV['SEATGEEK_CLIENT_ID'].nil?
+  Rails.logger.warn "SeatGeek configuration is not present!"
+end
+
+SeatGeek::Connection.protocol = :https
+SeatGeek::Connection.client_id = ENV['SEATGEEK_CLIENT_ID']

--- a/lib/tasks/seatgeek.rake
+++ b/lib/tasks/seatgeek.rake
@@ -97,7 +97,6 @@ namespace :seatgeek do
       next unless et.seatgeek?
       params = Rack::Utils.parse_query URI(et.import_key).query
       params[:per_page] = 1000
-      SeatGeek::Connection.protocol = :https
       response = SeatGeek::Connection.performers(params)
       seatgeek_data[et.import_key] = response['performers']
     end

--- a/test/models/entity_test.rb
+++ b/test/models/entity_test.rb
@@ -39,9 +39,10 @@ class EntityTest < ActiveSupport::TestCase
   end
 
   test 'import from SeatGeek' do
+    SeatGeek::Connection.client_id = 'a_test_client_id'
     stub_request(
       :get,
-      'https://api.seatgeek.com/2/events'\
+      'https://a_test_client_id:@api.seatgeek.com/2/events'\
         '?per_page=500&performers.slug=nashville-predators&venue.id=2195'
     ).to_return(
       status: 200,


### PR DESCRIPTION
Fixes #249 

The Ruby gem has been updated to 1.0.0 with this requirement, so we can now update this app to use it. Will require the addition of the `SEATGEEK_CLIENT_ID` environment variable to be added to Heroku (staging) and the Chef cookbooks (production).
