### PR TITLE
Hide Date TBA events

### DIFF
--- a/app/controllers/calendar_controller.rb
+++ b/app/controllers/calendar_controller.rb
@@ -76,8 +76,7 @@ class CalendarController < ApplicationController
     end
 
     # Loop through the events
-    group.events.each do |group_event|
-      next if group_event.date_tba? == true
+    group.events.confirmed.each do |group_event|
       cal.add_event(
         group_event.to_ics(
           url_for(

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -8,6 +8,7 @@ class EventsController < ApplicationController
   def show
     @group = Group.find_by_id(params[:group_id]) || not_found
     @event = Event.find_by_id(params[:id]) || not_found
+    not_found unless @group.entity.id == @event.entity.id
     @tickets = @event.tickets.where(group_id: @group.id).by_seat
     @ticket_stats = @event.ticket_stats(@group, current_user)
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -111,9 +111,7 @@ class GroupsController < ApplicationController
     @entity = @group.entity
     not_found if @group.status != 1
     redirect_to(action: 'index') && return unless @group.member?(current_user)
-    @events = @group.events
-              .future
-              .by_date
+    @events = @group.events.future.confirmed.by_date
     @members = @group.members.by_name
     session[:current_group_id] = @group.id
   end
@@ -124,7 +122,7 @@ class GroupsController < ApplicationController
     @group = Group.find_by_id(params[:id]) || not_found
     not_found if @group.status != 1
     fail 'NotGroupMember' unless @group.member?(current_user)
-    @events = @group.events.by_date
+    @events = @group.events.confirmed.by_date
 
     feed = []
     @events.each do |event|

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -75,9 +75,7 @@ class TicketsController < ApplicationController
       @ticket_stats = @event.ticket_stats(@group, current_user)
       @page_title = "#{@event.event_name}"
     else
-      @events = @group.events
-                .order('start_time ASC')
-                .where('start_time > ?', Time.zone.today)
+      @events = @group.events.by_date.future.confirmed
       @page_title = 'Add Tickets'
     end
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -13,6 +13,7 @@ class Event < ActiveRecord::Base
   scope :past, -> { where('start_time < ?', Time.zone.now) }
   scope :next_seven_days, -> { next_seven_days }
   scope :today, -> { today }
+  scope :confirmed, -> { where('date_tba = 0') }
 
   @ticket_stats = nil
 

--- a/lib/tasks/send_reminders.rake
+++ b/lib/tasks/send_reminders.rake
@@ -8,7 +8,7 @@ namespace :send_reminders do
     groups = Group.active
     puts "Sending Daily Reminders for events for today"
     for group in groups
-      events = group.events.today.by_date
+      events = group.events.today.confirmed.by_date
       if events.count > 0
         for membership in group.memberships
           if membership.daily_reminder == 1
@@ -38,7 +38,7 @@ namespace :send_reminders do
     groups = Group.active
     puts "Sending Weekly Reminders for events for next seven days"
     for group in groups
-    events = group.events.next_seven_days.by_date
+    events = group.events.next_seven_days.confirmed.by_date
       if events.count > 0
         for membership in group.memberships
           if membership.weekly_reminder == 1

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -14,11 +14,16 @@ class EventsControllerTest < ActionController::TestCase
     @user = User.find(1)
     sign_in :user, @user
 
-    get :show, id: 1, group_id: 2
+    get :show, id: 4, group_id: 1
 
     assert_response :success, 'received a 200 status'
-    assert_select 'title', 'Belmont Bruins vs. Brescia', 'event title matches'
+    assert_select 'title', 'Nashville Predators vs. St. Louis Blues',
+                  'event title matches'
     assert_select 'table', 1, 'there is a table for tickets'
+
+    assert_raises 'NotFound' do
+      get :show, id: 1, group_id: 2
+    end
   end
 
   test 'should see localized timezone' do


### PR DESCRIPTION
Fixes #251

Hides `date_tba` events from web, calendar and emailed schedule views. As SeatGeek data is updated to include a real date, these would then be visable again.
