### PR TITLE
Use Bower for Select2 loading

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,9 +46,6 @@ gem 'aws-sdk-v1', '~> 1.66.0'
 # Postgres
 gem 'pg', '~> 0.18.4'
 
-# Select2
-gem 'select2-rails', '~> 4.0.0'
-
 # ActiveAdmin
 gem 'activeadmin', github: 'activeadmin'
 gem 'active_admin_importable', github: 'krhorst/active_admin_importable'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -348,8 +348,6 @@ GEM
       multi_json
       rake
       yajl-ruby
-    select2-rails (4.0.0)
-      thor (~> 0.14)
     shellany (0.0.1)
     slack-notifier (1.5.1)
     slackistrano (1.0.0)
@@ -445,7 +443,6 @@ DEPENDENCIES
   sass-rails (~> 5.0.4)
   sdoc (~> 0.4.1)
   seatgeek (~> 1.0.0)
-  select2-rails (~> 4.0.0)
   slack-notifier (~> 1.5.1)
   slackistrano (~> 1.0.0)
   spork-minitest!

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,5 +18,4 @@
 //= require underscore
 //= require clndr
 //= require select2
-//= require clipboard
 //= require_directory .

--- a/app/assets/javascripts/groups.js.coffee
+++ b/app/assets/javascripts/groups.js.coffee
@@ -3,6 +3,7 @@ groupsReady = ->
   # Create Group
   if $("#group_entity_id").length > 0
     $("#group_entity_id").select2({
+      theme: 'bootstrap',
       placeholder: "Click to search our more than 2,700 available teams",
       allowClear: true
     })

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -10,7 +10,7 @@
  *
  *= require_self
  *= require select2
- *= require select2-bootstrap
+ *= require select2-bootstrap-theme
  *= require_directory .
  */
 

--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,8 @@
   "name": "seatshare-rails",
   "dependencies": {
     "clndr": "1.2.14",
-    "clipboard": "1.5.9"
+    "clipboard": "1.5.9",
+    "select2": "4.0.2",
+    "select2-bootstrap-theme": "0.1.0-beta.4"
   }
 }


### PR DESCRIPTION
Makes more sense than to pin to a gem that will likely end up being a few versions behind the actual project. Considering switching to use `bower-rails` for the asset pipeline, but the current approach still works.
