### PR TITLE
Display ticket history in reverse order

### DIFF
--- a/app/models/ticket_history.rb
+++ b/app/models/ticket_history.rb
@@ -8,6 +8,8 @@ class TicketHistory < ActiveRecord::Base
 
   validates :ticket_id, :group_id, :event_id, :user_id, :entry, presence: true
 
+  default_scope { order(created_at: :desc) }
+
   ##
   # Display name for ticket history record
   def display_name

--- a/test/fixtures/ticket_histories.yml
+++ b/test/fixtures/ticket_histories.yml
@@ -14,4 +14,25 @@ history_2:
   group_id: 1
   event_id: 4
   user_id: 1
-  entry: '{"text":"created","user":null,"ticket":{"event_id":"1","section":"326","row":"K","seat":"9","cost":"32.00","user_id":"0","id":2}}'
+  entry: '{"text":"created","user":null,"ticket":{"event_id":"1","section":"326","row":"K","seat":"9","cost":"30.00","user_id":"0","id":2}}'
+  created_at: Wed, 20 Nov 2013 17:30:00 +0000
+
+history_3:
+  id: 3
+  ticket_id: 2
+  event_id: 1
+  group_id: 1
+  event_id: 4
+  user_id: 1
+  entry: '{"text":"updated","user":null,"ticket":{"event_id":"1","section":"326","row":"K","seat":"9","cost":"31.00","user_id":"0","id":2}}'
+  created_at: Wed, 20 Nov 2013 17:10:00 +0000
+
+history_4:
+  id: 4
+  ticket_id: 2
+  event_id: 1
+  group_id: 1
+  event_id: 4
+  user_id: 1
+  entry: '{"text":"updated","user":null,"ticket":{"event_id":"1","section":"326","row":"K","seat":"9","cost":"32.00","user_id":"0","id":2}}'
+  created_at: Wed, 20 Nov 2013 17:20:00 +0000

--- a/test/models/ticket_history_test.rb
+++ b/test/models/ticket_history_test.rb
@@ -49,4 +49,13 @@ class TicketHistoryTest < ActiveSupport::TestCase
 
     assert_equal 'Jim Stone', ticket_history.user.display_name
   end
+
+  test 'history returned in a reverse chronological order' do
+    ticket_history = Ticket.find(2).ticket_histories
+
+    assert_equal 2, ticket_history[0].id
+    assert_equal 4, ticket_history[1].id
+    assert_equal 3, ticket_history[2].id
+  end
+
 end


### PR DESCRIPTION
Prior to this PR, the ordering of history records was arbitrary. This updates the default sorting to be reverse chronology, with the most recent updates appearing first the in the set. Also updates test cases to ensure this is enforced.

Fixes #288