### PR TITLE
Add JSON-LD Schema to sign-up pages

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -61,6 +61,21 @@
   </style>
   <% end %>
 </div>
+
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "SportsTeam",
+  "name": "<%= @entity.entity_name %>",
+  "memberOf": [
+    {
+      "@type": "SportsOrganization",
+      "name": "<%= @entity.entity_type.entity_type_name %>"
+    }
+  ]
+}
+</script>
+
 <% end %>
 
 <%= form_for(resource, html: {class: "form-horizontal", role: "form"}, as: resource_name, url: registration_path(resource_name)) do |f| %>


### PR DESCRIPTION
Raven's Auditor tool complains that these pages don't have any Schema.org data on it. Not that the tool will detect this version of Schema, but we should have something on the page anyway for extra SEO goodness.
