### PR TITLE
Default to overwriting event titles, update tests

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -109,8 +109,9 @@ class Event < ActiveRecord::Base
   def self.import(hash = nil, overwrite = false, allow_duplicate = false)
     event = find_by_import_key(hash[:import_key]) || new
     event.entity_id = hash[:entity_id]
+    event.event_name = hash[:event_name]
     if overwrite || event.new_record?
-      event.event_name = hash[:event_name]
+      # Attributes to overwrite (description)
       event.description = hash[:description]
     end
     event.start_time = hash[:start_time]

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -49,7 +49,7 @@
   <% else %>
   <div class="panel">
     <div class="panel-body text-center">
-      <span class=""><em>We will retrieve the latest schedule as soon as they are available.</em></span>
+      <span class=""><em>We will retrieve the latest schedule as soon as it is available.</em></span>
     </div>
   </div>
   <% end %>

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -3,6 +3,30 @@ require 'test_helper'
 ##
 # Registrations controller test
 class RegistrationsControllerTest < ActionController::TestCase
+  def setup
+    SeatGeek::Connection.client_id = 'a_test_client_id'
+    stub_request(
+      :get,
+      'https://a_test_client_id:@api.seatgeek.com/2/events'\
+        '?per_page=500&performers.slug=nashville-predators&venue.id=2195'
+    ).to_return(
+      status: 200,
+      body: File.new(
+        'test/fixtures/seatgeek/events-nashville-predators.json'
+      ).read
+    )
+    stub_request(
+      :get,
+      'https://a_test_client_id:@api.seatgeek.com/2/performers'\
+        '?slug=nashville-predators'
+    ).to_return(
+      status: 200,
+      body: File.new(
+        'test/fixtures/seatgeek/performers-nashville-predators.json'
+      ).read
+    )
+  end
+
   test 'get register route' do
     @request.env['devise.mapping'] = Devise.mappings[:user]
 
@@ -44,28 +68,6 @@ class RegistrationsControllerTest < ActionController::TestCase
   end
 
   test 'get register route with team id' do
-    SeatGeek::Connection.client_id = 'a_test_client_id'
-    stub_request(
-      :get,
-      'https://a_test_client_id:@api.seatgeek.com/2/events'\
-        '?per_page=500&performers.slug=nashville-predators&venue.id=2195'
-    ).to_return(
-      status: 200,
-      body: File.new(
-        'test/fixtures/seatgeek/events-nashville-predators.json'
-      ).read
-    )
-    stub_request(
-      :get,
-      'https://a_test_client_id:@api.seatgeek.com/2/performers'\
-        '?slug=nashville-predators'
-    ).to_return(
-      status: 200,
-      body: File.new(
-        'test/fixtures/seatgeek/performers-nashville-predators.json'
-      ).read
-    )
-
     @request.env['devise.mapping'] = Devise.mappings[:user]
 
     get :new, entity_id: '1', entity_slug: 'nashville-predators-nhl'

--- a/test/integration/ticket_flow_test.rb
+++ b/test/integration/ticket_flow_test.rb
@@ -8,6 +8,7 @@ class TicketFlowTest < ActionDispatch::IntegrationTest
   ##
   # Set up test
   def setup
+    stub_request(:any, /api.twilio.com/)
     Time.zone = 'Central Time (US & Canada)'
   end
 
@@ -152,8 +153,6 @@ class TicketFlowTest < ActionDispatch::IntegrationTest
   end
 
   test 'request a ticket' do
