### PR TITLE
Allow a non-Grouped user to see own profile

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,6 +73,7 @@ class User < ActiveRecord::Base
   # - user: instance of user to see if they have a common group
   def user_can_view?(user)
     return false if user.nil?
+    return true if user.id == id
     shared_users = []
     groups.collect do |group|
       group.members.collect do |u|

--- a/test/controllers/admin_api/v1/admin_api_controller_test.rb
+++ b/test/controllers/admin_api/v1/admin_api_controller_test.rb
@@ -19,10 +19,10 @@ module AdminApi
         json = JSON.parse(@response.body)
 
         assert_response :success
-        assert json['version'] == 1
-        assert json['method'] == 'methods'
-        assert json['status'] == 'success'
-        assert json['data'].length == 9
+        assert_equal json['version'], 1
+        assert_equal json['method'], 'methods'
+        assert_equal json['status'], 'success'
+        assert_equal json['data'].length, 9
       end
 
       test 'get API error with incorrect key' do
@@ -31,9 +31,9 @@ module AdminApi
         json = JSON.parse(@response.body)
 
         assert_response :forbidden
-        assert json['version'] == 1
-        assert json['status'] == 'error'
-        assert json['error'] == 'Invalid API key'
+        assert_equal json['version'], 1
+        assert_equal json['status'], 'error'
+        assert_equal json['error'], 'Invalid API key'
       end
 
       test 'get API error with no key established' do
@@ -43,9 +43,9 @@ module AdminApi
         json = JSON.parse(@response.body)
 
         assert_response :forbidden
-        assert json['version'] == 1
-        assert json['status'] == 'error'
-        assert json['error'] == 'Invalid API key'
+        assert_equal json['version'], 1
+        assert_equal json['status'], 'error'
+        assert_equal json['error'], 'Invalid API key'
       end
 
       test 'get user counts' do
@@ -53,10 +53,10 @@ module AdminApi
 
         json = JSON.parse(@response.body)
 
-        assert json['version'] == 1
-        assert json['method'] == 'user_count'
-        assert json['status'] == 'success'
-        assert json['data'] == 6
+        assert_equal json['version'], 1
+        assert_equal json['method'], 'user_count'
+        assert_equal json['status'], 'success'
+        assert_equal json['data'], 7
       end
 
       test 'get group counts' do
@@ -64,10 +64,10 @@ module AdminApi
 
         json = JSON.parse(@response.body)
 
-        assert json['version'] == 1
-        assert json['method'] == 'group_count'
-        assert json['status'] == 'success'
-        assert json['data'] == 2
+        assert_equal json['version'], 1
+        assert_equal json['method'], 'group_count'
+        assert_equal json['status'], 'success'
+        assert_equal json['data'], 2
       end
 
       test 'get total invites' do
@@ -75,10 +75,10 @@ module AdminApi
 
         json = JSON.parse(@response.body)
 
-        assert json['version'] == 1
-        assert json['method'] == 'total_invites'
-        assert json['status'] == 'success'
-        assert json['data'] == 0
+        assert_equal json['version'], 1
+        assert_equal json['method'], 'total_invites'
+        assert_equal json['status'], 'success'
+        assert_equal json['data'], 0
       end
 
       test 'get accepted invites' do
@@ -86,10 +86,10 @@ module AdminApi
 
         json = JSON.parse(@response.body)
 
-        assert json['version'] == 1
-        assert json['method'] == 'accepted_invites'
-        assert json['status'] == 'success'
-        assert json['data'] == 0
+        assert_equal json['version'], 1
+        assert_equal json['method'], 'accepted_invites'
+        assert_equal json['status'], 'success'
+        assert_equal json['data'], 0
       end
 
       test 'get recent groups' do
@@ -97,10 +97,10 @@ module AdminApi
 
         json = JSON.parse(@response.body)
 
-        assert json['version'] == 1
-        assert json['method'] == 'recent_groups'
-        assert json['status'] == 'success'
-        assert json['data'].length == 3
+        assert_equal json['version'], 1
+        assert_equal json['method'], 'recent_groups'
+        assert_equal json['status'], 'success'
+        assert_equal json['data'].length, 3
       end
 
       test 'get recent users' do
@@ -108,10 +108,10 @@ module AdminApi
 
         json = JSON.parse(@response.body)
 
-        assert json['version'] == 1
-        assert json['method'] == 'recent_users'
-        assert json['status'] == 'success'
-        assert json['data'].length == 5
+        assert_equal json['version'], 1
+        assert_equal json['method'], 'recent_users'
+        assert_equal json['status'], 'success'
+        assert_equal json['data'].length, 5
       end
 
       test 'get total tickets' do
@@ -119,10 +119,10 @@ module AdminApi
 
         json = JSON.parse(@response.body)
 
-        assert json['version'] == 1
-        assert json['method'] == 'total_tickets'
-        assert json['status'] == 'success'
-        assert json['data'] == 9
+        assert_equal json['version'], 1
+        assert_equal json['method'], 'total_tickets'
+        assert_equal json['status'], 'success'
+        assert_equal json['data'], 9
       end
 
       test 'get tickets transferred' do
@@ -130,10 +130,10 @@ module AdminApi
 
         json = JSON.parse(@response.body)
 
-        assert json['version'] == 1
-        assert json['method'] == 'tickets_transferred'
-        assert json['status'] == 'success'
-        assert json['data'] == 2
+        assert_equal json['version'], 1
+        assert_equal json['method'], 'tickets_transferred'
+        assert_equal json['status'], 'success'
+        assert_equal json['data'], 2
       end
 
       # tickets_unused
@@ -142,10 +142,10 @@ module AdminApi
 
         json = JSON.parse(@response.body)
 
-        assert json['version'] == 1
-        assert json['method'] == 'tickets_unused'
-        assert json['status'] == 'success'
-        assert json['data'] == 2
+        assert_equal json['version'], 1
+        assert_equal json['method'], 'tickets_unused'
+        assert_equal json['status'], 'success'
+        assert_equal json['data'], 2
       end
     end
   end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -69,3 +69,12 @@ jane:
   encrypted_password: $2a$10$/FjTIo/TTt6ebMH.ahTE6uDKUFxLDqoBT1lAfkn4YTYVuSXZFAc3C
   status: true
   calendar_token: 18eqlBdVVd7hxyBcXCYTOw
+
+larry:
+  id: 8
+  first_name: Larry
+  last_name: Jennings
+  email: larry@example.net
+  encrypted_password: $2a$10$/FjTIo/TTt6ebMH.ahTE6uDKUFxLDqoBT1lAfkn4YTYVuSXZFAc3C
+  status: true
+  calendar_token: CY0YbuOyiFrSTQuj0sJE4x

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -48,11 +48,13 @@ class UserTest < ActiveSupport::TestCase
     user2 = User.find(2)
     user3 = User.find(3)
     user4 = User.find(4)
+    user8 = User.find(8)
 
     assert user1.user_can_view?(user2) == true
     assert user2.user_can_view?(user3) == true
     assert user3.user_can_view?(user4) == false
     assert user4.user_can_view?(user2) == false
+    assert user8.user_can_view?(user8) == true
   end
 
   test 'convert phone number to E.164 format' do


### PR DESCRIPTION
If a user attempts to update their profile before joining a group, they are given an access denied message. The reason for this is that the profile page does a check before showing a particular profile that the logged in user must share a group with them. In the case of a user without a group, that check fails. This PR adds an exception that a user can always view their own profile and adds a relevant test case:

Fixes #286

Unrelated:

- Updated admin API to use better `assert_equal` instead of normal `assert`.