### PR TITLE
Fix XSS vulnerability in markdown parser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ gem 'slackistrano', '~> 1.0.0', require: false
 gem 'whenever', '~> 0.9.4', require: false
 
 # Markdown Support
-gem 'github-markdown', '~> 0.6.9'
+gem 'redcarpet', '~> 3.4.0'
 
 # REST Client (for Google Analytics goal tracking)
 gem 'rest-client', '~> 1.8.0'
@@ -118,7 +118,7 @@ end
 group :development do
   gem 'pry-coolline', '~> 0.2.4'
   gem 'rubocop', '~> 0.41.2'
-  gem 'bundler', '~> 1.12.5'
+  gem 'bundler'
   gem 'rack-livereload', '~> 0.3.16'
   gem 'guard-livereload', '~> 2.5.1'
   gem 'guard-bundler', '~> 2.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,7 +162,6 @@ GEM
       actionpack (>= 3.2.13)
     formtastic_i18n (0.6.0)
     foundation_emails (2.2.0.0)
-    github-markdown (0.6.9)
     global_phone (1.0.1)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
@@ -338,6 +337,7 @@ GEM
       json (~> 1.4)
     recaptcha (4.0.0)
       json
+    redcarpet (3.4.0)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
     rest-client (1.8.0)
@@ -430,7 +430,7 @@ DEPENDENCIES
   activeadmin!
   aws-sdk (~> 2.3.22)
   bootstrap-sass (~> 3.3.6)
-  bundler (~> 1.12.5)
+  bundler
   capistrano (~> 3.4.0)
   capistrano-bower (~> 1.1.0)
   capistrano-rails (~> 1.1.5)
@@ -440,7 +440,6 @@ DEPENDENCIES
   dynamic_sitemaps (~> 2.0.0)
   font-awesome-rails (~> 4.5.0.0)
   foundation_emails
-  github-markdown (~> 0.6.9)
   global_phone (~> 1.0.1)
   guard-bundler (~> 2.1.0)
   guard-livereload (~> 2.5.1)
@@ -464,6 +463,7 @@ DEPENDENCIES
   rails (~> 4.2.7.1)
   rails_12factor (~> 0.0.3)
   recaptcha
+  redcarpet (~> 3.4.0)
   rest-client (~> 1.8.0)
   rubocop (~> 0.41.2)
   sass-rails (~> 5.0.4)
@@ -485,4 +485,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.5
+   1.14.5

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -98,7 +98,9 @@ class Event < ActiveRecord::Base
   ##
   # Description as Markdown
   def description_md
-    GitHub::Markdown.render(description)
+    renderer = Redcarpet::Render::HTML.new(filter_html: true)
+    markdown = Redcarpet::Markdown.new(renderer, autolink: true)
+    markdown.render(description || '')
   end
 
   ##

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -63,7 +63,9 @@ class User < ActiveRecord::Base
   ##
   # Bio as Markdown
   def bio_md
-    GitHub::Markdown.render(bio)
+    renderer = Redcarpet::Render::HTML.new(filter_html: true)
+    markdown = Redcarpet::Markdown.new(renderer, autolink: true)
+    markdown.render(bio || '')
   end
 
   ##

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -62,15 +62,21 @@ class UserTest < ActiveSupport::TestCase
 
   test 'uses markdown for bio' do
     user = User.find(1)
-    user.bio = "*I'm a teapot*"
 
+    user.bio = "*I'm a teapot*"
     assert_equal user.bio_md, "<p><em>I&#39;m a teapot</em></p>\n"
 
     user.bio = 'http://google.com'
-
     assert_equal(
-      user.bio_md,
-      "<p><a href=\"http://google.com\">http://google.com</a></p>\n"
+      "<p><a href=\"http://google.com\">http://google.com</a></p>\n",
+      user.bio_md
     )
+  end
+
+  test 'included a script tag in bio' do
+    user = User.find(1)
+
+    user.bio = "<script>window.alert('evil')</script>"
+    assert_equal "<p>window.alert(&#39;evil&#39;)</p>\n", user.bio_md
   end
 end


### PR DESCRIPTION
Was not sanitizing markdown content prior to passing it off to the view. Had thought that GitHub's own parser would handle that for me. Bad assumption.

Fixes #280