### PR TITLE
Fix Turbolinks

### DIFF
--- a/app/assets/javascripts/groups.js.coffee
+++ b/app/assets/javascripts/groups.js.coffee
@@ -8,16 +8,9 @@ groupsReady = ->
       allowClear: true
     })
 
-  # Change Placeholder Text
-  $("#group_entity_id").on "select2-selected", ->
-    data = $("#group_entity_id").select2 "data"
-    suffixes = ['Fans', 'Super Fans', 'Supporters', 'Backers', 'Crew', 'Pride']
-    suffix = suffixes[Math.floor(Math.random() * suffixes.length)];
-    $('#group_group_name').attr 'placeholder', "e.g. #{data.text} #{suffix}"
-
   # Calendar
-  group_id = $('#group_selector').val()
   if $("#sidebar_calendar").length > 0
+    group_id = $('#group_selector').val()
     $.get "/groups/#{group_id}/events_feed", (result) ->
       $("#sidebar_calendar").clndr
         template: "<div class='clndr-controls'>" +
@@ -72,4 +65,4 @@ groupsReady = ->
       return
 
 $(document).ready(groupsReady)
-$(document).on('page:load', groupsReady)
+$(document).on('turbolinks:load', groupsReady)

--- a/app/assets/javascripts/login.js.coffee
+++ b/app/assets/javascripts/login.js.coffee
@@ -9,4 +9,4 @@ loginReady = ->
       $(this).addClass 'enabled'
 
 $(document).ready(loginReady)
-$(document).on('page:load', loginReady)
+$(document).on('turbolinks:load', loginReady)

--- a/app/assets/javascripts/public.js.coffee
+++ b/app/assets/javascripts/public.js.coffee
@@ -14,4 +14,4 @@ publicTeamsReady = ->
   wordLoop()
 
 $(document).ready(publicTeamsReady)
-$(document).on('page:load', publicTeamsReady)
+$(document).on('turbolinks:load', publicTeamsReady)

--- a/app/assets/javascripts/seatshare.js.coffee
+++ b/app/assets/javascripts/seatshare.js.coffee
@@ -1,4 +1,4 @@
-$(document).on 'page:load ready', ->
+$(document).on 'turbolinks:load ready', ->
   # Navbar group switching
   $('#group_switcher select#group_selector').change (e) ->
     window.location = '/groups/' + $(this).val()

--- a/app/assets/javascripts/tickets.js.coffee
+++ b/app/assets/javascripts/tickets.js.coffee
@@ -27,4 +27,4 @@ ticketsReady = ->
 	true
 
 $(document).ready(ticketsReady)
-$(document).on('page:load', ticketsReady)
+$(document).on('turbolinks:load', ticketsReady)

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -136,7 +136,7 @@ ol.user-steps {
   bottom: 0 !important;
 }
 .HW_visible {
-  z-index: 99999;
+  z-index: 99999 !important;
 }
 
 /* Form Errors */


### PR DESCRIPTION
The latest verison of Turbolinks changed `page:*` to `turbolinks:*` for JavaScript events. This causes issues on subequent page navigations that doesn't show up on initial load.