-    stub_request(:any, /api.twilio.com/)
-
     post_via_redirect(
       '/login',
       user: { email: users(:jill).email, password: 'testing123' }

--- a/test/integration/user_signup_test.rb
+++ b/test/integration/user_signup_test.rb
@@ -3,9 +3,32 @@ require 'test_helper'
 ##
 # User Signup test
 class UserSignupTest < ActionDispatch::IntegrationTest
-  test 'signup for an account - success' do
+  def setup
+    SeatGeek::Connection.client_id = 'a_test_client_id'
+    stub_request(
+      :get,
+      'https://a_test_client_id:@api.seatgeek.com/2/events'\
+        '?per_page=500&performers.slug=nashville-predators&venue.id=2195'
+    ).to_return(
+      status: 200,
+      body: File.new(
+        'test/fixtures/seatgeek/events-nashville-predators.json'
+      ).read
+    )
+    stub_request(
+      :get,
+      'https://a_test_client_id:@api.seatgeek.com/2/performers'\
+        '?slug=nashville-predators'
+    ).to_return(
+      status: 200,
+      body: File.new(
+        'test/fixtures/seatgeek/performers-nashville-predators.json'
+      ).read
+    )
     stub_request(:any, /api.mailchimp.com/)
+  end
 
+  test 'signup for an account - success' do
     get '/register'
     assert_response :success
 
@@ -90,28 +113,6 @@ class UserSignupTest < ActionDispatch::IntegrationTest
   end
 
   test 'signup for an account with a team id' do
-    SeatGeek::Connection.client_id = 'a_test_client_id'
-    stub_request(
-      :get,
-      'https://a_test_client_id:@api.seatgeek.com/2/events'\
-        '?per_page=500&performers.slug=nashville-predators&venue.id=2195'
-    ).to_return(
-      status: 200,
-      body: File.new(
-        'test/fixtures/seatgeek/events-nashville-predators.json'
-      ).read
-    )
-    stub_request(
-      :get,
-      'https://a_test_client_id:@api.seatgeek.com/2/performers'\
-        '?slug=nashville-predators'
-    ).to_return(
-      status: 200,
-      body: File.new(
-        'test/fixtures/seatgeek/performers-nashville-predators.json'
-      ).read
-    )
-
     get '/register/nashville-predators-nhl/1'
     assert_response :success
     assert_select 'h4', 'Create a Nashville Predators group'

--- a/test/models/entity_test.rb
+++ b/test/models/entity_test.rb
@@ -3,42 +3,7 @@ require 'test_helper'
 ##
 # Entity test
 class EntityTest < ActiveSupport::TestCase
-  test 'new entity has attributes' do
-    entity = Entity.new(
-      entity_name: 'Nashville Sportsball (Inactive)',
-      entity_type_id: 5
-    )
-    entity.save!
-
-    assert entity.entity_name?, 'Name for entity is set'
-    assert entity.status == 0, 'Status for entity is inactive'
-  end
-
-  test 'fixture entity has attributes' do
-    entity = Entity.find(1)
-
-    assert entity.entity_name == 'Nashville Predators', 'Name for entity is set'
-    assert entity.status == 1, 'Status for entity is inactive'
-  end
-
-  test 'gets entity by group ID' do
-    entity = Group.find(2).entity
-
-    assert entity.id == 5, 'fixture entity ID matches'
-    assert entity.entity_name == 'Nashville Sportsball', 'fixture name matches'
-    assert entity.entity_type.display_name == 'Sportsball League (SBL)'
-    assert entity.status == 1, 'fixture entity is active'
-  end
-
-  test 'get all active entities' do
-    entities = Entity.active
-
-    assert entities.count == 5, 'count of fixture entities matches'
-    assert entities[0].class.to_s == 'Entity', 'class of fixture entity matches'
-    assert entities[0].entity_name?, 'fixture entity name is set'
-  end
-
-  test 'import from SeatGeek' do
+  def setup
     SeatGeek::Connection.client_id = 'a_test_client_id'
     stub_request(
       :get,
@@ -50,20 +15,107 @@ class EntityTest < ActiveSupport::TestCase
         'test/fixtures/seatgeek/events-nashville-predators.json'
       ).read
     )
