### PR TITLE
Twilio gem update broke stats

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,7 +79,7 @@ gem 'rest-client'
 gem 'paperclip'
 
 # Twilio / SMS related
-gem 'twilio-ruby'
+gem 'twilio-ruby', '~>4.11.1'
 gem 'global_phone'
 
 # Sitemaps

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,7 +231,6 @@ GEM
       activerecord
       kaminari-core (= 1.0.1)
     kaminari-core (1.0.1)
-    libxml-ruby (3.0.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -418,10 +417,10 @@ GEM
     turbolinks (5.0.1)
       turbolinks-source (~> 5)
     turbolinks-source (5.0.3)
-    twilio-ruby (5.0.0)
-      faraday (~> 0.9)
-      jwt (~> 1.5)
-      libxml-ruby (= 3.0.0)
+    twilio-ruby (4.11.1)
+      builder (>= 2.1.2)
+      jwt (~> 1.0)
+      multi_json (>= 1.3.0)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
     uglifier (3.2.0)
@@ -497,7 +496,7 @@ DEPENDENCIES
   spork-rails
   thin
   turbolinks
-  twilio-ruby
+  twilio-ruby (~> 4.11.1)
   uglifier
   underscore-rails
   webmock


### PR DESCRIPTION
The [v5](https://github.com/twilio/twilio-ruby/wiki/Ruby-Version-5.x-Upgrade-Guide) release of the `twilio-ruby` gem broke a handful of things not covered by test, so locking this one down to v4.