### PR TITLE
Fix `NaN` displayed in previous month's dates

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "seatshare-rails",
   "dependencies": {
-    "clndr": "1.2.14",
+    "clndr": "1.4.7",
     "clipboard": "1.5.9",
     "select2": "4.0.2",
     "select2-bootstrap-theme": "0.1.0-beta.4"


### PR DESCRIPTION
![screen shot 2016-12-12 at 4 47 12 pm](https://cloud.githubusercontent.com/assets/80459/21119978/a690115c-c08a-11e6-8718-942a4ed261c6.png)

This was broken by an update in `momentjs`.

Refs: https://github.com/kylestetz/CLNDR/pull/289
Refs: https://github.com/kylestetz/CLNDR/issues/288