+    stub_request(
+      :get,
+      'https://a_test_client_id:@api.seatgeek.com/2/performers'\
+        '?slug=nashville-predators'
+    ).to_return(
+      status: 200,
+      body: File.new(
+        'test/fixtures/seatgeek/performers-nashville-predators.json'
+      ).read
+    )
+    super
+  end
 
+  test 'new entity has attributes' do
+    entity = Entity.new(
+      entity_name: 'Nashville Sportsball (Inactive)',
+      entity_type_id: 5
+    )
+    entity.save!
+
+    assert entity.entity_name?
+    assert_equal 0, entity.status
+  end
+
+  test 'fixture entity has attributes' do
+    entity = Entity.find(1)
+
+    assert_equal 'Nashville Predators', entity.entity_name
+    assert_equal 1, entity.status
+  end
+
+  test 'gets entity by group id' do
+    entity = Group.find(2).entity
+
+    assert_equal 5, entity.id
+    assert_equal 'Nashville Sportsball', entity.entity_name
+    assert_equal 'Sportsball League (SBL)', entity.entity_type.display_name
+    assert_equal 1, entity.status
+  end
+
+  test 'get all active entities' do
+    entities = Entity.active
+
+    assert entities.count == 5, 'count of fixture entities matches'
+    assert entities[0].class.to_s == 'Entity', 'class of fixture entity matches'
+    assert entities[0].entity_name?, 'fixture entity name is set'
+  end
+
+  test 'import from SeatGeek' do
     entity = Entity.find(1)
     records = entity.seatgeek_import
 
-    assert records.count == 29
-    assert records.first.event_name == 'Florida Panthers at Nashville Predators'
-    assert records.first.description == 'Bridgestone Arena (Nashville, TN)'
-    assert records.first.start_time == '2015-12-03 19:00:00 -0600'
+    assert_equal 29, records.count
+    assert_equal(
+      'Florida Panthers at Nashville Predators',
+      records.first.event_name
+    )
+    assert_equal 'Bridgestone Arena (Nashville, TN)', records.first.description
+    assert_equal(
+      '2015-12-03 19:00:00 -0600',
+      records.first.start_time.to_s
+    )
   end
 
   test 'import from SeatGeek without proper import key' do
     entity = Entity.find(2)
     response = entity.seatgeek_import
 
-    assert response == 'Not a SeatGeek entity'
+    assert_equal 'Not a SeatGeek entity', response
+  end
+
+  test 'gets a default avatar' do
+    entity = Entity.find(1)
+    default_avatar = entity.default_avatar
+
+    assert_match(
+      %r{^/assets/entity_types/nhl-group-medium-missing-},
+      default_avatar
+    )
+  end
+
+  test 'gets SeatGeek schedule data' do
+    entity = Entity.find(1)
+    schedule = entity.seatgeek_schedule
+
+    assert_equal 29, schedule['events'].count
+    assert_equal(
+      'Florida Panthers at Nashville Predators',
+      schedule['events'].first['title']
+    )
+  end
+
+  test 'gets SeatGeek performer data' do
+    entity = Entity.find(1)
+    performer = entity.seatgeek_performer
+
+    assert_equal 'Nashville Predators', performer['name']
+    assert_equal(
+      'https://chairnerd.global.ssl.fastly.net/images/performers-landscape/'\
+      'nashville-predators-4acd2d/2136/huge.jpg',
+      performer['image']
+    )
   end
 end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -157,7 +157,7 @@ class EventTest < ActiveSupport::TestCase
   test 'imported row does not overwrite existing values' do
     row = {
       entity_id: 2,
-      event_name: 'Big Game: Belmont Bruins vs. Lipscomb',
+      event_name: 'Belmont Bruins vs. Lipscomb',
       description: 'New value',
       start_time: '20131120T18:00:00-0500',
       time_tba: true,


### PR DESCRIPTION
- Titles of events (e.g. playoff games) should be updated with a SetGeek pull
- New methods on `Entity` needed tests
- Fix subject/verb agreement if no schedule pulled for a registration page
- Refactor a few tests to DRY up the stubs
