### PR TITLE
Rails Asset Pipeline Security Update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -399,7 +399,7 @@ GEM
     spork-rails (4.0.0)
       rails (>= 3.0.0, < 5)
       spork (>= 1.0rc0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)


### PR DESCRIPTION
Fixes CVE-2018-3760.